### PR TITLE
SW471678: Op940 dbus timeout fix in SMGR

### DIFF
--- a/bmc_state_manager.cpp
+++ b/bmc_state_manager.cpp
@@ -1,9 +1,11 @@
 #include <cassert>
 #include <config.h>
 #include <phosphor-logging/log.hpp>
+#include <phosphor-logging/elog-errors.hpp>
 #include <sdbusplus/exception.hpp>
 #include <sys/sysinfo.h>
 #include "bmc_state_manager.hpp"
+#include "xyz/openbmc_project/Common/error.hpp"
 
 namespace phosphor
 {
@@ -17,6 +19,7 @@ namespace server = sdbusplus::xyz::openbmc_project::State::server;
 
 using namespace phosphor::logging;
 using sdbusplus::exception::SdBusError;
+using sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
 
 constexpr auto obmcStandbyTarget = "multi-user.target";
 constexpr auto signalDone = "done";
@@ -120,7 +123,9 @@ void BMC::subscribeToSystemdSignals()
     }
     catch (const SdBusError& e)
     {
-        log<level::INFO>("Error in Subscribe", entry("ERROR=%s", e.what()));
+        log<level::ERR>("Failed to subscribe to systemd signals",
+                        entry("ERR=%s", e.what()));
+        elog<InternalFailure>();
     }
 
     return;

--- a/bmc_state_manager.cpp
+++ b/bmc_state_manager.cpp
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <config.h>
 #include <phosphor-logging/log.hpp>
 #include <sdbusplus/exception.hpp>
 #include <sys/sysinfo.h>
@@ -111,7 +112,11 @@ void BMC::subscribeToSystemdSignals()
 
     try
     {
-        this->bus.call(method);
+        // The phosphor-state-manager service start around the same time
+        // systemd is mounting the host filesystems. This can cause a delay
+        // in D-bus calls to systemd. Use a configurable timeout when
+        // subscribing to systemd signals. The timeout is in microseconds
+        this->bus.call(method, (SYSTEMD_SUBSCRIBE_DBUS_TIMEOUT * 1000000L));
     }
     catch (const SdBusError& e)
     {

--- a/chassis_state_manager.cpp
+++ b/chassis_state_manager.cpp
@@ -54,7 +54,11 @@ void Chassis::subscribeToSystemdSignals()
     {
         auto method = this->bus.new_method_call(
             SYSTEMD_SERVICE, SYSTEMD_OBJ_PATH, SYSTEMD_INTERFACE, "Subscribe");
-        this->bus.call(method);
+        // The phosphor-state-manager service start around the same time
+        // systemd is mounting the host filesystems. This can cause a delay
+        // in D-bus calls to systemd. Use a configurable timeout when
+        // subscribing to systemd signals. The timeout is in microseconds
+        this->bus.call(method, (SYSTEMD_SUBSCRIBE_DBUS_TIMEOUT * 1000000L));
     }
     catch (const sdbusplus::exception::SdBusError& ex)
     {

--- a/configure.ac
+++ b/configure.ac
@@ -83,5 +83,11 @@ AC_ARG_VAR(CLASS_VERSION, [Class version to register with Cereal])
 AS_IF([test "x$CLASS_VERSION" == "x"], [CLASS_VERSION=1])
 AC_DEFINE_UNQUOTED([CLASS_VERSION], [$CLASS_VERSION], [Class version to register with Cereal])
 
+# TODO geissonator openbmc/phosphor-state-manager#9
+# Remove once UBI no longer used
+AC_ARG_VAR(SYSTEMD_SUBSCRIBE_DBUS_TIMEOUT, [The maximum time in seconds to wait for the D-bus systemd signal subscribe call])
+AS_IF([test "x$SYSTEMD_SUBSCRIBE_DBUS_TIMEOUT" == "x"], [SYSTEMD_SUBSCRIBE_DBUS_TIMEOUT=60])
+AC_DEFINE_UNQUOTED([SYSTEMD_SUBSCRIBE_DBUS_TIMEOUT], [$SYSTEMD_SUBSCRIBE_DBUS_TIMEOUT], [The maximum time in seconds to wait for the D-bus systemd signal subscribe call])
+
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/host_state_manager.cpp
+++ b/host_state_manager.cpp
@@ -77,7 +77,11 @@ void Host::subscribeToSystemdSignals()
 {
     auto method = this->bus.new_method_call(SYSTEMD_SERVICE, SYSTEMD_OBJ_PATH,
                                             SYSTEMD_INTERFACE, "Subscribe");
-    this->bus.call_noreply(method);
+    // The phosphor-state-manager service start around the same time
+    // systemd is mounting the host filesystems. This can cause a delay
+    // in D-bus calls to systemd. Use a configurable timeout when
+    // subscribing to systemd signals. The timeout is in microseconds
+    this->bus.call(method, (SYSTEMD_SUBSCRIBE_DBUS_TIMEOUT * 1000000L));
 
     return;
 }


### PR DESCRIPTION
This addresses one part of SW471678 (bmc and chassis state management failures). Another PR will come for the network part.

Upstream commits:
https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-state-manager/+/25020/3
https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-state-manager/+/25153/2

Due to this change being a workaround for a UBI related performance issue, this fix will not be upstreamed. UBI is going away after OP940. 