### PR TITLE
correct logic on detecting a pinhole reset

### DIFF
--- a/bmc_state_manager.cpp
+++ b/bmc_state_manager.cpp
@@ -306,7 +306,8 @@ void BMC::discoverLastRebootCause()
     auto gpioval =
         phosphor::state::manager::utils::getGpioValue("reset-cause-pinhole");
 
-    if (1 == gpioval)
+    // A 0 indicates a pinhole reset occurred
+    if (0 == gpioval)
     {
         info("The BMC reset was caused by a pinhole reset");
         this->lastRebootCause(RebootCause::PinholeReset);


### PR DESCRIPTION
Per our circuit designer, a 0 actually is what indicates a pinhole
reset. My testing was in simulation so I was able to falsely test
my thinking of how the hardware behaved.

There is also still an ongoing discussion on why some machines show the
inverse of this logic but the circuit designer assures me that a 1 is
the default and indicates the reboot was not a pinhole reset and a 0
indicates it was a pinhole reset.

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>
Change-Id: I24e536e2dcb8b3263f4fa407bc6f91fdef3ae0ad