### PR TITLE
Stop FSI scan service if chassis power on but host not booting

### DIFF
--- a/host_reset_recovery.cpp
+++ b/host_reset_recovery.cpp
@@ -36,6 +36,7 @@ constexpr auto SYSTEMD_SERVICE = "org.freedesktop.systemd1";
 constexpr auto SYSTEMD_OBJ_PATH = "/org/freedesktop/systemd1";
 constexpr auto SYSTEMD_INTERFACE = "org.freedesktop.systemd1.Manager";
 constexpr auto HOST_STATE_QUIESCE_TGT = "obmc-host-quiesce@0.target";
+constexpr auto FSI_SCAN_SVC = "fsi-scan@0.service";
 
 bool wasHostBooting(sdbusplus::bus::bus& bus)
 {
@@ -145,6 +146,27 @@ void moveToHostQuiesce(sdbusplus::bus::bus& bus)
     }
 }
 
+void stopFsiScan(sdbusplus::bus::bus& bus)
+{
+    try
+    {
+        auto method = bus.new_method_call(SYSTEMD_SERVICE, SYSTEMD_OBJ_PATH,
+                                          SYSTEMD_INTERFACE, "StopUnit");
+
+        method.append(FSI_SCAN_SVC);
+
+        bus.call_noreply(method);
+    }
+    catch (const sdbusplus::exception::exception& e)
+    {
+        error("sdbusplus call exception stopping FSI scan target: {ERROR}",
+              "ERROR", e);
+
+        throw std::runtime_error(
+            "Error in invoking D-Bus systemd StopUnit method");
+    }
+}
+
 } // namespace manager
 } // namespace state
 } // namespace phosphor
@@ -175,6 +197,7 @@ int main()
     // the BMC reboot occurred
     if (!wasHostBooting(bus))
     {
+        stopFsiScan(bus);
         return 0;
     }
 


### PR DESCRIPTION
If the host is then started, CFAM reset will start so FSI needs to be
scanned again, otherwise FSI access is broken.