### PR TITLE
host-sensors: Reset when system off but last state was on

### DIFF
--- a/chassis_state_manager.hpp
+++ b/chassis_state_manager.hpp
@@ -98,14 +98,13 @@ class Chassis : public ChassisInherit
      **/
     void subscribeToSystemdSignals();
 
-    /** @brief Execute the transition request
+    /** @brief Start the systemd unit requested
      *
-     * This function calls the appropriate systemd target for the input
-     * transition.
+     * This function calls `StartUnit` on the systemd unit given.
      *
-     * @param[in] tranReq    - Transition requested
+     * @param[in] sysdUnit    - Systemd unit
      */
-    void executeTransition(Transition tranReq);
+    void startUnit(const std::string& sysdUnit);
 
     /**
      * @brief Determine if target is active


### PR DESCRIPTION
When power was on before a BMC reboot and system is now off, the host
sensors need to be reset to show the correct system state of `off` now.
This is done by starting the `phosphor-reset-sensor-states@0.service`
unit, which handles setting the appropriate dbus properties.

Tested:
  Power on system and then remove/add AC
  Check BootProgress, etc.. properties set by reset service

Change-Id: I4928a231495a1295425dc828606b40de03253bab
Signed-off-by: Matthew Barth <msbarth@us.ibm.com>