### PR TITLE
Fix stopFSIScan Dbus call

### DIFF
--- a/host_reset_recovery.cpp
+++ b/host_reset_recovery.cpp
@@ -153,7 +153,7 @@ void stopFsiScan(sdbusplus::bus::bus& bus)
         auto method = bus.new_method_call(SYSTEMD_SERVICE, SYSTEMD_OBJ_PATH,
                                           SYSTEMD_INTERFACE, "StopUnit");
 
-        method.append(FSI_SCAN_SVC);
+        method.append(FSI_SCAN_SVC, "replace");
 
         bus.call_noreply(method);
     }


### PR DESCRIPTION
Mar 09 03:28:22 p10bmc phosphor-host-reset-recovery[587]: Chassis power on has completed, checking if host is still running after the BMC reboot
Mar 09 03:28:22 p10bmc phosphor-host-reset-recovery[587]: Host was not booting before BMC reboot
Mar 09 03:28:22 p10bmc systemd[1]: fsi-scan@0.service: Deactivated successfully.
Mar 09 03:28:22 p10bmc systemd[1]: Stopped Scan FSI devices.