### PR TITLE
ensure proper phosphor-logging dependencies

### DIFF
--- a/bmc_state_manager.cpp
+++ b/bmc_state_manager.cpp
@@ -61,7 +61,9 @@ std::string BMC::getUnitState(const std::string& unitToCheck)
     }
     catch (const sdbusplus::exception::exception& e)
     {
-        error("Error in GetUnit call: {ERROR}", "ERROR", e);
+        // Not all input units will have been loaded yet so just return an
+        // empty string if an exception is caught in this path
+        info("Unit {UNIT} not found: {ERROR}", "UNIT", unitToCheck, "ERROR", e);
         return std::string{};
     }
 
@@ -76,7 +78,7 @@ std::string BMC::getUnitState(const std::string& unitToCheck)
     {
         auto result = this->bus.call(method);
 
-        // Is obmc-standby.target active or inactive?
+        // Is input target active or inactive?
         result.read(currentState);
     }
     catch (const sdbusplus::exception::exception& e)

--- a/service_files/phosphor-systemd-target-monitor.service
+++ b/service_files/phosphor-systemd-target-monitor.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=phosphor systemd target monitor
 After=dbus.service
+Wants=xyz.openbmc_project.Logging.service
+After=xyz.openbmc_project.Logging.service
 
 [Service]
 Restart=always

--- a/service_files/xyz.openbmc_project.State.BMC.service
+++ b/service_files/xyz.openbmc_project.State.BMC.service
@@ -3,6 +3,8 @@ Description=Phosphor BMC State Manager
 Before=mapper-wait@-xyz-openbmc_project-state-bmc.service
 Wants=obmc-mapper.target
 After=obmc-mapper.target
+Wants=xyz.openbmc_project.Logging.service
+After=xyz.openbmc_project.Logging.service
 
 
 [Service]

--- a/service_files/xyz.openbmc_project.State.Chassis.service
+++ b/service_files/xyz.openbmc_project.State.Chassis.service
@@ -4,6 +4,8 @@ Before=mapper-wait@-xyz-openbmc_project-state-chassis.service
 Wants=obmc-mapper.target
 After=obmc-mapper.target
 After=org.openbmc.control.Power@0.service
+Wants=xyz.openbmc_project.Logging.service
+After=xyz.openbmc_project.Logging.service
 
 [Service]
 ExecStart=/usr/bin/phosphor-chassis-state-manager

--- a/service_files/xyz.openbmc_project.State.Host.service
+++ b/service_files/xyz.openbmc_project.State.Host.service
@@ -10,6 +10,8 @@ After=obmc-mapper.target
 After=phosphor-ipmi-host.service
 After=pldmd.service
 Before=obmc-host-reset@0.target
+Wants=xyz.openbmc_project.Logging.service
+After=xyz.openbmc_project.Logging.service
 
 [Service]
 ExecStart=/usr/bin/phosphor-host-state-manager

--- a/service_files/xyz.openbmc_project.State.ScheduledHostTransition.service
+++ b/service_files/xyz.openbmc_project.State.ScheduledHostTransition.service
@@ -5,6 +5,8 @@ Wants=obmc-mapper.target
 After=obmc-mapper.target
 Wants=xyz.openbmc_project.State.Host.service
 After=xyz.openbmc_project.State.Host.service
+Wants=xyz.openbmc_project.Logging.service
+After=xyz.openbmc_project.Logging.service
 
 [Service]
 ExecStart=/usr/bin/phosphor-scheduled-host-transition


### PR DESCRIPTION
As more errors are added to state-manager services, need to ensure they
are run after phosphor-logging is up and running. I saw an error path
recently on a BMC reset with the host up scenario where
bmc-state-manager tried to log an error but phosphor-logging was not
running yet, resulting in an unhandled exception.

Tested:
- Verify all state services start after logging (bmc is earliest):
Mar 09 18:40:33 p10bmc systemd[1]: Starting Phosphor Log Manager...
Mar 09 18:40:34 p10bmc systemd[1]: Started Phosphor Log Manager.
Mar 09 18:40:34 p10bmc systemd[1]: Starting Phosphor BMC State Manager...
Mar 09 18:40:35 p10bmc systemd[1]: Started Phosphor BMC State Manager.

- Verify PEL data after all services running:
"User Data 0": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "0x2000",
    "BMCState": "Ready",
    "BootState": "Unspecified",
    "ChassisState": "Off",
    "FW Version ID": "fw1020.00-44.2-9-g1186c2a5f8",
    "HostState": "Off",
    "System IM": "50001001"
},

- Verify PEL data when BMC state service is stopped, and logging service
  is restarted (to mimic error prior to state service running)
"User Data 0": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "0x2000",
    "BMCState": "",
    "BootState": "Unspecified",
    "ChassisState": "Off",
    "FW Version ID": "fw1020.00-44.2-9-g1186c2a5f8",
    "HostState": "Off",
    "System IM": "50001001"
},

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>
Change-Id: Id9528ab911fc57b400e40fdfc9353f4432f57d63