### PR TITLE
chassis: Monitor the PowerSystemInputs for power status

### DIFF
--- a/chassis_state_manager.cpp
+++ b/chassis_state_manager.cpp
@@ -13,6 +13,7 @@
 #include <sdbusplus/exception.hpp>
 #include <sdeventplus/event.hpp>
 #include <sdeventplus/exception.hpp>
+#include <xyz/openbmc_project/State/Decorator/PowerSystemInputs/server.hpp>
 
 #include <filesystem>
 #include <fstream>
@@ -28,6 +29,8 @@ PHOSPHOR_LOG2_USING;
 
 // When you see server:: you know we're referencing our base class
 namespace server = sdbusplus::xyz::openbmc_project::State::server;
+namespace decoratorServer =
+    sdbusplus::xyz::openbmc_project::State::Decorator::server;
 
 using namespace phosphor::logging;
 using sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
@@ -66,6 +69,8 @@ constexpr auto MAPPER_BUSNAME = "xyz.openbmc_project.ObjectMapper";
 constexpr auto MAPPER_PATH = "/xyz/openbmc_project/object_mapper";
 constexpr auto MAPPER_INTERFACE = "xyz.openbmc_project.ObjectMapper";
 constexpr auto UPOWER_INTERFACE = "org.freedesktop.UPower.Device";
+constexpr auto POWERSYSINPUTS_INTERFACE =
+    "xyz.openbmc_project.State.Decorator.PowerSystemInputs";
 constexpr auto PROPERTY_INTERFACE = "org.freedesktop.DBus.Properties";
 
 void Chassis::subscribeToSystemdSignals()
@@ -97,6 +102,14 @@ void Chassis::determineInitialState()
         sdbusplus::bus::match::rules::propertiesChangedNamespace(
             "/org/freedesktop/UPower", UPOWER_INTERFACE),
         [this](auto& msg) { this->uPowerChangeEvent(msg); });
+
+    // Monitor for any properties changed signals on PowerSystemInputs
+    powerSysInputsPropChangeSignal = std::make_unique<sdbusplus::bus::match_t>(
+        bus,
+        sdbusplus::bus::match::rules::propertiesChangedNamespace(
+            "/xyz/openbmc_project/power/power_supplies/chassis0/psus",
+            POWERSYSINPUTS_INTERFACE),
+        [this](auto& msg) { this->powerSysInputsChangeEvent(msg); });
 
     determineStatusOfPower();
 
@@ -198,6 +211,17 @@ void Chassis::determineStatusOfPower()
     // Default PowerStatus to good
     server::Chassis::currentPowerStatus(PowerStatus::Good);
 
+    determineStatusOfUPSPower();
+    if (server::Chassis::currentPowerStatus() != PowerStatus::Good)
+    {
+        return;
+    }
+
+    determineStatusOfPSUPower();
+}
+
+void Chassis::determineStatusOfUPSPower()
+{
     // Find all implementations of the UPower interface
     auto mapper = bus.new_method_call(MAPPER_BUSNAME, MAPPER_PATH,
                                       MAPPER_INTERFACE, "GetSubTree");
@@ -302,6 +326,73 @@ void Chassis::determineStatusOfPower()
     return;
 }
 
+void Chassis::determineStatusOfPSUPower()
+{
+    // Find all implementations of the PowerSystemInputs interface
+    auto mapper = bus.new_method_call(MAPPER_BUSNAME, MAPPER_PATH,
+                                      MAPPER_INTERFACE, "GetSubTree");
+
+    mapper.append("/", 0, std::vector<std::string>({POWERSYSINPUTS_INTERFACE}));
+
+    std::map<std::string, std::map<std::string, std::vector<std::string>>>
+        mapperResponse;
+
+    try
+    {
+        auto mapperResponseMsg = bus.call(mapper);
+        mapperResponseMsg.read(mapperResponse);
+    }
+    catch (const sdbusplus::exception::exception& e)
+    {
+        error("Error in mapper GetSubTree call for PowerSystemInputs: {ERROR}",
+              "ERROR", e);
+        throw;
+    }
+
+    for (const auto& [path, services] : mapperResponse)
+    {
+        for (const auto& serviceIter : services)
+        {
+            const std::string& service = serviceIter.first;
+
+            try
+            {
+                auto method = bus.new_method_call(service.c_str(), path.c_str(),
+                                                  PROPERTY_INTERFACE, "GetAll");
+                method.append(POWERSYSINPUTS_INTERFACE);
+
+                auto response = bus.call(method);
+                using Property = std::string;
+                using Value = std::variant<std::string>;
+                using PropertyMap = std::map<Property, Value>;
+                PropertyMap properties;
+                response.read(properties);
+
+                auto statusStr = std::get<std::string>(properties["Status"]);
+                auto status =
+                    decoratorServer::PowerSystemInputs::convertStatusFromString(
+                        statusStr);
+
+                if (status == decoratorServer::PowerSystemInputs::Status::Fault)
+                {
+                    info("Power System Inputs status is in Fault state");
+                    server::Chassis::currentPowerStatus(PowerStatus::BrownOut);
+                    return;
+                }
+            }
+            catch (const sdbusplus::exception::exception& e)
+            {
+                error(
+                    "Error reading Power System Inputs property, error: {ERROR}, "
+                    "service: {SERVICE} path: {PATH}",
+                    "ERROR", e, "SERVICE", service, "PATH", path);
+                throw;
+            }
+        }
+    }
+    return;
+}
+
 void Chassis::uPowerChangeEvent(sdbusplus::message::message& msg)
 {
     debug("UPS Property Change Event Triggered");
@@ -309,9 +400,9 @@ void Chassis::uPowerChangeEvent(sdbusplus::message::message& msg)
     std::map<std::string, std::variant<uint, bool>> msgData;
     msg.read(statusInterface, msgData);
 
-    // If the change is to any of the three properties we are interested in
-    // then call determineStatusOfPower() to see if a power status change
-    // is needed
+    // If the change is to any of the properties we are interested in, then call
+    // determineStatusOfPower(), which looks at all the power-related
+    // interfaces, to see if a power status change is needed
     auto propertyMap = msgData.find("IsPresent");
     if (propertyMap != msgData.end())
     {
@@ -335,6 +426,28 @@ void Chassis::uPowerChangeEvent(sdbusplus::message::message& msg)
     {
         info("UPS BatteryLevel changed to {UPS_BAT_LEVEL}", "UPS_BAT_LEVEL",
              std::get<uint>(propertyMap->second));
+        determineStatusOfPower();
+        return;
+    }
+    return;
+}
+
+void Chassis::powerSysInputsChangeEvent(sdbusplus::message::message& msg)
+{
+    debug("Power System Inputs Property Change Event Triggered");
+    std::string statusInterface;
+    std::map<std::string, std::variant<std::string>> msgData;
+    msg.read(statusInterface, msgData);
+
+    // If the change is to any of the properties we are interested in, then call
+    // determineStatusOfPower(), which looks at all the power-related
+    // interfaces, to see if a power status change is needed
+    auto propertyMap = msgData.find("Status");
+    if (propertyMap != msgData.end())
+    {
+        info("Power System Inputs status changed to {POWER_SYS_INPUT_STATUS}",
+             "POWER_SYS_INPUT_STATUS",
+             std::get<std::string>(propertyMap->second));
         determineStatusOfPower();
         return;
     }

--- a/chassis_state_manager.hpp
+++ b/chassis_state_manager.hpp
@@ -86,8 +86,20 @@ class Chassis : public ChassisInherit
     /** @brief Determine initial chassis state and set internally */
     void determineInitialState();
 
-    /** @brief Determine status of power into system */
+    /** @brief Determine status of power into system by examining all the
+     *        power-related interfaces of interest
+     */
     void determineStatusOfPower();
+
+    /** @brief Determine status of power provided by an Uninterruptible Power
+     *         Supply into the system
+     */
+    void determineStatusOfUPSPower();
+
+    /** @brief Determine status of power provided by the power supply units into
+     *         the system
+     */
+    void determineStatusOfPSUPower();
 
     /**
      * @brief subscribe to the systemd signals
@@ -134,8 +146,11 @@ class Chassis : public ChassisInherit
     /** @brief Used to subscribe to dbus systemd signals **/
     sdbusplus::bus::match_t systemdSignals;
 
-    /** @brief Watch for any changes to UPS properties  **/
+    /** @brief Watch for any changes to UPS properties **/
     std::unique_ptr<sdbusplus::bus::match_t> uPowerPropChangeSignal;
+
+    /** @brief Watch for any changes to PowerSystemInputs properties **/
+    std::unique_ptr<sdbusplus::bus::match_t> powerSysInputsPropChangeSignal;
 
     /** @brief Used to Set value of POHCounter */
     uint32_t pohCounter(uint32_t value) override;
@@ -216,6 +231,16 @@ class Chassis : public ChassisInherit
      *
      */
     void uPowerChangeEvent(sdbusplus::message::message& msg);
+
+    /** @brief Process PowerSystemInputs property changes
+     *
+     * Instance specific interface to monitor for changes to the
+     * PowerSystemInputs properties which may impact CurrentPowerStatus
+     *
+     * @param[in]  msg              - Data associated with subscribed signal
+     *
+     */
+    void powerSysInputsChangeEvent(sdbusplus::message::message& msg);
 };
 
 } // namespace manager


### PR DESCRIPTION
In addition to the uPower interface, monitor the PowerSystemInputs
interface to detect a Brownout condition. Reference:
https://gerrit.openbmc-project.xyz/c/openbmc/docs/+/48015

Tested: In simulation, trigger a power supply brownout and clear it,
verify that phosphor-chassis-check-power-status detects the condition:

Mar 29 19:02:21 p10bmc phosphor-chassis-state-manager[1101]: Power
System Inputs status changed to
xyz.openbmc_project.State.Decorator.PowerSystemInputs.Status.Fault
Mar 29 19:02:21 p10bmc phosphor-chassis-state-manager[1101]: Power
System Inputs status is in Fault state

root@p10bmc:~# /usr/bin/phosphor-chassis-check-power-status --chassis 0
<3> Chassis power status is not good:
xyz.openbmc_project.State.Chassis.PowerStatus.BrownOut
Mar 29 19:08:20 p10bmc phosphor-chassis-check-power-status[1133]:
Chassis power status is not good:
xyz.openbmc_project.State.Chassis.PowerStatus.BrownOut
Mar 29 19:08:20 p10bmc phosphor-log-manager[319]: Created PEL 0x50000004
(BMC ID 4) with SRC BDA13402
Mar 29 19:08:20 p10bmc phosphor-ledmanager[447]: SAI: FRU path:
/xyz/openbmc_project/inventory/system

Mar 29 19:02:21 p10bmc phosphor-chassis-state-manager[1101]: Power
System Inputs status changed to
xyz.openbmc_project.State.Decorator.PowerSystemInputs.Status.Good
Mar 29 19:02:21 p10bmc phosphor-chassis-state-manager[1101]:
determineStatusOfPSUPower(): Good

root@p10bmc:~# /usr/bin/phosphor-chassis-check-power-status --chassis 0
<6> Chassis power status good, start power on

Change-Id: I6adbb6474155e50219b6a48dd9b2cf872934f4a6
Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>