### PR TITLE
ensure /run/openbmc dir created on power loss

### DIFF
--- a/bmc_state_manager.hpp
+++ b/bmc_state_manager.hpp
@@ -34,7 +34,7 @@ class BMC : public BMCInherit
      * @param[in] objPath   - The Dbus object path
      */
     BMC(sdbusplus::bus::bus& bus, const char* objPath) :
-        BMCInherit(bus, objPath, true), bus(bus),
+        BMCInherit(bus, objPath, BMCInherit::action::defer_emit), bus(bus),
         stateSignal(std::make_unique<decltype(stateSignal)::element_type>(
             bus,
             sdbusRule::type::signal() + sdbusRule::member("JobRemoved") +

--- a/chassis_state_manager.cpp
+++ b/chassis_state_manager.cpp
@@ -168,6 +168,7 @@ void Chassis::determineInitialState()
                     setStateChangeTime();
 
                     // Generate file indicating AC loss occurred
+                    fs::create_directories(BASE_FILE_DIR);
                     auto size =
                         std::snprintf(nullptr, 0, CHASSIS_LOST_POWER_FILE, 0);
                     size++; // null

--- a/chassis_state_manager.hpp
+++ b/chassis_state_manager.hpp
@@ -46,7 +46,8 @@ class Chassis : public ChassisInherit
      * @param[in] objPath   - The Dbus object path
      */
     Chassis(sdbusplus::bus::bus& bus, const char* objPath) :
-        ChassisInherit(bus, objPath, true), bus(bus),
+        ChassisInherit(bus, objPath, ChassisInherit::action::defer_emit),
+        bus(bus),
         systemdSignals(
             bus,
             sdbusRule::type::signal() + sdbusRule::member("JobRemoved") +

--- a/host_state_manager.hpp
+++ b/host_state_manager.hpp
@@ -53,7 +53,7 @@ class Host : public HostInherit
      * @param[in] objPath   - The Dbus object path
      */
     Host(sdbusplus::bus::bus& bus, const char* objPath) :
-        HostInherit(bus, objPath, true), bus(bus),
+        HostInherit(bus, objPath, HostInherit::action::defer_emit), bus(bus),
         systemdSignalJobRemoved(
             bus,
             sdbusRule::type::signal() + sdbusRule::member("JobRemoved") +

--- a/hypervisor_state_manager.hpp
+++ b/hypervisor_state_manager.hpp
@@ -41,7 +41,9 @@ class Hypervisor : public HypervisorInherit
      * @param[in] objPath   - The Dbus object path
      */
     Hypervisor(sdbusplus::bus::bus& bus, const char* objPath) :
-        HypervisorInherit(bus, objPath, false), bus(bus),
+        HypervisorInherit(bus, objPath,
+                          HypervisorInherit::action::emit_object_added),
+        bus(bus),
         bootProgressChangeSignal(
             bus,
             sdbusRule::propertiesChanged(

--- a/meson.build
+++ b/meson.build
@@ -53,6 +53,9 @@ endif
 
 # globals shared across applications
 conf.set_quoted(
+    'BASE_FILE_DIR', '/run/openbmc/')
+
+conf.set_quoted(
     'HOST_RUNNING_FILE', '/run/openbmc/host@%d-on')
 
 conf.set_quoted(

--- a/scheduled_host_transition.hpp
+++ b/scheduled_host_transition.hpp
@@ -31,7 +31,8 @@ class ScheduledHostTransition : public ScheduledHostTransitionInherit
   public:
     ScheduledHostTransition(sdbusplus::bus::bus& bus, const char* objPath,
                             const sdeventplus::Event& event) :
-        ScheduledHostTransitionInherit(bus, objPath, true),
+        ScheduledHostTransitionInherit(
+            bus, objPath, ScheduledHostTransition::action::defer_emit),
         bus(bus), event(event),
         timer(event, std::bind(&ScheduledHostTransition::callback, this))
     {


### PR DESCRIPTION
This directory is created by default on r/r scenarios but on an AC
loss, the directory is not created.

This is downstream only code and fixes SW548523

Tested:
- Verified on AC loss the expected /run/openbmc/chassis@0-lost-power
  file is now created and APR logic sees it.

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>