### PR TITLE
host-graceful-quiesce: introduce new target

### DIFF
--- a/target_files/meson.build
+++ b/target_files/meson.build
@@ -12,6 +12,7 @@ unit_files = [
     'obmc-host-crash@.target',
     'obmc-host-diagnostic-mode@.target',
     'obmc-host-force-warm-reboot@.target',
+    'obmc-host-graceful-quiesce@.target',
     'obmc-host-quiesce@.target',
     'obmc-host-reboot@.target',
     'obmc-host-reset-running@.target',

--- a/target_files/obmc-host-graceful-quiesce@.target
+++ b/target_files/obmc-host-graceful-quiesce@.target
@@ -1,0 +1,4 @@
+[Unit]
+Description=Graceful Quiesce Target
+After=multi-user.target
+Conflicts=obmc-chassis-poweroff@%i.target


### PR DESCRIPTION
Per design here:
 https://gerrit.openbmc-project.xyz/c/openbmc/docs/+/52874

This introduces a new target which can be started to gracefully quiesce
the host. This allows the host an opportunity to shut itself down
gracefully.

Tested:
- Built image with new target and included pldmSoftPowerOff.service in
  it so that host firmware got a chance to gracefully shut down prior to
  Quiesce.

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>
Change-Id: I1b5d609b50951e5d529379196c36c0d66e429a8f