### PR TITLE
delay apr power on by 30 seconds

### DIFF
--- a/discover_system_state.cpp
+++ b/discover_system_state.cpp
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include <thread>
 
 namespace phosphor
 {
@@ -153,7 +154,8 @@ int main(int argc, char** argv)
         if (RestorePolicy::Policy::AlwaysOn ==
             RestorePolicy::convertPolicyFromString(powerPolicy))
         {
-            info("power_policy=ALWAYS_POWER_ON, powering host on");
+            info("power_policy=ALWAYS_POWER_ON, powering host on (30s delay)");
+            std::this_thread::sleep_for(std::chrono::seconds(30));
             phosphor::state::manager::utils::setProperty(
                 bus, hostPath, HOST_BUSNAME, "RestartCause",
                 convertForMessage(
@@ -179,12 +181,13 @@ int main(int argc, char** argv)
         else if (RestorePolicy::Policy::Restore ==
                  RestorePolicy::convertPolicyFromString(powerPolicy))
         {
-            info("power_policy=RESTORE, restoring last state");
+            info("power_policy=RESTORE, restoring last state (30s delay)");
             // Read last requested state and re-request it to execute it
             auto hostReqState = phosphor::state::manager::utils::getProperty(
                 bus, hostPath, HOST_BUSNAME, "RequestedHostTransition");
             if (hostReqState == convertForMessage(server::Host::Transition::On))
             {
+                std::this_thread::sleep_for(std::chrono::seconds(30));
                 phosphor::state::manager::utils::setProperty(
                     bus, hostPath, HOST_BUSNAME, "RestartCause",
                     convertForMessage(

--- a/discover_system_state.cpp
+++ b/discover_system_state.cpp
@@ -167,12 +167,14 @@ int main(int argc, char** argv)
         else if (RestorePolicy::Policy::AlwaysOff ==
                  RestorePolicy::convertPolicyFromString(powerPolicy))
         {
-            info("power_policy=ALWAYS_POWER_OFF, set requested state to off");
+            info(
+                "power_policy=ALWAYS_POWER_OFF, set requested state to off (30s delay)");
             // Read last requested state and re-request it to execute it
             auto hostReqState = phosphor::state::manager::utils::getProperty(
                 bus, hostPath, HOST_BUSNAME, "RequestedHostTransition");
             if (hostReqState == convertForMessage(server::Host::Transition::On))
             {
+                std::this_thread::sleep_for(std::chrono::seconds(30));
                 phosphor::state::manager::utils::setProperty(
                     bus, hostPath, HOST_BUSNAME, "RequestedHostTransition",
                     convertForMessage(server::Host::Transition::Off));


### PR DESCRIPTION
Recently code was added to move the vpd collection services to later in
the BMC boot. This caused a conflict with the APR (Automatic Power
Restart) service. The APR service would start the power on of the host
before vpd collection had completed. This caused conflicts on the shared
i2c busses between the BMC and host firmware.

Long term, we need a way to know when the vpd collection services have
completed and APR should not run until the BMC has reached READY state
and the vpd collection has completed.

Short term, add a 30 second delay when APR detects it needs to power on
the system. This ensure APR does not impact the BMC boot when it's not
needed and adds a safe delay when it does need to boot the system.

Tested:
- Powered on p10bmc chassis, caused an AC cycle, and verified that APR
  did not initiate the boot until after vpd collection had completed.
  No host i2c errors were logged and system booted as expected.
- Issued a r/r and verified service did not run
- Verified service exited quickly when no host power on was needed

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>