### PR TITLE
Power restore from last state after AC Loss

### DIFF
--- a/discover_system_state.cpp
+++ b/discover_system_state.cpp
@@ -172,7 +172,8 @@ int main(int argc, char** argv)
             // Read last requested state and re-request it to execute it
             auto hostReqState = phosphor::state::manager::utils::getProperty(
                 bus, hostPath, HOST_BUSNAME, "RequestedHostTransition");
-            if (hostReqState == convertForMessage(server::Host::Transition::On))
+            if (hostReqState !=
+                convertForMessage(server::Host::Transition::Off))
             {
                 std::this_thread::sleep_for(std::chrono::seconds(30));
                 phosphor::state::manager::utils::setProperty(
@@ -187,7 +188,10 @@ int main(int argc, char** argv)
             // Read last requested state and re-request it to execute it
             auto hostReqState = phosphor::state::manager::utils::getProperty(
                 bus, hostPath, HOST_BUSNAME, "RequestedHostTransition");
-            if (hostReqState == convertForMessage(server::Host::Transition::On))
+
+            // As long as the host transition is not 'Off' power on host state.
+            if (hostReqState !=
+                convertForMessage(server::Host::Transition::Off))
             {
                 std::this_thread::sleep_for(std::chrono::seconds(30));
                 phosphor::state::manager::utils::setProperty(
@@ -196,7 +200,7 @@ int main(int argc, char** argv)
                         server::Host::RestartCause::PowerPolicyPreviousState));
                 phosphor::state::manager::utils::setProperty(
                     bus, hostPath, HOST_BUSNAME, "RequestedHostTransition",
-                    hostReqState);
+                    convertForMessage(server::Host::Transition::On));
             }
         }
     }


### PR DESCRIPTION
In situations where the power restore policy was set to Restore from
the last known state (Restore) and the requested host transition was
not denoted as On would lead to the host never powering back on.
For example, this occurs during a fresh boot of a system or after
completing a system update where other RequestedHostTransition
properties may be set such as 'GracefulWarmReboot'. This lead to the
old logic in discover system state to never power the host back on
which means there was a potential that users would have to manually
power back on the host. This change inverts the logic, essentially
checking to ensure the 'RequestedHostTransition' was not set to off
and therefore indicating that power should be restored in all other
cases (per the interface documentation).

 Tested:
        - All testing was with PowerRestorePolicy as 'Restore'
          The corresponding gui option is 'LastState'.

        - Applied changes and ensured that power was restored to
          the host with 'GracefulWarmReboot' set as the desired
          host transition property.

        - Set 'RequestedHostTransition' property to Reboot,
          GraceFulWarmReboot, ForcedWarmReboot and verified
          that chassis power state was restored to 'On' after
          a power cycle.

        - Confirmed that with any of the transition properties
          listed above set that the 'RequestedHostTransition'
          state switched to on after reboot.

        - Verified that power state remained off when the
          'RequestedHostTransition' property was set to 'Off'.
          Also that this property remained 'Off' after reboot.