### PR TITLE
only quiesce in reboot on host crash

### DIFF
--- a/scripts/host-reboot
+++ b/scripts/host-reboot
@@ -16,6 +16,14 @@ get_reboot_count()
         | cut -d ' ' -f2
 }
 
+get_restart_cause()
+{
+    busctl get-property xyz.openbmc_project.State.Host \
+        /xyz/openbmc_project/state/host0 \
+        xyz.openbmc_project.State.Host RestartCause \
+        | cut -d '"' -f2
+}
+
 # host instance id is input parameter to function
 host_quiesce()
 {
@@ -37,11 +45,21 @@ sleep 5
 
 host_instance=$1
 
+# Normally the standard power on path will determine if the system has reached
+# its reboot count and halt in Quiesce if so. But in the host-crash path this
+# standard path is not utilized, as it goes only through systemd targets. To
+# ensure the system does not end up in an endless reboot loop, put host into
+# Quiesce if reboot count is exhausted and the reason for the reboot was a
+# HostCrash
 reboot_count=$(get_reboot_count)
-if [ "$reboot_count" -eq 0 ]; then
-    echo "reboot count is 0, go to host quiesce"
+restart_cause=$(get_restart_cause)
+if [ "$reboot_count" -eq 0 ] && \
+   [ "$restart_cause" == "xyz.openbmc_project.State.Host.RestartCause.HostCrash" ];
+then
+    echo "reboot count is 0 and host crashed, go to host quiesce"
     host_quiesce "$host_instance"
 else
-    echo "reboot count is $reboot_count so reboot host"
+    echo "reboot count ($reboot_count) is greater then 0 or host did not" \
+         "crash so reboot host"
     host_reboot "$host_instance"
 fi


### PR DESCRIPTION
This script was introduced to ensure a system properly halted in scenarios where the host has crashed (obmc-host-crash@.target). There was a loophole where the standard reboot attempt logic check was not running in this specific path.

Unfortunately, that original change was not done quite right. This script is actually called on all host reboots so we have run into situations where the host is being put into quiesce before being given one last try to boot. That last try in non-host crash scenarios is where certain recovery actions (like trying alternate boot sources for some devices) is done.

This commit modifies the script to ensure it only moves the host to the quiesce state when the cause of the host reboot was a host crash.

Tested:
- Verified in normal reboot path, even if AttemptsLeft is 0, the reboot is still done
- Verified that if AttemptsLeft is 0 and reboot reason is HostCrash that host was put in quiesce

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>
Change-Id: I18e21cc33b3c38334ad760148a0754e2bd7d0780