### PR TITLE
Handle timeout when getting PowerSystemInputs

### DIFF
--- a/chassis_state_manager.cpp
+++ b/chassis_state_manager.cpp
@@ -420,7 +420,11 @@ bool Chassis::determineStatusOfPSUPower()
                     "Error reading Power System Inputs property, error: {ERROR}, "
                     "service: {SERVICE} path: {PATH}",
                     "ERROR", e, "SERVICE", service, "PATH", path);
-                throw;
+                // This D-Bus call can fail due to timeout.  This occurs when
+                // the BMC is heavily loaded, such as when the BMC is rebooted
+                // while the chassis is powered on.  Assume PSU power is good.
+                // Rely on a PropertiesChanged event if that changes.
+                return true;
             }
         }
     }


### PR DESCRIPTION
When phosphor-chassis-state-manager starts, it makes a D-Bus call to get the Status property of the PowerSystemInputs interface.  This property indicates whether the power supplies are receiving adequate input power.

This D-Bus call can fail due to a timeout.  This occurs when the BMC is heavily loaded, such as when the BMC is rebooted while the chassis is powered on.

If this D-Bus call fails, initially assume the power supply input power is good.  Rely on a PropertiesChanged event for notification if the input power state changes.

Without this commit, a timeout causes the application to exit and the BMC to go into the Quiesced state.

Signed-off-by: Shawn McCarney <shawnmm@us.ibm.com>
Change-Id: I6ad10484a5a9768f2db13b70fb675dd50db4ffda