### PR TITLE
1050 sched host fixes

### DIFF
--- a/chassis_state_manager.cpp
+++ b/chassis_state_manager.cpp
@@ -410,7 +410,11 @@ bool Chassis::determineStatusOfPSUPower()
                     "Error reading Power System Inputs property, error: {ERROR}, "
                     "service: {SERVICE} path: {PATH}",
                     "ERROR", e, "SERVICE", service, "PATH", path);
-                throw;
+                // This D-Bus call can fail due to timeout.  This occurs when
+                // the BMC is heavily loaded, such as when the BMC is rebooted
+                // while the chassis is powered on.  Assume PSU power is good.
+                // Rely on a PropertiesChanged event if that changes.
+                return true;
             }
         }
     }

--- a/host_reset_recovery.cpp
+++ b/host_reset_recovery.cpp
@@ -37,6 +37,7 @@ constexpr auto SYSTEMD_SERVICE = "org.freedesktop.systemd1";
 constexpr auto SYSTEMD_OBJ_PATH = "/org/freedesktop/systemd1";
 constexpr auto SYSTEMD_INTERFACE = "org.freedesktop.systemd1.Manager";
 constexpr auto HOST_STATE_QUIESCE_TGT = "obmc-host-quiesce@0.target";
+constexpr auto FSI_SCAN_SVC = "fsi-scan@0.service";
 
 bool wasHostBooting(sdbusplus::bus_t& bus)
 {
@@ -148,6 +149,27 @@ void moveToHostQuiesce(sdbusplus::bus_t& bus)
     }
 }
 
+void stopFsiScan(sdbusplus::bus::bus& bus)
+{
+    try
+    {
+        auto method = bus.new_method_call(SYSTEMD_SERVICE, SYSTEMD_OBJ_PATH,
+                                          SYSTEMD_INTERFACE, "StopUnit");
+
+        method.append(FSI_SCAN_SVC, "replace");
+
+        bus.call_noreply(method);
+    }
+    catch (const sdbusplus::exception::exception& e)
+    {
+        error("sdbusplus call exception stopping FSI scan target: {ERROR}",
+              "ERROR", e);
+
+        throw std::runtime_error(
+            "Error in invoking D-Bus systemd StopUnit method");
+    }
+}
+
 } // namespace manager
 } // namespace state
 } // namespace phosphor
@@ -178,6 +200,7 @@ int main()
     // the BMC reboot occurred
     if (!wasHostBooting(bus))
     {
+        stopFsiScan(bus);
         return 0;
     }
 

--- a/scheduled_host_transition_main.cpp
+++ b/scheduled_host_transition_main.cpp
@@ -56,6 +56,13 @@ int main(int argc, char** argv)
     phosphor::state::manager::ScheduledHostTransition manager(
         bus, objPathInst.c_str(), hostId, event);
 
+    // For backwards compatibility, request a busname without host id if
+    // input id is 0.
+    if (hostId == 0)
+    {
+        bus.request_name(SCHEDULED_HOST_TRANSITION_BUSNAME);
+    }
+
     bus.request_name((std::string{SCHEDULED_HOST_TRANSITION_BUSNAME} +
                       std::to_string(hostId))
                          .c_str());


### PR DESCRIPTION
This is just a rebase with upstream. Not entirely sure why it shows the 2 patches we carry downstream as new (1040 stop fsi scan, Handle timeout...). They are already in the 1050 branch. But maybe with this rebase and PR, it'll make things "right" for future rebases. The only new content is the "scheduled-host-transition" patch which is merged upstream.