### PR TITLE
default AttemptsLeft to max when 0 is sent

### DIFF
--- a/host_state_manager.hpp
+++ b/host_state_manager.hpp
@@ -145,6 +145,13 @@ class Host : public HostInherit
         debug("External request to reset reboot count");
         auto retryAttempts = sdbusplus::xyz::openbmc_project::Control::Boot::
             server::RebootAttempts::retryAttempts();
+
+        // For legacy purposes, if a caller passes in 0, they expect the
+        // default to be set
+        if (value == 0)
+        {
+            value = retryAttempts;
+        }
         return (
             sdbusplus::xyz::openbmc_project::Control::Boot::server::
                 RebootAttempts::attemptsLeft(std::min(value, retryAttempts)));


### PR DESCRIPTION
The default in 1020/1030 code was that any external setting of host reboot attempts (AttemptsLeft) 
would result in setting AttemptsLeft to 3. The design point was that BMC firmware owned the reboot count.

Upstream added Redfish support to set the host reboot count so the design has changed to allow external users to now actually set the AttemptsLeft property.

The issue is that PHYP sends a 0 down via PLDM, expecting the BMC firmware to reset AttemptsLeft to the default (not 0). Long term the PHYP code will need to change to send down the correct AttemptsLeft value but BMC will carry a targeted patch until they are done to ensure the same behavior we had in 1020/1030.

Tested:
- Booted system and verified AttemptsLeft was reset to 3 once PHYP standby was reached.

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>