### PR TITLE
1030 retry subscribe timeouts

### DIFF
--- a/bmc_state_manager.cpp
+++ b/bmc_state_manager.cpp
@@ -117,24 +117,6 @@ void BMC::discoverInitialState()
     return;
 }
 
-void BMC::subscribeToSystemdSignals()
-{
-    auto method = this->bus.new_method_call(SYSTEMD_SERVICE, SYSTEMD_OBJ_PATH,
-                                            SYSTEMD_INTERFACE, "Subscribe");
-
-    try
-    {
-        this->bus.call(method);
-    }
-    catch (const sdbusplus::exception::exception& e)
-    {
-        error("Failed to subscribe to systemd signals: {ERROR}", "ERROR", e);
-        elog<InternalFailure>();
-    }
-
-    return;
-}
-
 void BMC::executeTransition(const Transition tranReq)
 {
     // HardReboot does not shutdown any services and immediately transitions

--- a/bmc_state_manager.hpp
+++ b/bmc_state_manager.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "utils.hpp"
 #include "xyz/openbmc_project/State/BMC/server.hpp"
 
 #include <linux/watchdog.h>
@@ -43,7 +44,7 @@ class BMC : public BMCInherit
             std::bind(std::mem_fn(&BMC::bmcStateChange), this,
                       std::placeholders::_1)))
     {
-        subscribeToSystemdSignals();
+        utils::subscribeToSystemdSignals(bus);
         discoverInitialState();
         discoverLastRebootCause();
         this->emit_object_added();
@@ -77,11 +78,6 @@ class BMC : public BMCInherit
      * @brief discover the state of the bmc
      **/
     void discoverInitialState();
-
-    /**
-     * @brief subscribe to the systemd signals
-     **/
-    void subscribeToSystemdSignals();
 
     /** @brief Execute the transition request
      *

--- a/chassis_state_manager.cpp
+++ b/chassis_state_manager.cpp
@@ -79,23 +79,6 @@ constexpr auto POWERSYSINPUTS_INTERFACE =
     "xyz.openbmc_project.State.Decorator.PowerSystemInputs";
 constexpr auto PROPERTY_INTERFACE = "org.freedesktop.DBus.Properties";
 
-void Chassis::subscribeToSystemdSignals()
-{
-    try
-    {
-        auto method = this->bus.new_method_call(
-            SYSTEMD_SERVICE, SYSTEMD_OBJ_PATH, SYSTEMD_INTERFACE, "Subscribe");
-        this->bus.call(method);
-    }
-    catch (const sdbusplus::exception::exception& e)
-    {
-        error("Failed to subscribe to systemd signals: {ERROR}", "ERROR", e);
-        elog<InternalFailure>();
-    }
-
-    return;
-}
-
 // TODO - Will be rewritten once sdbusplus client bindings are in place
 //        and persistent storage design is in place and sdbusplus
 //        has read property function

--- a/chassis_state_manager.hpp
+++ b/chassis_state_manager.hpp
@@ -2,6 +2,7 @@
 
 #include "config.h"
 
+#include "utils.hpp"
 #include "xyz/openbmc_project/State/Chassis/server.hpp"
 #include "xyz/openbmc_project/State/PowerOnHours/server.hpp"
 
@@ -60,7 +61,7 @@ class Chassis : public ChassisInherit
                  std::chrono::minutes{1})
     {
 
-        subscribeToSystemdSignals();
+        utils::subscribeToSystemdSignals(bus);
 
         restoreChassisStateChangeTime();
 
@@ -108,15 +109,6 @@ class Chassis : public ChassisInherit
      *  @return True if PSU power is good, false otherwise
      */
     bool determineStatusOfPSUPower();
-
-    /**
-     * @brief subscribe to the systemd signals
-     *
-     * This object needs to capture when it's systemd targets complete
-     * so it can keep it's state updated
-     *
-     **/
-    void subscribeToSystemdSignals();
 
     /** @brief Start the systemd unit requested
      *

--- a/host_state_manager.cpp
+++ b/host_state_manager.cpp
@@ -90,33 +90,6 @@ constexpr auto SYSTEMD_INTERFACE = "org.freedesktop.systemd1.Manager";
 constexpr auto SYSTEMD_PROPERTY_IFACE = "org.freedesktop.DBus.Properties";
 constexpr auto SYSTEMD_INTERFACE_UNIT = "org.freedesktop.systemd1.Unit";
 
-void Host::subscribeToSystemdSignals()
-{
-    auto method = this->bus.new_method_call(SYSTEMD_SERVICE, SYSTEMD_OBJ_PATH,
-                                            SYSTEMD_INTERFACE, "Subscribe");
-    // There are times during the BMC boot where systemd is unable to respond to
-    // the "Subscribe" call. Handle this by retrying the call up to 3 times
-    // before logging an error
-    for (int i = 0; i < 3; i++)
-    {
-        try
-        {
-            this->bus.call_noreply(method);
-        }
-        catch (const sdbusplus::exception::exception& e)
-        {
-            error("Failed to subscribe to systemd signals: {ERROR}", "ERROR",
-                  e);
-            continue;
-        }
-        return;
-    }
-    // Multiple tries above did not work so log an InternalFailure and crash the
-    // service
-    elog<InternalFailure>();
-    return;
-}
-
 void Host::determineInitialState()
 {
 

--- a/host_state_manager.hpp
+++ b/host_state_manager.hpp
@@ -3,6 +3,7 @@
 #include "config.h"
 
 #include "settings.hpp"
+#include "utils.hpp"
 #include "xyz/openbmc_project/State/Host/server.hpp"
 
 #include <cereal/access.hpp>
@@ -71,7 +72,7 @@ class Host : public HostInherit
         settings(bus)
     {
         // Enable systemd signals
-        subscribeToSystemdSignals();
+        utils::subscribeToSystemdSignals(bus);
 
         // Will throw exception on fail
         determineInitialState();
@@ -119,15 +120,6 @@ class Host : public HostInherit
     }
 
   private:
-    /**
-     * @brief subscribe to the systemd signals
-     *
-     * This object needs to capture when it's systemd targets complete
-     * so it can keep it's state updated
-     *
-     **/
-    void subscribeToSystemdSignals();
-
     /**
      * @brief Determine initial host state and set internally
      *

--- a/utils.cpp
+++ b/utils.cpp
@@ -15,10 +15,41 @@ namespace utils
 
 PHOSPHOR_LOG2_USING;
 
+constexpr auto SYSTEMD_SERVICE = "org.freedesktop.systemd1";
+constexpr auto SYSTEMD_OBJ_PATH = "/org/freedesktop/systemd1";
+constexpr auto SYSTEMD_INTERFACE = "org.freedesktop.systemd1.Manager";
+
 constexpr auto MAPPER_BUSNAME = "xyz.openbmc_project.ObjectMapper";
 constexpr auto MAPPER_PATH = "/xyz/openbmc_project/object_mapper";
 constexpr auto MAPPER_INTERFACE = "xyz.openbmc_project.ObjectMapper";
 constexpr auto PROPERTY_INTERFACE = "org.freedesktop.DBus.Properties";
+
+void subscribeToSystemdSignals(sdbusplus::bus::bus& bus)
+{
+    auto method = bus.new_method_call(SYSTEMD_SERVICE, SYSTEMD_OBJ_PATH,
+                                      SYSTEMD_INTERFACE, "Subscribe");
+    // There are times during the BMC boot where systemd is unable to respond to
+    // the "Subscribe" call. Handle this by retrying the call up to 3 times
+    // before logging an error
+    for (int i = 0; i < 3; i++)
+    {
+        try
+        {
+            bus.call_noreply(method);
+        }
+        catch (const sdbusplus::exception::exception& e)
+        {
+            error("Failed to subscribe to systemd signals: {ERROR}", "ERROR",
+                  e);
+            continue;
+        }
+        return;
+    }
+    // Multiple tries above did not work so throw an error and crash the
+    // service
+    throw std::runtime_error("Unable to subscribe to systemd signals");
+    return;
+}
 
 std::string getService(sdbusplus::bus::bus& bus, std::string path,
                        std::string interface)

--- a/utils.hpp
+++ b/utils.hpp
@@ -12,6 +12,14 @@ namespace manager
 namespace utils
 {
 
+/** @brief Tell systemd to generate d-bus events
+ *
+ * @param[in] bus          - The Dbus bus object
+ *
+ * @return void, will throw exception on failure
+ */
+void subscribeToSystemdSignals(sdbusplus::bus::bus& bus);
+
 /** @brief Get service name from object path and interface
  *
  * @param[in] bus          - The Dbus bus object


### PR DESCRIPTION
An issue was recently hit in manufacturing where this call to the
Subscribe method provided by systemd returned a dbus timeout. The
phosphor-host-state-manager service was restarted and the call then
passed, but by this time the first fail generated a core dump
and resulted in a BMC Quiesced state.

No searching of systemd bugs has turned up anything in this area so it
appears to be specific to OpenBMC. Opening a bug against systemd is not
allowed as this was found in our older firmware release which is running
older systemd. There would also be very minimal data to provide systemd.

https://github.com/openbmc/phosphor-state-manager/issues/4 was a similar issue, but in the chassis
state manager. Similar to that situation, a lot was going on with the
BMC at the time of the timeout. In our most recent recreate, the BMC was
booting to Ready, handling multiple vpd udev events, setting up the host
filesystem, and running our IPMI deactivate workaround (this BMC boot
was after a factory reset).

This commit adds 3 retries on any fail to the method call. Subsequent
commits will move this common code into a utility function and have all
code within phosphor-state-manager use the common function.

Tested
- Verified good path works as expected
- Verified when one error was hit, retry was done and service started up
  successfully
- Verified when all 3 retries failed that internal error was logged and
  application core dumped as expected

Defect: 409858
Upstream: No, this has only hit once, would like to see if we can get a recreate with 1050/upstream and work with systemd if we do get a recreate