### PR TITLE
secure-boot: Log an error if TPM measurement fails

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -61,6 +61,9 @@ endif
 conf.set10(
     'ONLY_RUN_APR_ON_POWER_LOSS', get_option('only-run-apr-on-power-loss'))
 
+conf.set_quoted(
+    'SYSFS_TPM_MEASUREMENT_PATH', get_option('sysfs-tpm-measurement-path'))
+
 # globals shared across applications
 conf.set_quoted(
     'BASE_FILE_DIR', '/run/openbmc/')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -130,3 +130,9 @@ option('only-run-apr-on-power-loss', type : 'boolean',
     value : 'false',
     description : 'Only run automatic restore policy due to loss of AC power.'
 )
+
+option('sysfs-tpm-measurement-path', type : 'string',
+    value : '/sys/class/tpm/tpm0/pcr-sha256/0',
+    description : 'The sysfs path to the tpm measurement value.',
+)
+


### PR DESCRIPTION
Log an error if the TPM measurement fails due to the absence or invalid value of the file '/sys/class/tpm/tpm0/pcr-sha256/0'.

Upstream Commit :
https://gerrit.openbmc.org/c/openbmc/phosphor-state-manager/+/61963

Tested:
Verified that an error is logged when '/sys/class/tpm/tpm0/pcr-sha256/0' is absent, empty, or has a value of 0, indicating that the TPM measurement has failed.
```
"Severity" : {
	"type" : "s",
	"data" : "xyz.openbmc_project.Logging.Entry.Level.Error"
},
"Message" : {
	"type" : "s",
	"data" : "xyz.openbmc_project.State.Error.TpmMeasurementFail"
},
"AdditionalData" : {
	"type" : "as",
	"data" : [
		"ERROR=TPM measurement value is empty: /sys/class/tpm/tpm0/pcr-sha256/0",
		"_PID=501"
	]
},
```