### PR TITLE
1050 no new apr delay prop

### DIFF
--- a/discover_system_state.cpp
+++ b/discover_system_state.cpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include <thread>
 
 namespace phosphor
 {
@@ -144,7 +145,8 @@ int main(int argc, char** argv)
         if (RestorePolicy::Policy::AlwaysOn ==
             RestorePolicy::convertPolicyFromString(powerPolicy))
         {
-            info("power_policy=ALWAYS_POWER_ON, powering host on");
+            info("power_policy=ALWAYS_POWER_ON, powering host on (30s delay)");
+            std::this_thread::sleep_for(std::chrono::seconds(30));
             phosphor::state::manager::utils::setProperty(
                 bus, hostPath, HOST_BUSNAME, "RestartCause",
                 convertForMessage(
@@ -167,13 +169,15 @@ int main(int argc, char** argv)
         else if (RestorePolicy::Policy::AlwaysOff ==
                  RestorePolicy::convertPolicyFromString(powerPolicy))
         {
-            info("power_policy=ALWAYS_POWER_OFF, set requested state to off");
+            info(
+                "power_policy=ALWAYS_POWER_OFF, set requested state to off (30s delay)");
             // Read last requested state and re-request it to execute it
             auto hostReqState = phosphor::state::manager::utils::getProperty(
                 bus, hostPath, HOST_BUSNAME, "RequestedHostTransition");
             if (hostReqState !=
                 convertForMessage(server::Host::Transition::Off))
             {
+                std::this_thread::sleep_for(std::chrono::seconds(30));
                 phosphor::state::manager::utils::setProperty(
                     bus, hostPath, HOST_BUSNAME, "RequestedHostTransition",
                     convertForMessage(server::Host::Transition::Off));
@@ -182,7 +186,7 @@ int main(int argc, char** argv)
         else if (RestorePolicy::Policy::Restore ==
                  RestorePolicy::convertPolicyFromString(powerPolicy))
         {
-            info("power_policy=RESTORE, restoring last state");
+            info("power_policy=RESTORE, restoring last state (30s delay)");
             // Read last requested state and re-request it to execute it
             auto hostReqState = phosphor::state::manager::utils::getProperty(
                 bus, hostPath, HOST_BUSNAME, "RequestedHostTransition");
@@ -191,6 +195,7 @@ int main(int argc, char** argv)
             if (hostReqState !=
                 convertForMessage(server::Host::Transition::Off))
             {
+                std::this_thread::sleep_for(std::chrono::seconds(30));
                 phosphor::state::manager::utils::setProperty(
                     bus, hostPath, HOST_BUSNAME, "RestartCause",
                     convertForMessage(

--- a/discover_system_state.cpp
+++ b/discover_system_state.cpp
@@ -20,7 +20,6 @@
 #include <iostream>
 #include <map>
 #include <string>
-#include <thread>
 
 namespace phosphor
 {
@@ -139,34 +138,13 @@ int main(int argc, char** argv)
                 convertForMessage(RestorePolicy::Policy::None));
         }
 
-        auto methodUserSettingDelay = bus.new_method_call(
-            settings.service(settings.powerRestorePolicy, powerRestoreIntf)
-                .c_str(),
-            settings.powerRestorePolicy.c_str(),
-            "org.freedesktop.DBus.Properties", "Get");
-
-        methodUserSettingDelay.append(powerRestoreIntf, "PowerRestoreDelay");
-
-        std::variant<uint64_t> restoreDelay;
-
-        auto delayResult = bus.call(methodUserSettingDelay);
-        delayResult.read(restoreDelay);
-        auto powerRestoreDelayUsec =
-            std::chrono::microseconds(std::get<uint64_t>(restoreDelay));
-        auto powerRestoreDelaySec =
-            std::chrono::duration_cast<std::chrono::seconds>(
-                powerRestoreDelayUsec);
-
         info("Host power is off, processing power policy {POWER_POLICY}",
              "POWER_POLICY", powerPolicy);
 
         if (RestorePolicy::Policy::AlwaysOn ==
             RestorePolicy::convertPolicyFromString(powerPolicy))
         {
-            info(
-                "power_policy=ALWAYS_POWER_ON, powering host on ({DELAY}s delay)",
-                "DELAY", powerRestoreDelaySec.count());
-            std::this_thread::sleep_for(powerRestoreDelayUsec);
+            info("power_policy=ALWAYS_POWER_ON, powering host on");
             phosphor::state::manager::utils::setProperty(
                 bus, hostPath, HOST_BUSNAME, "RestartCause",
                 convertForMessage(
@@ -189,10 +167,7 @@ int main(int argc, char** argv)
         else if (RestorePolicy::Policy::AlwaysOff ==
                  RestorePolicy::convertPolicyFromString(powerPolicy))
         {
-            info(
-                "power_policy=ALWAYS_POWER_OFF, set requested state to off ({DELAY}s delay)",
-                "DELAY", powerRestoreDelaySec.count());
-            std::this_thread::sleep_for(powerRestoreDelayUsec);
+            info("power_policy=ALWAYS_POWER_OFF, set requested state to off");
             // Read last requested state and re-request it to execute it
             auto hostReqState = phosphor::state::manager::utils::getProperty(
                 bus, hostPath, HOST_BUSNAME, "RequestedHostTransition");
@@ -207,9 +182,7 @@ int main(int argc, char** argv)
         else if (RestorePolicy::Policy::Restore ==
                  RestorePolicy::convertPolicyFromString(powerPolicy))
         {
-            info("power_policy=RESTORE, restoring last state ({DELAY}s delay)",
-                 "DELAY", powerRestoreDelaySec.count());
-            std::this_thread::sleep_for(powerRestoreDelayUsec);
+            info("power_policy=RESTORE, restoring last state");
             // Read last requested state and re-request it to execute it
             auto hostReqState = phosphor::state::manager::utils::getProperty(
                 bus, hostPath, HOST_BUSNAME, "RequestedHostTransition");


### PR DESCRIPTION
A part of the fix for PE00L4LY and needed because of https://github.com/openbmc/phosphor-settingsd/issues/16

This reverts a upstream change and brings in an old downstream-only change in its place.