### PR TITLE
1050 pinhole reset reason first

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build*/
 subprojects/*
 !subprojects/*.wrap
+.vscode/

--- a/chassis_state_manager.cpp
+++ b/chassis_state_manager.cpp
@@ -394,7 +394,11 @@ bool Chassis::determineStatusOfPSUPower()
                     "Error reading Power System Inputs property, error: {ERROR}, "
                     "service: {SERVICE} path: {PATH}",
                     "ERROR", e, "SERVICE", service, "PATH", path);
-                throw;
+                // This D-Bus call can fail due to timeout.  This occurs when
+                // the BMC is heavily loaded, such as when the BMC is rebooted
+                // while the chassis is powered on.  Assume PSU power is good.
+                // Rely on a PropertiesChanged event if that changes.
+                return true;
             }
         }
     }

--- a/discover_system_state.cpp
+++ b/discover_system_state.cpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include <thread>
 
 namespace phosphor
 {
@@ -144,7 +145,8 @@ int main(int argc, char** argv)
         if (RestorePolicy::Policy::AlwaysOn ==
             RestorePolicy::convertPolicyFromString(powerPolicy))
         {
-            info("power_policy=ALWAYS_POWER_ON, powering host on");
+            info("power_policy=ALWAYS_POWER_ON, powering host on (30s delay)");
+            std::this_thread::sleep_for(std::chrono::seconds(30));
             phosphor::state::manager::utils::setProperty(
                 bus, hostPath, HOST_BUSNAME, "RestartCause",
                 convertForMessage(
@@ -167,13 +169,15 @@ int main(int argc, char** argv)
         else if (RestorePolicy::Policy::AlwaysOff ==
                  RestorePolicy::convertPolicyFromString(powerPolicy))
         {
-            info("power_policy=ALWAYS_POWER_OFF, set requested state to off");
+            info(
+                "power_policy=ALWAYS_POWER_OFF, set requested state to off (30s delay)");
             // Read last requested state and re-request it to execute it
             auto hostReqState = phosphor::state::manager::utils::getProperty(
                 bus, hostPath, HOST_BUSNAME, "RequestedHostTransition");
             if (hostReqState !=
                 convertForMessage(server::Host::Transition::Off))
             {
+                std::this_thread::sleep_for(std::chrono::seconds(30));
                 phosphor::state::manager::utils::setProperty(
                     bus, hostPath, HOST_BUSNAME, "RequestedHostTransition",
                     convertForMessage(server::Host::Transition::Off));
@@ -182,7 +186,7 @@ int main(int argc, char** argv)
         else if (RestorePolicy::Policy::Restore ==
                  RestorePolicy::convertPolicyFromString(powerPolicy))
         {
-            info("power_policy=RESTORE, restoring last state");
+            info("power_policy=RESTORE, restoring last state (30s delay)");
             // Read last requested state and re-request it to execute it
             auto hostReqState = phosphor::state::manager::utils::getProperty(
                 bus, hostPath, HOST_BUSNAME, "RequestedHostTransition");
@@ -191,6 +195,7 @@ int main(int argc, char** argv)
             if (hostReqState !=
                 convertForMessage(server::Host::Transition::Off))
             {
+                std::this_thread::sleep_for(std::chrono::seconds(30));
                 phosphor::state::manager::utils::setProperty(
                     bus, hostPath, HOST_BUSNAME, "RestartCause",
                     convertForMessage(

--- a/discover_system_state.cpp
+++ b/discover_system_state.cpp
@@ -20,7 +20,6 @@
 #include <iostream>
 #include <map>
 #include <string>
-#include <thread>
 
 namespace phosphor
 {
@@ -139,34 +138,13 @@ int main(int argc, char** argv)
                 convertForMessage(RestorePolicy::Policy::None));
         }
 
-        auto methodUserSettingDelay = bus.new_method_call(
-            settings.service(settings.powerRestorePolicy, powerRestoreIntf)
-                .c_str(),
-            settings.powerRestorePolicy.c_str(),
-            "org.freedesktop.DBus.Properties", "Get");
-
-        methodUserSettingDelay.append(powerRestoreIntf, "PowerRestoreDelay");
-
-        std::variant<uint64_t> restoreDelay;
-
-        auto delayResult = bus.call(methodUserSettingDelay);
-        delayResult.read(restoreDelay);
-        auto powerRestoreDelayUsec =
-            std::chrono::microseconds(std::get<uint64_t>(restoreDelay));
-        auto powerRestoreDelaySec =
-            std::chrono::duration_cast<std::chrono::seconds>(
-                powerRestoreDelayUsec);
-
         info("Host power is off, processing power policy {POWER_POLICY}",
              "POWER_POLICY", powerPolicy);
 
         if (RestorePolicy::Policy::AlwaysOn ==
             RestorePolicy::convertPolicyFromString(powerPolicy))
         {
-            info(
-                "power_policy=ALWAYS_POWER_ON, powering host on ({DELAY}s delay)",
-                "DELAY", powerRestoreDelaySec.count());
-            std::this_thread::sleep_for(powerRestoreDelayUsec);
+            info("power_policy=ALWAYS_POWER_ON, powering host on");
             phosphor::state::manager::utils::setProperty(
                 bus, hostPath, HOST_BUSNAME, "RestartCause",
                 convertForMessage(
@@ -189,10 +167,7 @@ int main(int argc, char** argv)
         else if (RestorePolicy::Policy::AlwaysOff ==
                  RestorePolicy::convertPolicyFromString(powerPolicy))
         {
-            info(
-                "power_policy=ALWAYS_POWER_OFF, set requested state to off ({DELAY}s delay)",
-                "DELAY", powerRestoreDelaySec.count());
-            std::this_thread::sleep_for(powerRestoreDelayUsec);
+            info("power_policy=ALWAYS_POWER_OFF, set requested state to off");
             // Read last requested state and re-request it to execute it
             auto hostReqState = phosphor::state::manager::utils::getProperty(
                 bus, hostPath, HOST_BUSNAME, "RequestedHostTransition");
@@ -207,9 +182,7 @@ int main(int argc, char** argv)
         else if (RestorePolicy::Policy::Restore ==
                  RestorePolicy::convertPolicyFromString(powerPolicy))
         {
-            info("power_policy=RESTORE, restoring last state ({DELAY}s delay)",
-                 "DELAY", powerRestoreDelaySec.count());
-            std::this_thread::sleep_for(powerRestoreDelayUsec);
+            info("power_policy=RESTORE, restoring last state");
             // Read last requested state and re-request it to execute it
             auto hostReqState = phosphor::state::manager::utils::getProperty(
                 bus, hostPath, HOST_BUSNAME, "RequestedHostTransition");

--- a/host_reset_recovery.cpp
+++ b/host_reset_recovery.cpp
@@ -37,6 +37,7 @@ constexpr auto SYSTEMD_SERVICE = "org.freedesktop.systemd1";
 constexpr auto SYSTEMD_OBJ_PATH = "/org/freedesktop/systemd1";
 constexpr auto SYSTEMD_INTERFACE = "org.freedesktop.systemd1.Manager";
 constexpr auto HOST_STATE_QUIESCE_TGT = "obmc-host-quiesce@0.target";
+constexpr auto FSI_SCAN_SVC = "fsi-scan@0.service";
 
 bool wasHostBooting(sdbusplus::bus_t& bus)
 {
@@ -148,6 +149,27 @@ void moveToHostQuiesce(sdbusplus::bus_t& bus)
     }
 }
 
+void stopFsiScan(sdbusplus::bus::bus& bus)
+{
+    try
+    {
+        auto method = bus.new_method_call(SYSTEMD_SERVICE, SYSTEMD_OBJ_PATH,
+                                          SYSTEMD_INTERFACE, "StopUnit");
+
+        method.append(FSI_SCAN_SVC, "replace");
+
+        bus.call_noreply(method);
+    }
+    catch (const sdbusplus::exception::exception& e)
+    {
+        error("sdbusplus call exception stopping FSI scan target: {ERROR}",
+              "ERROR", e);
+
+        throw std::runtime_error(
+            "Error in invoking D-Bus systemd StopUnit method");
+    }
+}
+
 } // namespace manager
 } // namespace state
 } // namespace phosphor
@@ -178,6 +200,7 @@ int main()
     // the BMC reboot occurred
     if (!wasHostBooting(bus))
     {
+        stopFsiScan(bus);
         return 0;
     }
 

--- a/host_state_manager.hpp
+++ b/host_state_manager.hpp
@@ -146,6 +146,13 @@ class Host : public HostInherit
         debug("External request to reset reboot count");
         auto retryAttempts = sdbusplus::xyz::openbmc_project::Control::Boot::
             server::RebootAttempts::retryAttempts();
+
+        // For legacy purposes, if a caller passes in 0, they expect the
+        // default to be set
+        if (value == 0)
+        {
+            value = retryAttempts;
+        }
         return (
             sdbusplus::xyz::openbmc_project::Control::Boot::server::
                 RebootAttempts::attemptsLeft(std::min(value, retryAttempts)));


### PR DESCRIPTION
As usual, the diff shows more then I'm actually doing here with this upstream rebase for whatever reason. This is just picking up 2 commits:

- https://gerrit.openbmc.org/c/openbmc/phosphor-state-manager/+/64257
- https://gerrit.openbmc.org/c/openbmc/phosphor-state-manager/+/64258