### PR TITLE
Check the TPM measurement if TPM is present

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -62,6 +62,9 @@ conf.set10(
     'ONLY_RUN_APR_ON_POWER_LOSS', get_option('only-run-apr-on-power-loss'))
 
 conf.set_quoted(
+    'SYSFS_TPM_DEVICE_PATH', get_option('sysfs-tpm-device-path'))
+
+conf.set_quoted(
     'SYSFS_TPM_MEASUREMENT_PATH', get_option('sysfs-tpm-measurement-path'))
 
 conf.set10(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -131,6 +131,11 @@ option('only-run-apr-on-power-loss', type : 'boolean',
     description : 'Only run automatic restore policy due to loss of AC power.'
 )
 
+option('sysfs-tpm-device-path', type : 'string',
+    value : '/sys/firmware/devicetree/base/ahb/apb/bus@1e78a000/i2c-bus@680/tpm@2e',
+    description : 'The sysfs path to the tpm device.',
+)
+
 option('sysfs-tpm-measurement-path', type : 'string',
     value : '/sys/class/tpm/tpm0/pcr-sha256/0',
     description : 'The sysfs path to the tpm measurement value.',

--- a/secure_boot_check.cpp
+++ b/secure_boot_check.cpp
@@ -187,9 +187,11 @@ int main()
                 additionalData);
         }
     }
-
-    // Check the TPM measurement
-    checkTpmMeasurement();
+    // Check the TPM measurement if TPM is enabled
+    if (std::filesystem::exists(std::string(SYSFS_TPM_DEVICE_PATH)))
+    {
+        checkTpmMeasurement();
+    }
 
     return 0;
 }


### PR DESCRIPTION
Perform the TPM Measurement Check only if TPM is present. This commit
adds a new option to provide the sysfs TPM device tree path, which will
be used to verify TPM's presence. If the device tree path doesn't exist,
it indicates that TPM is not present.

Upstream Commit :
https://gerrit.openbmc.org/c/openbmc/phosphor-state-manager/+/65283

Tested: Tested in all three systems

Change-Id: I583355b0677d1377007cf99003c3d9676f445aba