### PR TITLE
clang-format: copy latest and re-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -14,26 +14,30 @@ AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: Empty
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Empty
-AllowShortIfStatementsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: true
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: true
 BinPackParameters: true
+BitFieldColonSpacing: None
 BraceWrapping:
   AfterCaseLabel:  true
   AfterClass:      true
   AfterControlStatement: true
   AfterEnum:       true
+  AfterExternBlock: true
   AfterFunction:   true
   AfterNamespace:  true
   AfterObjCDeclaration: true
   AfterStruct:     true
   AfterUnion:      true
-  AfterExternBlock: true
   BeforeCatch:     true
   BeforeElse:      true
+  BeforeLambdaBody: false
+  BeforeWhile:     false
   IndentBraces:    false
   SplitEmptyFunction:   false
   SplitEmptyRecord:     false
@@ -48,17 +52,16 @@ BreakStringLiterals: false
 ColumnLimit:     80
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
-DeriveLineEnding: false
 DerivePointerAlignment: false
-PointerAlignment: Left
 DisableFormat:   false
-ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
-ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
 IncludeBlocks: Regroup
 IncludeCategories:
   - Regex:           '^[<"](gtest|gmock)'
@@ -78,6 +81,7 @@ IncludeCategories:
   - Regex:           '.*'
     Priority:        6
 IndentCaseLabels: true
+IndentExternBlock: NoIndent
 IndentRequiresClause: true
 IndentWidth:     4
 IndentWrappedFunctionNames: true
@@ -92,6 +96,7 @@ NamespaceIndentation: None
 ObjCBlockIndentWidth: 2
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: BinPack
 PenaltyBreakAssignment: 25
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
@@ -100,12 +105,13 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
 QualifierAlignment: Left
 ReferenceAlignment: Left
 ReflowComments:  true
 RequiresClausePosition: OwnLine
 RequiresExpressionIndentation: Keyword
-SortIncludes:    true
+SortIncludes: CaseSensitive
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: true
@@ -117,7 +123,7 @@ SpaceBeforeParens: ControlStatements
 SpaceBeforeRangeBasedForLoopColon: true
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
-SpacesInAngles:  false
+SpacesInAngles: Never
 SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false

--- a/hypervisor_state_manager.hpp
+++ b/hypervisor_state_manager.hpp
@@ -44,13 +44,12 @@ class Hypervisor : public HypervisorInherit
         HypervisorInherit(bus, objPath,
                           HypervisorInherit::action::emit_object_added),
         bus(bus),
-        bootProgressChangeSignal(bus,
-                                 sdbusRule::propertiesChanged(
-                                     "/xyz/openbmc_project/state/host0",
-                                     "xyz.openbmc_project.State.Boot.Progress"),
-                                 [this](sdbusplus::message_t& m) {
-        bootProgressChangeEvent(m);
-        })
+        bootProgressChangeSignal(
+            bus,
+            sdbusRule::propertiesChanged(
+                "/xyz/openbmc_project/state/host0",
+                "xyz.openbmc_project.State.Boot.Progress"),
+            [this](sdbusplus::message_t& m) { bootProgressChangeEvent(m); })
     {}
 
     /** @brief Set value of HostTransition */


### PR DESCRIPTION
clang-format-17 has some backwards incompatible changes that require additional settings for best compatibility and re-running the formatter. Copy the latest .clang-format from the docs repository and reformat the repository.

Change-Id: I6c35c476f2c7238321c6e9a2662d7f5d4377c64a