### PR TITLE
1020:sched-host: add delay when BMC not at ready

### DIFF
--- a/service_files/xyz.openbmc_project.State.ScheduledHostTransition.service
+++ b/service_files/xyz.openbmc_project.State.ScheduledHostTransition.service
@@ -5,6 +5,8 @@ Wants=obmc-mapper.target
 After=obmc-mapper.target
 Wants=xyz.openbmc_project.State.Host.service
 After=xyz.openbmc_project.State.Host.service
+Wants=xyz.openbmc_project.State.BMC.service
+After=xyz.openbmc_project.State.BMC.service
 Wants=xyz.openbmc_project.Logging.service
 After=xyz.openbmc_project.Logging.service
 


### PR DESCRIPTION
This was fixed in upstream code via the introduction of the BMC Ready feature[1]. Backporting all of that function would bring additional risks for our old releases so put a simpler version of it in that will just dealy 60s when the BMC is not at a Ready state.

Tested:
- Set a time that would expire during the BMC reboot and rebooted the BMC. Confirmed code path was hit and power on was delayed by 60s.

[1]: https://gerrit.openbmc.org/c/openbmc/phosphor-state-manager/+/68576