### PR TITLE
Revert "remove 'flush' failure modes"

### DIFF
--- a/target_files/obmc-chassis-poweron@.target
+++ b/target_files/obmc-chassis-poweron@.target
@@ -8,4 +8,4 @@ Wants=obmc-power-start-pre@%i.target
 Wants=obmc-power-start@%i.target
 Wants=obmc-power-on@%i.target
 OnFailure=obmc-chassis-poweroff@%i.target
-OnFailureJobMode=fail
+OnFailureJobMode=flush

--- a/target_files/obmc-host-reboot@.target
+++ b/target_files/obmc-host-reboot@.target
@@ -3,4 +3,4 @@ Description=Reboot Host%i
 After=multi-user.target
 Conflicts=obmc-host-startmin@%i.target
 OnFailure=obmc-chassis-poweroff@%i.target
-OnFailureJobMode=fail
+OnFailureJobMode=flush

--- a/target_files/obmc-host-shutdown@.target
+++ b/target_files/obmc-host-shutdown@.target
@@ -2,4 +2,4 @@
 Description=Power%i Host Off
 After=multi-user.target
 OnFailure=obmc-chassis-poweroff@%i.target
-OnFailureJobMode=fail
+OnFailureJobMode=flush

--- a/target_files/obmc-host-start@.target
+++ b/target_files/obmc-host-start@.target
@@ -3,4 +3,4 @@ Description=Start Host%i
 After=multi-user.target
 Conflicts=obmc-host-stop@%i.target
 OnFailure=obmc-host-quiesce@%i.target
-OnFailureJobMode=fail
+OnFailureJobMode=flush

--- a/target_files/obmc-host-startmin@.target
+++ b/target_files/obmc-host-startmin@.target
@@ -6,4 +6,4 @@ Wants=obmc-host-start-pre@%i.target
 Wants=obmc-host-starting@%i.target
 Wants=obmc-host-started@%i.target
 OnFailure=obmc-host-quiesce@%i.target
-OnFailureJobMode=fail
+OnFailureJobMode=flush

--- a/target_files/obmc-host-stop@.target
+++ b/target_files/obmc-host-stop@.target
@@ -7,4 +7,4 @@ Wants=obmc-host-stop-pre@%i.target
 Wants=obmc-host-stopping@%i.target
 Wants=obmc-host-stopped@%i.target
 OnFailure=obmc-chassis-poweroff@%i.target
-OnFailureJobMode=fail
+OnFailureJobMode=flush


### PR DESCRIPTION
This reverts commit b62410b3c209d44086909294c33a60b88f49aeb6.

We finally picked this up in downstream and pretty quickly ran into a couple of issues.

The first was then when hitting an error early in the obmc-chassis-poweron@0.target, we hit situations where the obmc-chassis-poweroff@0.target would be properly triggered during the OnFailure but it would not properly stop the obmc-power-start.service. This caused the subsequent power on to fail because the obmc-power-start.service was considered already running. I dug around for a bit on this but can only conclude we're doing something systemd can not handle (there are a lot of services running in obmc-chassis-poweron@0.target and obmc-chassis-poweroff@0.target).

The second issue is that on IBM systems, the host firmware requests a lot of host reboots. They do this a lot after a new image has been flashed as they update different parts of the hardware. Host firmware can also request reboots as they deconfigure hardware. The host firmware requests these reboots during a normal boot. Because we now have "fail" in the targets, the services that are stopped are treated as failed. If you hit these quickly enough (which we do sometimes when the right set of fails occur early in the boot), then the services will hit their fail limit and stop being executed.

I understand the reasoning behind the initial commit, but it doesn't seem like it's going to work. I'm wondering if the default for this, ["replace"][1] is best.

I'm not recommending we merge this revert at this time but use it to get the discussion going (and we'll probably pull it into our downstream code for now).

[1]: https://www.freedesktop.org/software/systemd/man/latest/systemctl.html#--job-mode=

Change-Id: I44680d261924e4e71f2da021b561cb89e96ad7e3