### PR TITLE
RBMC: Introduce RBMC state manager

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -357,3 +357,7 @@ gmock = dependency('gmock', disabler: true, required: build_tests)
       )
   )
 endif
+
+if get_option('rbmc-state-management').allowed()
+  subdir('redundant-bmc')
+endif

--- a/meson.options
+++ b/meson.options
@@ -108,3 +108,8 @@ option('only-allow-boot-when-bmc-ready', type : 'boolean',
     value : false,
     description : 'Only allow chassis and host power on operations when BMC is Ready.'
 )
+
+option('rbmc-state-management', type: 'feature',
+    value : 'enabled',
+    description : 'Enable redundant BMC state management'
+)

--- a/redundant-bmc/meson.build
+++ b/redundant-bmc/meson.build
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+subdir('src')

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -1,0 +1,45 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#include "manager.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+namespace rbmc
+{
+
+Manager::Manager(sdbusplus::async::context& ctx) :
+    ctx(ctx),
+    redundancyInterface(ctx.get_bus(), RedundancyInterface::instance_path)
+{
+    ctx.spawn(startup());
+}
+
+// clang-tidy currently mangles this into something unreadable
+// NOLINTNEXTLINE
+sdbusplus::async::task<> Manager::startup()
+{
+    // TODO: Actually figure out the role
+    lg2::info("Setting role to passive");
+    redundancyInterface.role(RedundancyInterface::Role::Passive);
+
+    ctx.spawn(doHeartBeat());
+
+    co_return;
+}
+
+// clang-tidy currently mangles this into something unreadable
+// NOLINTNEXTLINE
+sdbusplus::async::task<> Manager::doHeartBeat()
+{
+    using namespace std::chrono_literals;
+    lg2::info("Starting heartbeat");
+
+    while (!ctx.stop_requested())
+    {
+        redundancyInterface.heartbeat();
+        co_await sdbusplus::async::sleep_for(ctx, 1s);
+    }
+
+    co_return;
+}
+
+} // namespace rbmc

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -1,0 +1,62 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#pragma once
+
+#include <sdbusplus/async.hpp>
+#include <xyz/openbmc_project/State/BMC/Redundancy/server.hpp>
+
+namespace rbmc
+{
+
+using RedundancyIntf =
+    sdbusplus::xyz::openbmc_project::State::BMC::server::Redundancy;
+using RedundancyInterface = sdbusplus::server::object_t<RedundancyIntf>;
+
+/**
+ * @class Manager
+ *
+ * Manages the high level operations of the redundant
+ * BMC functionality.
+ */
+class Manager
+{
+  public:
+    Manager() = delete;
+    ~Manager() = default;
+    Manager(const Manager&) = delete;
+    Manager& operator=(const Manager&) = delete;
+    Manager(Manager&&) = delete;
+    Manager& operator=(Manager&&) = delete;
+
+    /**
+     * @brief Constructor
+     *
+     * @param[in] ctx - The async context object
+     */
+    explicit Manager(sdbusplus::async::context& ctx);
+
+  private:
+    /**
+     * @brief Kicks off the Manager startup
+     */
+    sdbusplus::async::task<> startup();
+
+    /**
+     * @brief Emits a heartbeat signal every second
+     *
+     * The sibling gets this via the sibling app to
+     * know all's well.
+     */
+    sdbusplus::async::task<> doHeartBeat();
+
+    /**
+     * @brief The async context object
+     */
+    sdbusplus::async::context& ctx;
+
+    /**
+     * @brief The Redundancy D-Bus interface
+     */
+    RedundancyInterface redundancyInterface;
+};
+
+} // namespace rbmc

--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+execinstalldir = join_paths(get_option('libexecdir'), 'phosphor-state-manager')
+
+executable('phosphor-rbmc-state-manager',
+           'manager.cpp',
+           'rbmc_manager_main.cpp',
+            dependencies: [
+                phosphordbusinterfaces,
+                phosphorlogging,
+                sdbusplus,
+            ],
+    install: true,
+    install_dir: execinstalldir,
+)

--- a/redundant-bmc/src/rbmc_manager_main.cpp
+++ b/redundant-bmc/src/rbmc_manager_main.cpp
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "manager.hpp"
+
+#include <sdbusplus/async/context.hpp>
+#include <sdbusplus/server/manager.hpp>
+#include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
+
+using Redundancy =
+    sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy;
+
+int main()
+{
+    sdbusplus::async::context ctx;
+    sdbusplus::server::manager_t objMgr{ctx, "/xyz/openbmc_project/state"};
+
+    rbmc::Manager manager{ctx};
+
+    // clang-tidy currently mangles this into something unreadable
+    // NOLINTNEXTLINE
+    ctx.spawn([](sdbusplus::async::context& ctx) -> sdbusplus::async::task<> {
+        ctx.request_name(Redundancy::interface);
+        co_return;
+    }(ctx));
+
+    ctx.run();
+
+    return 0;
+}

--- a/service_files/meson.build
+++ b/service_files/meson.build
@@ -12,6 +12,7 @@ unit_files = [
     'phosphor-reset-host-running@.service',
     'phosphor-reset-sensor-states@.service',
     'xyz.openbmc_project.State.BMC.service',
+    'xyz.openbmc_project.State.BMC.Redundancy.service',
     'xyz.openbmc_project.State.Chassis@.service',
     'xyz.openbmc_project.State.Host@.service',
     'xyz.openbmc_project.State.Hypervisor.service',

--- a/service_files/xyz.openbmc_project.State.BMC.Redundancy.service
+++ b/service_files/xyz.openbmc_project.State.BMC.Redundancy.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Phosphor Redundant BMC State Manager
+Wants=xyz.openbmc_project.State.BMC.service
+After=xyz.openbmc_project.State.BMC.service
+
+[Service]
+ExecStart=/usr/libexec/phosphor-state-manager/phosphor-rbmc-state-manager
+Restart=always
+Type=dbus
+BusName=xyz.openbmc_project.State.BMC.Redundancy
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
As discussed in the redundant BMC design doc
https://gerrit.openbmc.org/c/openbmc/docs/+/70233, a new application is needed to manage redundant BMC functionality.

This application is called phosphor-rbmc-state-manager, and its compilation is enabled with a 'rbmc-state-management' meson option.  The code is in its own 'redundant-bmc' subdirectory because it will probably be made up of a lot of files, and hopefully have a lot of testcases, by the time it is finished.

It hosts an xyz.openbmc_project.State.BMC.Redundancy interface on a service of the same name, on the /xyz/openbmc_project/state/bmc0 object path.

This commit just gets the application running where it immediately sets its role to Passive and starts up its heartbeat signal, which will eventually be obtained by the sibling to know the management app is healthy.

Tested:
When flash image is built with it, app starts up as expected:

```
Sep 03 19:40:37 huygens phosphor-rbmc-state-manager[641]: Setting role to passive
Sep 03 19:40:37 huygens phosphor-rbmc-state-manager[641]: Starting heartbeat
```

```
$ busctl introspect -l xyz.openbmc_project.State.BMC.Redundancy /xyz/openbmc_project/state/bmc0
NAME                                     TYPE      SIGNATURE RESULT/VALUE                                            FLAGS
org.freedesktop.DBus.Introspectable      interface -         -                                                       -
.Introspect                              method    -         s                                                       -
org.freedesktop.DBus.Peer                interface -         -                                                       -
.GetMachineId                            method    -         s                                                       -
.Ping                                    method    -         -                                                       -
org.freedesktop.DBus.Properties          interface -         -                                                       -
.Get                                     method    ss        v                                                       -
.GetAll                                  method    s         a{sv}                                                   -
.Set                                     method    ssv       -                                                       -
.PropertiesChanged                       signal    sa{sv}as  -                                                       -
xyz.openbmc_project.State.BMC.Redundancy interface -         -                                                       -
.RedundancyEnabled                       property  b         false                                                   emits-change
.Role                                    property  s         "xyz.openbmc_project.State.BMC.Redundancy.Role.Passive" emits-change
.Heartbeat                               signal    -         -
-
```

Heartbeat signals seen with dbus-monitor:

```
... path=/xyz/openbmc_project/state/bmc0; interface=xyz.openbmc_project.State.BMC.Redundancy; member=Heartbeat
```