### PR TITLE
RBMC: Choose role based on position

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -286,8 +286,26 @@ build_tests = get_option('tests')
 # If test coverage of source files within the root directory are wanted,
 # need to define and build the tests from here
 if not build_tests.disabled()
-gtest = dependency('gtest', main: true, disabler: true, required: build_tests)
-gmock = dependency('gmock', disabler: true, required: build_tests)
+gtest = dependency('gtest', main: true, disabler: true, required: false, include_type: 'system')
+gmock = dependency('gmock', disabler: true, required: false, include_type: 'system')
+    if not gtest.found() or not gmock.found()
+        gtest_proj = import('cmake').subproject('googletest', required: false)
+        if gtest_proj.found()
+            gtest = declare_dependency(
+                dependencies: [
+                    dependency('threads'),
+                    gtest_proj.dependency('gtest'),
+                    gtest_proj.dependency('gtest_main'),
+                ]
+            )
+            gmock = gtest_proj.dependency('gmock')
+        else
+            assert(
+                not get_option('tests').enabled(),
+                'Googletest is required if tests are enabled'
+            )
+        endif
+    endif
   test(
       'test_systemd_parser',
       executable('test_systemd_parser',

--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -1,0 +1,21 @@
+# Redundant BMC Management
+
+The phosphor-rbmc-state-manager application manages redundant BMC functionality.
+
+It hosts an xyz.openbmc_project.State.BMC.Redundancy interface on a service of
+the same name, on the /xyz/openbmc_project/state/bmc0 object path. This
+interface provides the Active vs Passive role property as well as some other
+redundancy related properties.
+
+## Startup
+
+So far on startup the application will just immediately determine its role.
+
+## Role Determination Rules
+
+The current rules for role determination are:
+
+1. If BMC position zero choose the active role, otherwise passive.
+
+If there is an internal failure during role determination, like an exception,
+the BMC will also have to become passive.

--- a/redundant-bmc/meson.build
+++ b/redundant-bmc/meson.build
@@ -1,2 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 subdir('src')
+
+if get_option('tests').allowed()
+    subdir('test')
+endif

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -1,6 +1,9 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 #pragma once
 
+#include "role_determination.hpp"
+#include "services.hpp"
+
 #include <sdbusplus/async.hpp>
 #include <xyz/openbmc_project/State/BMC/Redundancy/server.hpp>
 
@@ -31,8 +34,10 @@ class Manager
      * @brief Constructor
      *
      * @param[in] ctx - The async context object
+     * @param[in] services - The services object to interface with system data.
      */
-    explicit Manager(sdbusplus::async::context& ctx);
+    Manager(sdbusplus::async::context& ctx,
+            std::unique_ptr<Services>&& services);
 
   private:
     /**
@@ -49,6 +54,13 @@ class Manager
     sdbusplus::async::task<> doHeartBeat();
 
     /**
+     * @brief Determines the BMC role
+     *
+     * @return Role - The role
+     */
+    Role determineRole();
+
+    /**
      * @brief The async context object
      */
     sdbusplus::async::context& ctx;
@@ -57,6 +69,13 @@ class Manager
      * @brief The Redundancy D-Bus interface
      */
     RedundancyInterface redundancyInterface;
+
+    /**
+     * @brief The services object
+     *
+     * Wraps system interfaces.
+     */
+    std::unique_ptr<Services> services;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -4,6 +4,8 @@ execinstalldir = join_paths(get_option('libexecdir'), 'phosphor-state-manager')
 executable('phosphor-rbmc-state-manager',
            'manager.cpp',
            'rbmc_manager_main.cpp',
+           'role_determination.cpp',
+           'services_impl.cpp',
             dependencies: [
                 phosphordbusinterfaces,
                 phosphorlogging,

--- a/redundant-bmc/src/rbmc_manager_main.cpp
+++ b/redundant-bmc/src/rbmc_manager_main.cpp
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include "manager.hpp"
+#include "services_impl.hpp"
 
 #include <sdbusplus/async/context.hpp>
 #include <sdbusplus/server/manager.hpp>
@@ -14,7 +15,10 @@ int main()
     sdbusplus::async::context ctx;
     sdbusplus::server::manager_t objMgr{ctx, "/xyz/openbmc_project/state"};
 
-    rbmc::Manager manager{ctx};
+    std::unique_ptr<rbmc::Services> services =
+        std::make_unique<rbmc::ServicesImpl>();
+
+    rbmc::Manager manager{ctx, std::move(services)};
 
     // clang-tidy currently mangles this into something unreadable
     // NOLINTNEXTLINE

--- a/redundant-bmc/src/role_determination.cpp
+++ b/redundant-bmc/src/role_determination.cpp
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "role_determination.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+namespace rbmc::role_determination
+{
+
+Role run(const Input& input)
+{
+    if (input.bmcPosition == 0)
+    {
+        lg2::info("Role = active due to BMC position 0");
+        return Role::Active;
+    }
+    return Role::Passive;
+}
+
+} // namespace rbmc::role_determination

--- a/redundant-bmc/src/role_determination.hpp
+++ b/redundant-bmc/src/role_determination.hpp
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
+
+namespace rbmc
+{
+
+using Role =
+    sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy::Role;
+
+namespace role_determination
+{
+
+/**
+ * @brief Inputs to the role determination function.
+ */
+struct Input
+{
+    size_t bmcPosition;
+};
+
+/**
+ * @brief Determines if this BMC should claim the Active or Passive role.
+ *
+ * @param[in] input  - The structure of inputs
+ *
+ * @return The role
+ */
+Role run(const Input& input);
+
+} // namespace role_determination
+
+} // namespace rbmc

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -1,0 +1,37 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#pragma once
+#include <sdbusplus/async.hpp>
+
+namespace rbmc
+{
+
+/**
+ * @class Services
+ *
+ * This is the base class interface for dealing with system
+ * information, so that the details on how to obtain the data
+ * are abtracted away from the business logic.
+ *
+ * In addition to a derived class the implements the functionality,
+ * a mock version of the class can be used in unit test.
+ *
+ */
+class Services
+{
+  public:
+    Services() = default;
+    virtual ~Services() = default;
+    Services(const Services&) = delete;
+    Services& operator=(const Services&) = delete;
+    Services(Services&&) = delete;
+    Services& operator=(Services&&) = delete;
+
+    /**
+     * @brief Returns this BMC's position.
+     *
+     * @return - The position
+     */
+    virtual size_t getBMCPosition() const = 0;
+};
+
+} // namespace rbmc

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#include "services_impl.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+namespace rbmc
+{
+
+size_t ServicesImpl::getBMCPosition() const
+{
+    size_t bmcPosition = 0;
+
+    // NOTE:  This a temporary solution for simulation until the
+    // daemon that should be providing this information is in place.
+    // Most likely, this will then have to return a task<uint32_t>.
+
+    // Read it out of the bmc_position uboot environment variable
+    // This was written by a simulation script.
+    std::string cmd{"/sbin/fw_printenv -n bmc_position"};
+
+    // NOLINTBEGIN(cert-env33-c)
+    FILE* pipe = popen(cmd.c_str(), "r");
+    // NOLINTEND(cert-env33-c)
+    if (pipe == nullptr)
+    {
+        throw std::runtime_error("Error calling popen to get bmc_position");
+    }
+
+    std::string output;
+    std::array<char, 128> buffer;
+    while (fgets(buffer.data(), buffer.size(), pipe) != nullptr)
+    {
+        output.append(buffer.data());
+    }
+
+    int rc = pclose(pipe);
+    if (WEXITSTATUS(rc) != 0)
+    {
+        throw std::runtime_error{std::format(
+            "Error running cmd: {}, output = {}, rc = {}", cmd, output, rc)};
+    }
+
+    auto [_,
+          ec] = std::from_chars(&*output.begin(), &*output.end(), bmcPosition);
+    if (ec != std::errc())
+    {
+        throw std::runtime_error{
+            std::format("Could not extract position from {}: rc {}", output,
+                        std::to_underlying(ec))};
+    }
+
+    return bmcPosition;
+}
+
+} // namespace rbmc

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#pragma once
+
+#include "services.hpp"
+
+namespace rbmc
+{
+
+/**
+ * @class ServicesImpl
+ *
+ * Implements the Services functions to interact
+ * with the system.
+ *
+ */
+class ServicesImpl : public Services
+{
+  public:
+    ServicesImpl() = default;
+    ~ServicesImpl() override = default;
+    ServicesImpl(const ServicesImpl&) = delete;
+    ServicesImpl& operator=(const ServicesImpl&) = delete;
+    ServicesImpl(ServicesImpl&&) = delete;
+    ServicesImpl& operator=(ServicesImpl&&) = delete;
+
+    /**
+     * @brief Returns this BMC's position.
+     *
+     * @return - The position
+     */
+    size_t getBMCPosition() const override;
+};
+
+} // namespace rbmc

--- a/redundant-bmc/test/meson.build
+++ b/redundant-bmc/test/meson.build
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+
+test('rbmc-tests',
+  executable('rbmc-tests',
+    'role_determination_test.cpp',
+    '../src/role_determination.cpp',
+    dependencies: [
+      gtest,
+      sdbusplus,
+      phosphordbusinterfaces,
+      phosphorlogging,
+    ],
+    include_directories: '../src'
+  )
+)

--- a/redundant-bmc/test/role_determination_test.cpp
+++ b/redundant-bmc/test/role_determination_test.cpp
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "role_determination.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace rbmc;
+using namespace role_determination;
+
+TEST(RoleDeterminationTest, RoleDeterminationTest)
+{
+    {
+        Input input{.bmcPosition = 0};
+        EXPECT_EQ(run(input), Role::Active);
+    }
+
+    {
+        Input input{.bmcPosition = 1};
+        EXPECT_EQ(run(input), Role::Passive);
+    }
+}

--- a/subprojects/googletest.wrap
+++ b/subprojects/googletest.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+revision = HEAD
+url = https://github.com/google/googletest.git


### PR DESCRIPTION
At this point, there is only a minimal simulation model, and information about the sibling BMC is not yet available.  What is available is the BMC position, which is set by the simulation startup script by writing a 'bmc_position' udev environment variable:

```
$ fw_printenv bmc_position
bmc_position=0
```

This commit makes use of that variable to determine if it should be Active or Passive, where position zero is for the Active BMC. Eventually this would be replaced by a D-Bus property hosted by some other application.

A Services class was created to obtain that and future system information in a way that can be mocked if necessary for unit testing.

A new role_determination::run() function was created that for now just takes the BMC position value, but in the future will probably need to take many more parameters.  A structure is used for that so that it can be initialized with designated initializers (i.e. .name = value ) to make it obvious which value is which.

Tested:

BMC 0:
```
Role Determined: xyz.openbmc_project.State.BMC.Redundancy.Role.Active
```

BMC 1:
```
Role Determined: xyz.openbmc_project.State.BMC.Redundancy.Role.Passive
```