### PR TITLE
RBMC: Start systemd targets based on role

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -19,3 +19,11 @@ The current rules for role determination are:
 
 If there is an internal failure during role determination, like an exception,
 the BMC will also have to become passive.
+
+## After the role is determined
+
+After the role has been determined, the code will
+
+1. Update the Role property on D-Bus.
+1. Start either the obmc-bmc-active.target or obmc-bmc-passive.target systemd
+   target.

--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "active_role_handler.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+namespace rbmc
+{
+
+constexpr auto bmcActiveTarget = "obmc-bmc-active.target";
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> ActiveRoleHandler::start()
+{
+    try
+    {
+        // NOLINTNEXTLINE
+        co_await services->startUnit(bmcActiveTarget);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        // TODO: error log
+        lg2::error("Failed while starting BMC active target: {ERROR}", "ERROR",
+                   e);
+    }
+
+    co_return;
+}
+
+} // namespace rbmc

--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "role_handler.hpp"
+
+namespace rbmc
+{
+
+/**
+ * @class ActiveRoleHandler
+ *
+ * This class handles operation specific to the active role.
+ */
+class ActiveRoleHandler : public RoleHandler
+{
+  public:
+    ActiveRoleHandler() = delete;
+    ~ActiveRoleHandler() override = default;
+    ActiveRoleHandler(const ActiveRoleHandler&) = delete;
+    ActiveRoleHandler& operator=(const ActiveRoleHandler&) = delete;
+    ActiveRoleHandler(ActiveRoleHandler&&) = delete;
+    ActiveRoleHandler& operator=(ActiveRoleHandler&&) = delete;
+
+    /**
+     * @brief Constructor
+     *
+     * @param[in] ctx - The async context object
+     * @param[in] services - The services object
+     */
+    ActiveRoleHandler(sdbusplus::async::context& ctx,
+                      std::unique_ptr<Services>& services) :
+        RoleHandler(ctx, services)
+    {}
+
+    /**
+     * @brief Starts the handler.
+     */
+    sdbusplus::async::task<> start() override;
+};
+
+} // namespace rbmc

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "role_determination.hpp"
+#include "role_handler.hpp"
 #include "services.hpp"
 
 #include <sdbusplus/async.hpp>
@@ -61,6 +62,13 @@ class Manager
     Role determineRole();
 
     /**
+     * @brief Creates either an ActiveRoleHandler or
+     *        PassiveRoleHandler object depending on
+     *        the role and spawns handler->start().
+     */
+    void spawnRoleHandler();
+
+    /**
      * @brief The async context object
      */
     sdbusplus::async::context& ctx;
@@ -76,6 +84,11 @@ class Manager
      * Wraps system interfaces.
      */
     std::unique_ptr<Services> services;
+
+    /**
+     * @brief The role handler class
+     */
+    std::unique_ptr<RoleHandler> handler;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -2,7 +2,9 @@
 execinstalldir = join_paths(get_option('libexecdir'), 'phosphor-state-manager')
 
 executable('phosphor-rbmc-state-manager',
+           'active_role_handler.cpp',
            'manager.cpp',
+           'passive_role_handler.cpp',
            'rbmc_manager_main.cpp',
            'role_determination.cpp',
            'services_impl.cpp',

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "passive_role_handler.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+namespace rbmc
+{
+
+constexpr auto bmcPassiveTarget = "obmc-bmc-passive.target";
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> PassiveRoleHandler::start()
+{
+    try
+    {
+        // NOLINTNEXTLINE
+        co_await services->startUnit(bmcPassiveTarget);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        // TODO: error log
+        lg2::error("Failed while starting BMC passive target: {ERROR}", "ERROR",
+                   e);
+    }
+
+    co_return;
+}
+
+} // namespace rbmc

--- a/redundant-bmc/src/passive_role_handler.hpp
+++ b/redundant-bmc/src/passive_role_handler.hpp
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "role_handler.hpp"
+
+namespace rbmc
+{
+
+/**
+ * @class PassiveRoleHandler
+ *
+ * This class handles operation specific to the passive role.
+ */
+class PassiveRoleHandler : public RoleHandler
+{
+  public:
+    PassiveRoleHandler() = delete;
+    ~PassiveRoleHandler() override = default;
+    PassiveRoleHandler(const PassiveRoleHandler&) = delete;
+    PassiveRoleHandler& operator=(const PassiveRoleHandler&) = delete;
+    PassiveRoleHandler(PassiveRoleHandler&&) = delete;
+    PassiveRoleHandler& operator=(PassiveRoleHandler&&) = delete;
+
+    /**
+     * @brief Constructor
+     *
+     * @param[in] ctx - The async context object
+     * @param[in] services - The services object
+     */
+    PassiveRoleHandler(sdbusplus::async::context& ctx,
+                       std::unique_ptr<Services>& services) :
+        RoleHandler(ctx, services)
+    {}
+
+    /**
+     * @brief Starts the handler.
+     */
+    sdbusplus::async::task<> start() override;
+};
+
+} // namespace rbmc

--- a/redundant-bmc/src/rbmc_manager_main.cpp
+++ b/redundant-bmc/src/rbmc_manager_main.cpp
@@ -16,7 +16,7 @@ int main()
     sdbusplus::server::manager_t objMgr{ctx, "/xyz/openbmc_project/state"};
 
     std::unique_ptr<rbmc::Services> services =
-        std::make_unique<rbmc::ServicesImpl>();
+        std::make_unique<rbmc::ServicesImpl>(ctx);
 
     rbmc::Manager manager{ctx, std::move(services)};
 

--- a/redundant-bmc/src/role_handler.hpp
+++ b/redundant-bmc/src/role_handler.hpp
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "services.hpp"
+
+#include <sdbusplus/async.hpp>
+
+namespace rbmc
+{
+
+/**
+ * @class RoleHandler
+ *
+ * This is the base class for the active and passive role
+ * handler classes, which will handle all of the role specific
+ * code.
+ */
+class RoleHandler
+{
+  public:
+    RoleHandler() = delete;
+    virtual ~RoleHandler() = default;
+    RoleHandler(const RoleHandler&) = delete;
+    RoleHandler& operator=(const RoleHandler&) = delete;
+    RoleHandler(RoleHandler&&) = delete;
+    RoleHandler& operator=(RoleHandler&&) = delete;
+
+    /**
+     * @brief Constructor
+     *
+     * @param[in] ctx - The async context object
+     * @param[in] services - The services object
+     */
+    RoleHandler(sdbusplus::async::context& ctx,
+                std::unique_ptr<Services>& services) :
+        ctx(ctx), services(services)
+    {}
+
+    /**
+     * @brief Pure virtual function to start the handler
+     *        in an async context.
+     */
+    virtual sdbusplus::async::task<> start() = 0;
+
+  protected:
+    /**
+     * @brief The async context object
+     */
+    sdbusplus::async::context& ctx;
+
+    /**
+     * @brief The services object
+     */
+    std::unique_ptr<Services>& services;
+};
+
+} // namespace rbmc

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -32,6 +32,16 @@ class Services
      * @return - The position
      */
     virtual size_t getBMCPosition() const = 0;
+
+    /**
+     * @brief Starts a systemd unit
+     *
+     * Waits for it to be active or failed before returning.
+     *
+     * @param[in] unitName - The unit name
+     */
+    virtual sdbusplus::async::task<>
+        startUnit(const std::string& unitName) const = 0;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -6,6 +6,22 @@
 namespace rbmc
 {
 
+namespace object_path
+{
+constexpr auto systemd = "/org/freedesktop/systemd1";
+} // namespace object_path
+
+namespace interface
+{
+constexpr auto systemdMgr = "org.freedesktop.systemd1.Manager";
+constexpr auto systemdUnit = "org.freedesktop.systemd1.Unit";
+} // namespace interface
+
+namespace service
+{
+constexpr auto systemd = "org.freedesktop.systemd1";
+} // namespace service
+
 size_t ServicesImpl::getBMCPosition() const
 {
     size_t bmcPosition = 0;
@@ -50,6 +66,87 @@ size_t ServicesImpl::getBMCPosition() const
     }
 
     return bmcPosition;
+}
+
+// NOLINTBEGIN
+sdbusplus::async::task<sdbusplus::message::object_path>
+    ServicesImpl::getUnitPath(const std::string& unitName) const
+// NOLINTEND
+{
+    constexpr auto systemd = sdbusplus::async::proxy()
+                                 .service(service::systemd)
+                                 .path(object_path::systemd)
+                                 .interface(interface::systemdMgr);
+
+    co_return co_await systemd.call<sdbusplus::message::object_path>(
+        ctx, "GetUnit", unitName);
+}
+
+// NOLINTBEGIN
+sdbusplus::async::task<std::string>
+    ServicesImpl::getUnitState(const std::string& unitName) const
+// NOLINTEND
+{
+    try
+    {
+        auto unitPath = co_await getUnitPath(unitName);
+
+        auto systemd = sdbusplus::async::proxy()
+                           .service(service::systemd)
+                           .path(unitPath.str)
+                           .interface(interface::systemdUnit);
+        auto state =
+            co_await systemd.get_property<std::string>(ctx, "ActiveState");
+
+        co_return state;
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        // For some units systemd returns NoSuchUnit if it isn't running.
+        if ((e.name() == nullptr) ||
+            (std::string{e.name()} != "org.freedesktop.systemd1.NoSuchUnit"))
+        {
+            lg2::error(
+                "Unable to determine if {UNIT} is running: {ERROR}. Assuming it isn't.",
+                "UNIT", unitName, "ERROR", e.what());
+        }
+        else
+        {
+            lg2::debug("Got a NoSuchUnit error for {UNIT}", "UNIT", unitName);
+        }
+    }
+
+    co_return "inactive";
+}
+
+// NOLINTBEGIN
+sdbusplus::async::task<>
+    ServicesImpl::startUnit(const std::string& unitName) const
+// NOLINTEND
+{
+    using namespace std::chrono_literals;
+    constexpr auto systemd = sdbusplus::async::proxy()
+                                 .service(service::systemd)
+                                 .path(object_path::systemd)
+                                 .interface(interface::systemdMgr);
+
+    lg2::info("Starting unit {UNIT}", "UNIT", unitName);
+
+    co_await systemd.call<sdbusplus::message::object_path>(
+        ctx, "StartUnit", unitName, std::string{"replace"});
+
+    std::string state;
+
+    while ((state != "active") && (state != "failed"))
+    {
+        co_await sdbusplus::async::sleep_for(ctx, 1s);
+        state = co_await getUnitState(unitName);
+    }
+
+    lg2::info("Finished waiting for {UNIT} to start (result = {STATE})", "UNIT",
+              unitName, "STATE", state);
+
+    co_return;
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -16,7 +16,7 @@ namespace rbmc
 class ServicesImpl : public Services
 {
   public:
-    ServicesImpl() = default;
+    ServicesImpl() = delete;
     ~ServicesImpl() override = default;
     ServicesImpl(const ServicesImpl&) = delete;
     ServicesImpl& operator=(const ServicesImpl&) = delete;
@@ -24,11 +24,55 @@ class ServicesImpl : public Services
     ServicesImpl& operator=(ServicesImpl&&) = delete;
 
     /**
+     * @brief Constructor
+     *
+     * @param[in] ctx - The async context object
+     */
+    explicit ServicesImpl(sdbusplus::async::context& ctx) : ctx(ctx) {}
+
+    /**
      * @brief Returns this BMC's position.
      *
      * @return - The position
      */
     size_t getBMCPosition() const override;
+
+    /**
+     * @brief Starts a systemd unit
+     *
+     * Waits for it to be active or failed before returning.
+     *
+     * @param[in] unitName - The unit name
+     */
+    sdbusplus::async::task<>
+        startUnit(const std::string& unitName) const override;
+
+  private:
+    /**
+     * @brief Returns the D-Bus object path for the unit in the
+     *        systemd namespace.
+     *
+     * @param[in] unitName - The unit name, like obmc-bmc-active.target
+     *
+     * @return object_path - The systemd D-Bus object path
+     */
+    sdbusplus::async::task<sdbusplus::message::object_path>
+        getUnitPath(const std::string& unitName) const;
+
+    /**
+     * @brief Gets the systemd unit state
+     *
+     * @param[in] - The unit/service name
+     *
+     * @return state - The systemd unit state
+     */
+    sdbusplus::async::task<std::string>
+        getUnitState(const std::string& name) const;
+
+    /**
+     * @brief The async context object
+     */
+    sdbusplus::async::context& ctx;
 };
 
 } // namespace rbmc

--- a/target_files/meson.build
+++ b/target_files/meson.build
@@ -1,4 +1,6 @@
 unit_files = [
+    'obmc-bmc-active.target',
+    'obmc-bmc-passive.target',
     'obmc-bmc-service-quiesce@.target',
     'obmc-chassis-blackout@.target',
     'obmc-chassis-hard-poweroff@.target',

--- a/target_files/obmc-bmc-active.target
+++ b/target_files/obmc-bmc-active.target
@@ -1,0 +1,3 @@
+[Unit]
+Description=Active BMC Target
+Conflicts=obmc-bmc-passive.target

--- a/target_files/obmc-bmc-passive.target
+++ b/target_files/obmc-bmc-passive.target
@@ -1,0 +1,3 @@
+[Unit]
+Description=Passive BMC Target
+Conflicts=obmc-bmc-active.target


### PR DESCRIPTION
After the BMC has determined its role, start the new obmc-bmc-active.target or obmc-bmc-passive.target systemd targets.  In the future, systemd services that only run when the BMC has a certain role can use those.

This class also introduces ActiveRoleHandler and PassiveRoleHandler classes that will house all of the role specific code so that the Manager class doesn't have to handle everything.  The first thing they will do is start their respective targets.

The code waits for the target to finish (or fail) starting because in the case of the active target, redundancy will be enabled after waiting for all of the active services linked to the target to have started.

The two targets conflict with each other, so if the active target is started when the passive one is already running, the passive one will stop.

It doesn't use a PropertiesChanged or JobRemoved signal from systemd to wait for the target to be done because those have to be subscribed to first, and OpenBMC has problems with that Subscribe method call taking more than 25 seconds during startup which doesn't seem like a good trade off.

Tested:

```
phosphor-rbmc-state-manager[938]: Starting unit obmc-bmc-active.target
phosphor-rbmc-state-manager[938]: Finished waiting for obmc-bmc-active.target to start (result = active)
```

```
phosphor-rbmc-state-manager[636]: Starting unit obmc-bmc-passive.target
phosphor-rbmc-state-manager[636]: Finished waiting for obmc-bmc-passive.target to start (result = active)
```

```
$ systemctl status obmc-bmc-passive.target
* obmc-bmc-passive.target - Passive BMC Target
     Loaded: loaded (/usr/lib/systemd/system/obmc-bmc-passive.target; static)
     Active: active since Mon 2024-09-30 20:04:43 UTC; 50s ago
```