### PR TITLE
phosphor-set-chassis-transition: ensure only run once

### DIFF
--- a/service_files/phosphor-set-chassis-transition-to-off@.service
+++ b/service_files/phosphor-set-chassis-transition-to-off@.service
@@ -8,6 +8,7 @@ Conflicts=obmc-chassis-poweron@%i.target
 [Service]
 Restart=no
 Type=oneshot
+RemainAfterExit=yes
 SyslogIdentifier=phosphor-set-chassis-transition-to-off
 ExecStart=/bin/sh -c "busctl set-property `mapper get-service /xyz/openbmc_project/state/chassis%i` /xyz/openbmc_project/state/chassis%i xyz.openbmc_project.State.Chassis CurrentPowerState s xyz.openbmc_project.State.Chassis.PowerState.TransitioningToOff"
 

--- a/service_files/phosphor-set-chassis-transition-to-on@.service
+++ b/service_files/phosphor-set-chassis-transition-to-on@.service
@@ -9,6 +9,7 @@ ConditionPathExists=!/run/openbmc/chassis@%i-on
 [Service]
 Restart=no
 Type=oneshot
+RemainAfterExit=yes
 SyslogIdentifier=phosphor-set-chassis-transition-to-on
 ExecStart=/bin/sh -c "busctl set-property `mapper get-service /xyz/openbmc_project/state/chassis%i` /xyz/openbmc_project/state/chassis%i xyz.openbmc_project.State.Chassis CurrentPowerState s xyz.openbmc_project.State.Chassis.PowerState.TransitioningToOn"
 


### PR DESCRIPTION
If a user were to power their system on, and then off, and then off again, they will see their CurrentPowerState set to TransitioningToOff.

Although it's a bit of an unusual use case, it's fairly common in the lab/dev environment when users want to quickly ensure their system is in a powered off or on state (without first looking at its current state).

Similar to what is in the host transition services, ensure we only run the chassis transition services once per power on or off.

Tested:
- Ensured multiple power off requests will not leave CurrentPowerState in TransitioningToOff state

Change-Id: I4040072ed0b42f37c9488994b0f7a5975a2bb7c9