### PR TITLE
RBMC: Start looking at sibling BMC

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -9,13 +9,22 @@ redundancy related properties.
 
 ## Startup
 
-So far on startup the application will just immediately determine its role.
+On startup, the code will wait for up to six minutes for the sibling BMC's
+heartbeat to start, assuming the BMC is present. After that it will determine
+its role.
 
 ## Role Determination Rules
 
 The current rules for role determination are:
 
-1. If BMC position zero choose the active role, otherwise passive.
+1. If the sibling BMC doesn't have a heartbeat, choose active. It could be the
+   sibling isn't even present.
+1. If the sibling BMC's position matches this BMC's position, choose passive.
+   This is an error case.
+1. If the sibling isn't provisioned, choose active.
+1. If the sibling is already passive, choose active.
+1. If the sibling is already active, choose passive.
+1. If this BMC's position is zero choose active, otherwise passive.
 
 If there is an internal failure during role determination, like an exception,
 the BMC will also have to become passive.

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -80,26 +80,42 @@ sdbusplus::async::task<> Manager::doHeartBeat()
 
 Role Manager::determineRole()
 {
-    Role role{Role::Unknown};
+    using namespace role_determination;
+
+    RoleInfo roleInfo{Role::Unknown, ErrorCase::noError};
 
     try
     {
-        role_determination::Input input{
-            .bmcPosition = services->getBMCPosition()};
+        // Note:  If these returned nullopts, the algorithm wouldn't use
+        //        them anyway because there would be no heartbeat.
+        auto siblingRole = sibling->getRole().value_or(Role::Unknown);
+        auto siblingProvisioned = sibling->getProvisioned().value_or(false);
+        auto siblingPosition = sibling->getPosition().value_or(0xFF);
 
-        role = role_determination::run(input);
+        role_determination::Input input{
+            .bmcPosition = services->getBMCPosition(),
+            .siblingPosition = siblingPosition,
+            .siblingRole = siblingRole,
+            .siblingHeartbeat = sibling->hasHeartbeat(),
+            .siblingProvisioned = siblingProvisioned};
+
+        roleInfo = role_determination::run(input);
     }
     catch (const std::exception& e)
     {
         lg2::error("Exception while determining, role.  Will have to be "
                    "passive. Error = {ERROR}",
                    "ERROR", e);
-        role = Role::Passive;
+        roleInfo.role = Role::Passive;
+        roleInfo.error = ErrorCase::internalError;
     }
 
-    lg2::info("Role Determined: {ROLE}", "ROLE", role);
+    if (roleInfo.error != role_determination::ErrorCase::noError)
+    {
+        // TODO: Create an error log
+    }
 
-    return role;
+    return roleInfo.role;
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -4,6 +4,7 @@
 #include "role_determination.hpp"
 #include "role_handler.hpp"
 #include "services.hpp"
+#include "sibling.hpp"
 
 #include <sdbusplus/async.hpp>
 #include <xyz/openbmc_project/State/BMC/Redundancy/server.hpp>
@@ -36,9 +37,11 @@ class Manager
      *
      * @param[in] ctx - The async context object
      * @param[in] services - The services object to interface with system data.
+     * @param[in] sibling - The sibling access object
      */
     Manager(sdbusplus::async::context& ctx,
-            std::unique_ptr<Services>&& services);
+            std::unique_ptr<Services>&& services,
+            std::unique_ptr<Sibling>&& sibling);
 
   private:
     /**
@@ -89,6 +92,11 @@ class Manager
      * @brief The role handler class
      */
     std::unique_ptr<RoleHandler> handler;
+
+    /**
+     * @brief Object to handle sibling BMC access
+     */
+    std::unique_ptr<Sibling> sibling;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -8,6 +8,7 @@ executable('phosphor-rbmc-state-manager',
            'rbmc_manager_main.cpp',
            'role_determination.cpp',
            'services_impl.cpp',
+           'sibling_impl.cpp',
             dependencies: [
                 phosphordbusinterfaces,
                 phosphorlogging,

--- a/redundant-bmc/src/rbmc_manager_main.cpp
+++ b/redundant-bmc/src/rbmc_manager_main.cpp
@@ -2,6 +2,7 @@
 
 #include "manager.hpp"
 #include "services_impl.hpp"
+#include "sibling_impl.hpp"
 
 #include <sdbusplus/async/context.hpp>
 #include <sdbusplus/server/manager.hpp>
@@ -17,8 +18,10 @@ int main()
 
     std::unique_ptr<rbmc::Services> services =
         std::make_unique<rbmc::ServicesImpl>(ctx);
+    std::unique_ptr<rbmc::Sibling> sibling =
+        std::make_unique<rbmc::SiblingImpl>(ctx);
 
-    rbmc::Manager manager{ctx, std::move(services)};
+    rbmc::Manager manager{ctx, std::move(services), std::move(sibling)};
 
     // clang-tidy currently mangles this into something unreadable
     // NOLINTNEXTLINE

--- a/redundant-bmc/src/role_determination.cpp
+++ b/redundant-bmc/src/role_determination.cpp
@@ -7,14 +7,50 @@
 namespace rbmc::role_determination
 {
 
-Role run(const Input& input)
+RoleInfo run(const Input& input)
 {
+    // Must check this before any other sibling fields
+    if (!input.siblingHeartbeat)
+    {
+        lg2::info("Role = active due to no sibling heartbeat");
+        return {Role::Active, ErrorCase::noError};
+    }
+
+    if (input.bmcPosition == input.siblingPosition)
+    {
+        lg2::error(
+            "Role = passive due to both BMC's having the same position {POSITION}",
+            "POSITION", input.bmcPosition);
+        return {Role::Passive, ErrorCase::samePositions};
+    }
+
+    if (!input.siblingProvisioned)
+    {
+        lg2::info("Role = active due to the sibling not being provisioned");
+        return {Role::Active, ErrorCase::noError};
+    }
+
+    if (input.siblingRole == Role::Passive)
+    {
+        lg2::info("Role = active due to the sibling already being passive");
+        return {Role::Active, ErrorCase::noError};
+    }
+
+    if (input.siblingRole == Role::Active)
+    {
+        lg2::info("Role = passive due to the sibling already being active");
+        return {Role::Passive, ErrorCase::noError};
+    }
+
     if (input.bmcPosition == 0)
     {
         lg2::info("Role = active due to BMC position 0");
-        return Role::Active;
+        return {Role::Active, ErrorCase::noError};
     }
-    return Role::Passive;
+
+    lg2::info("Role = passive due to BMC position {POSITION}", "POSITION",
+              input.bmcPosition);
+    return {Role::Passive, ErrorCase::noError};
 }
 
 } // namespace rbmc::role_determination

--- a/redundant-bmc/src/role_determination.hpp
+++ b/redundant-bmc/src/role_determination.hpp
@@ -18,6 +18,32 @@ namespace role_determination
 struct Input
 {
     size_t bmcPosition;
+    size_t siblingPosition;
+    Role siblingRole;
+    bool siblingHeartbeat;
+    bool siblingProvisioned;
+};
+
+/**
+ * @brief Role determination error cases.
+ */
+enum class ErrorCase
+{
+    noError,
+    internalError,
+    samePositions
+};
+
+/**
+ * @brief The role and the error reason returned from run()
+ */
+struct RoleInfo
+{
+    Role role;
+    ErrorCase error;
+
+    // use the default <, ==, > operators for compares
+    auto operator<=>(const RoleInfo&) const = default;
 };
 
 /**
@@ -25,9 +51,9 @@ struct Input
  *
  * @param[in] input  - The structure of inputs
  *
- * @return The role
+ * @return The role and error case
  */
-Role run(const Input& input);
+RoleInfo run(const Input& input);
 
 } // namespace role_determination
 

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -1,0 +1,121 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#pragma once
+#include <sdbusplus/async.hpp>
+#include <xyz/openbmc_project/State/BMC/Redundancy/Sibling/client.hpp>
+#include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
+#include <xyz/openbmc_project/State/BMC/common.hpp>
+
+namespace rbmc
+{
+
+/**
+ * @class Sibling
+ *
+ * Provides information about the Sibling BMC, getting it from
+ * xyz.openbmc_project.State.BMC.Redundancy.Sibling.
+ *
+ * Will only provide data value when that Sibling interface is
+ * present with the heartbeat property true, meaning the code
+ * running on the sibling is alive.
+ *
+ * This is a pure virtual base class, so that these functions can
+ * be mocked in test.
+ */
+class Sibling
+{
+  public:
+    using Role =
+        sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy::Role;
+    using BMCState =
+        sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState;
+
+    Sibling() = default;
+    virtual ~Sibling() = default;
+    Sibling(const Sibling&) = delete;
+    Sibling& operator=(const Sibling&) = delete;
+    Sibling(Sibling&&) = delete;
+    Sibling& operator=(Sibling&&) = delete;
+
+    /**
+     * @brief Returns if the Sibling interface is on D-Bus
+     */
+    virtual bool getInterfacePresent() const = 0;
+
+    /**
+     * @brief Sets up the D-Bus matches
+     *
+     * @return - The task object
+     */
+    virtual sdbusplus::async::task<> init() = 0;
+
+    /**
+     * @brief Returns if the sibling heartbeat is active
+     */
+    virtual bool hasHeartbeat() const = 0;
+
+    /**
+     * @brief Waits up to 'timeout' for the sibling interface to
+     *        be on D-Bus and have the heartbeat property active.
+     *
+     * @return - The task object
+     */
+    virtual sdbusplus::async::task<>
+        waitForSiblingUp(const std::chrono::seconds& timeout) = 0;
+
+    /**
+     * @brief Returns the sibling BMC's position
+     *
+     * @return - The position or nullopt if not available
+     */
+    virtual std::optional<size_t> getPosition() const = 0;
+
+    /**
+     * @brief Returns the sibling BMC's state
+     *
+     * @return - The state or nullopt if not available
+     */
+    virtual std::optional<BMCState> getBMCState() const = 0;
+
+    /**
+     * @brief Returns the sibling BMC's role
+     *
+     * @return - The role, or nullopt if not available
+     */
+    virtual std::optional<Role> getRole() const = 0;
+
+    /**
+     * @brief Returns if the sibling has redundancy enabled.
+     *
+     * @return - If enabled, or nullopt if not available
+     */
+    virtual std::optional<bool> getRedundancyEnabled() const = 0;
+
+    /**
+     * @brief Returns the sibling BMC's provisioning status
+     *
+     * @return - The status, or nullopt if not available
+     */
+    virtual std::optional<bool> getProvisioned() const = 0;
+
+    /**
+     * @brief Returns the sibling BMC's FW version representation
+     *
+     * @return - The version, or nullopt if not available
+     */
+    virtual std::optional<std::string> getFWVersion() const = 0;
+
+    /**
+     * @brief Returns the sibling BMC's commsOK value
+     *
+     * @return - The value, or nullopt if not available
+     */
+    virtual std::optional<bool> getSiblingCommsOK() const = 0;
+
+    /**
+     * @brief Returns if the sibling BMC is plugged in
+     *
+     * @return bool - if present
+     */
+    virtual bool isBMCPresent() = 0;
+};
+} // namespace rbmc

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -1,0 +1,302 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#include "sibling_impl.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+#include <xyz/openbmc_project/ObjectMapper/client.hpp>
+
+namespace rbmc
+{
+
+bool SiblingImpl::isBMCPresent()
+{
+    // TODO: Actually check this.
+    // May also need to check if it has Vcs PGOOD.
+    return true;
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> SiblingImpl::init()
+{
+    if (initialized)
+    {
+        lg2::info("Sibling::init called more than once");
+        co_return;
+    }
+
+    // Start the D-Bus watches for the signals that don't
+    // need a service name.
+    ctx.spawn(watchInterfaceAdded());
+    ctx.spawn(watchInterfaceRemoved());
+    ctx.spawn(watchPropertyChanged());
+
+    // Attempt to get the D-Bus service name.  It would only
+    // be there if the sibling BMC is present.
+    serviceName = co_await getServiceName();
+
+    if (!serviceName.empty())
+    {
+        // Sibling interface is there, so start the NameOwnerChanged
+        // watch and read the initial property values.
+        interfacePresent = true;
+        ctx.spawn(watchNameOwnerChanged());
+
+        try
+        {
+            auto sibling = sdbusplus::async::proxy()
+                               .service(serviceName)
+                               .path(objectPath)
+                               .interface(redundancy_ns::Sibling::interface);
+            auto props = co_await sibling.get_all_properties<
+                redundancy_ns::Sibling::PropertiesVariant>(ctx);
+
+            loadFromPropertyMap(props);
+        }
+        catch (const sdbusplus::exception_t& e)
+        {
+            lg2::error("Failed reading sibling properties: {ERROR}", "ERROR",
+                       e);
+            interfacePresent = false;
+        }
+    }
+    else
+    {
+        // Sibling interface not on D-Bus.
+        interfacePresent = false;
+    }
+
+    lg2::info("In Sibling init, interface present is {PRESENT}", "PRESENT",
+              interfacePresent);
+
+    initialized = true;
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<std::string> SiblingImpl::getServiceName()
+{
+    using ObjectMapper =
+        sdbusplus::client::xyz::openbmc_project::ObjectMapper<>;
+
+    try
+    {
+        auto mapper = ObjectMapper(ctx)
+                          .service(ObjectMapper::default_service)
+                          .path(ObjectMapper::instance_path);
+
+        std::vector<std::string> interface{redundancy_ns::Sibling::interface};
+        auto object = co_await mapper.get_object(objectPath, interface);
+        co_return object.begin()->first;
+    }
+    catch (const sdbusplus::exception_t&)
+    {}
+
+    co_return std::string{};
+}
+
+// namespace util
+
+void SiblingImpl::loadFromPropertyMap(
+    const SiblingImpl::PropertyMap& propertyMap)
+{
+    auto it = propertyMap.find("BMCPosition");
+    if (it != propertyMap.end())
+    {
+        bmcPosition = std::get<size_t>(it->second);
+    }
+
+    it = propertyMap.find("FWVersion");
+    if (it != propertyMap.end())
+    {
+        fwVersion = std::get<std::string>(it->second);
+    }
+
+    it = propertyMap.find("Provisioned");
+    if (it != propertyMap.end())
+    {
+        provisioned = std::get<bool>(it->second);
+    }
+
+    it = propertyMap.find("RedundancyEnabled");
+    if (it != propertyMap.end())
+    {
+        redEnabled = std::get<bool>(it->second);
+    }
+
+    it = propertyMap.find("FailoversPaused");
+    if (it != propertyMap.end())
+    {
+        failoversPaused = std::get<bool>(it->second);
+    }
+
+    it = propertyMap.find("BMCState");
+    if (it != propertyMap.end())
+    {
+        bmcState = std::get<BMCState>(it->second);
+    }
+
+    it = propertyMap.find("Role");
+    if (it != propertyMap.end())
+    {
+        role = std::get<Role>(it->second);
+    }
+
+    it = propertyMap.find("CommunicationOK");
+    if (it != propertyMap.end())
+    {
+        commsOK = std::get<bool>(it->second);
+    }
+
+    it = propertyMap.find("Heartbeat");
+    if (it != propertyMap.end())
+    {
+        heartbeat = std::get<bool>(it->second);
+    }
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> SiblingImpl::watchInterfaceAdded()
+{
+    namespace rules = sdbusplus::bus::match::rules;
+    sdbusplus::async::match match(ctx,
+                                  rules::interfacesAddedAtPath(objectPath));
+
+    while (!ctx.stop_requested())
+    {
+        auto [_, interfaces] =
+            co_await match
+                .next<sdbusplus::message::object_path, InterfaceMap>();
+
+        auto it = interfaces.find(redundancy_ns::Sibling::interface);
+        if (it != interfaces.end())
+        {
+            lg2::info("Sibling D-Bus interface added");
+            loadFromPropertyMap(it->second);
+            interfacePresent = true;
+
+            // If first time seen, wait for the service name to get into
+            // the mapper and then start the nameOwnerChanged watch.
+            if (serviceName.empty())
+            {
+                const size_t mapperRetries = 200;
+                size_t count = 0;
+
+                do
+                {
+                    using namespace std::chrono_literals;
+                    co_await sdbusplus::async::sleep_for(ctx, 100ms);
+                    serviceName = co_await getServiceName();
+                    lg2::info(
+                        "After interfacesAdded, sibling service is {SERVICE}",
+                        "SERVICE", serviceName);
+                } while (serviceName.empty() && (count++ < mapperRetries));
+
+                if (!serviceName.empty())
+                {
+                    ctx.spawn(watchNameOwnerChanged());
+                }
+            }
+        }
+    }
+    co_return;
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> SiblingImpl::watchInterfaceRemoved()
+{
+    namespace rules = sdbusplus::bus::match::rules;
+    sdbusplus::async::match match(ctx,
+                                  rules::interfacesRemovedAtPath(objectPath));
+
+    while (!ctx.stop_requested())
+    {
+        auto [_, interfaces] =
+            co_await match.next<sdbusplus::message::object_path,
+                                std::vector<std::string>>();
+
+        if (std::ranges::contains(interfaces,
+                                  redundancy_ns::Sibling::interface))
+        {
+            lg2::info("Sibling D-Bus interface removed");
+            interfacePresent = false;
+            heartbeat = false;
+        }
+    }
+
+    co_return;
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> SiblingImpl::watchPropertyChanged()
+{
+    namespace rules = sdbusplus::bus::match::rules;
+    sdbusplus::async::match match(
+        ctx, rules::propertiesChanged(objectPath,
+                                      redundancy_ns::Sibling::interface));
+
+    while (!ctx.stop_requested())
+    {
+        auto [iface,
+              propertyMap] = co_await match.next<std::string, PropertyMap>();
+
+        for (const auto& [name, value] : propertyMap)
+        {
+            lg2::info("Sibling property {PROP} changed", "PROP", name);
+        }
+
+        loadFromPropertyMap(propertyMap);
+    }
+
+    co_return;
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> SiblingImpl::watchNameOwnerChanged()
+{
+    namespace rules = sdbusplus::bus::match::rules;
+    sdbusplus::async::match match(ctx, rules::nameOwnerChanged(serviceName));
+
+    while (!ctx.stop_requested())
+    {
+        auto [name, oldOwner, newOwner] =
+            co_await match.next<std::string, std::string, std::string>();
+
+        if (!oldOwner.empty() && newOwner.empty())
+        {
+            lg2::info("Sibling D-Bus name lost");
+            interfacePresent = false;
+            heartbeat = false;
+        }
+    }
+    co_return;
+}
+
+// NOLINTBEGIN
+sdbusplus::async::task<>
+    SiblingImpl::waitForSiblingUp(const std::chrono::seconds& timeout)
+// NOLINTEND
+{
+    using namespace std::chrono_literals;
+    auto start = std::chrono::steady_clock::now();
+    auto waiting = false;
+
+    while ((!interfacePresent || !heartbeat) &&
+           ((std::chrono::steady_clock::now() - start) < timeout))
+    {
+        if (!waiting)
+        {
+            lg2::info("Waiting for sibling interface and/or heartbeat: "
+                      "Present = {PRES}, Heartbeat = {HB}",
+                      "PRES", interfacePresent, "HB", heartbeat);
+            waiting = true;
+        }
+
+        co_await sdbusplus::async::sleep_for(ctx, 500ms);
+    }
+
+    lg2::info(
+        "Done waiting for sibling. Interface present = {PRES}, heartbeat = {HB}",
+        "PRES", interfacePresent, "HB", heartbeat);
+
+    co_return;
+}
+
+} // namespace rbmc

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -1,0 +1,294 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#pragma once
+#include "sibling.hpp"
+
+namespace rbmc
+{
+
+namespace redundancy_ns =
+    sdbusplus::common::xyz::openbmc_project::state::bmc::redundancy;
+
+/**
+ * @class SiblingImpl
+ *
+ * Implements the Sibling functionality.  Provides cached
+ * access to the sibling data members, assuming the interface
+ * is on D-Bus and the heartbeat is active.
+ */
+class SiblingImpl : public Sibling
+{
+  public:
+    using PropertyMap =
+        std::unordered_map<std::string,
+                           redundancy_ns::Sibling::PropertiesVariant>;
+    using InterfaceMap = std::map<std::string, PropertyMap>;
+    using SiblingNP = redundancy_ns::Sibling::namespace_path;
+
+    SiblingImpl() = delete;
+    ~SiblingImpl() override = default;
+    SiblingImpl(const SiblingImpl&) = delete;
+    SiblingImpl& operator=(const SiblingImpl&) = delete;
+    SiblingImpl(SiblingImpl&&) = delete;
+    SiblingImpl& operator=(SiblingImpl&&) = delete;
+
+    /**
+     * @brief Constructor
+     *
+     * @param[in] ctx - The async context object
+     */
+    explicit SiblingImpl(sdbusplus::async::context& ctx) :
+        ctx(ctx),
+        objectPath(std::string{SiblingNP::value} + '/' + SiblingNP::bmc)
+    {}
+
+    /**
+     * @brief Returns if the Sibling interface is on D-Bus
+     */
+    bool getInterfacePresent() const override
+    {
+        return interfacePresent;
+    }
+
+    /**
+     * @brief Returns if the sibling heartbeat is active
+     */
+    bool hasHeartbeat() const override
+    {
+        return heartbeat;
+    }
+
+    /**
+     * @brief Sets up the D-Bus matches
+     *
+     * @return - The task object
+     */
+    sdbusplus::async::task<> init() override;
+
+    /**
+     * @brief Waits up to 'timeout' for the sibling interface to
+     *        be on D-Bus and have the heartbeat property active.
+     *
+     * @return - The task object
+     */
+    sdbusplus::async::task<>
+        waitForSiblingUp(const std::chrono::seconds& timeout) override;
+
+    /**
+     * @brief Returns the sibling BMC's position
+     *
+     * @return - The position or nullopt if not available
+     */
+    std::optional<size_t> getPosition() const override
+    {
+        if (interfacePresent && heartbeat)
+        {
+            return bmcPosition;
+        }
+
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Returns the sibling BMC's state
+     *
+     * @return - The state or nullopt if not available
+     */
+    std::optional<BMCState> getBMCState() const override
+    {
+        if (interfacePresent && heartbeat)
+        {
+            return bmcState;
+        }
+
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Returns the sibling BMC's role
+     *
+     * @return - The role, or nullopt if not available
+     */
+    std::optional<Role> getRole() const override
+    {
+        if (interfacePresent && heartbeat)
+        {
+            return role;
+        }
+
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Returns if the sibling has redundancy enabled.
+     *
+     * @return - If enabled, or nullopt if not available
+     */
+    std::optional<bool> getRedundancyEnabled() const override
+    {
+        if (interfacePresent && heartbeat)
+        {
+            return redEnabled;
+        }
+
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Returns the sibling BMC's provisioning status
+     *
+     * @return - The status, or nullopt if not available
+     */
+    std::optional<bool> getProvisioned() const override
+    {
+        if (interfacePresent && heartbeat)
+        {
+            return provisioned;
+        }
+
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Returns the sibling BMC's FW version representation
+     *
+     * @return - The version, or nullopt if not available
+     */
+    std::optional<std::string> getFWVersion() const override
+    {
+        if (interfacePresent && heartbeat)
+        {
+            return fwVersion;
+        }
+
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Returns the sibling BMC's commsOK value
+     *
+     * @return - The value, or nullopt if not available
+     */
+    std::optional<bool> getSiblingCommsOK() const override
+    {
+        if (interfacePresent && heartbeat)
+        {
+            return commsOK;
+        }
+
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Returns if the sibling BMC is plugged in
+     *
+     * @return bool - if present
+     */
+    bool isBMCPresent() override;
+
+  private:
+    /**
+     * @brief Starts a Sibling InterfacesAdded watch
+     */
+    sdbusplus::async::task<> watchInterfaceAdded();
+
+    /**
+     * @brief Starts a Sibling InterfacesRemoved watch
+     */
+    sdbusplus::async::task<> watchInterfaceRemoved();
+
+    /**
+     * @brief Starts a Sibling NameOwnerChanged watch
+     */
+    sdbusplus::async::task<> watchNameOwnerChanged();
+
+    /**
+     * @brief Starts a Sibling PropertyChanged watch
+     */
+    sdbusplus::async::task<> watchPropertyChanged();
+
+    /**
+     * @brief Sets data members with whatever is in the property map
+     *
+     * @param[in] propertyMap - The property name -> value map
+     */
+    void loadFromPropertyMap(const PropertyMap& propertyMap);
+
+    /**
+     * @brief Gets the sibling D-Bus service name from the mapper
+     *
+     * @return std::string - The service name
+     */
+    sdbusplus::async::task<std::string> getServiceName();
+
+    /**
+     * @brief The async context object
+     */
+    sdbusplus::async::context& ctx;
+
+    /**
+     * @brief The sibling's D-Bus service name.
+     */
+    std::string serviceName;
+
+    /**
+     * @brief If the Sibling interface is on D-Bus
+     */
+    bool interfacePresent = false;
+
+    /**
+     * @brief If init() has been called
+     */
+    bool initialized = false;
+
+    /**
+     * @brief The sibling's BMC position
+     */
+    size_t bmcPosition = 0;
+
+    /**
+     * @brief The sibling's FW version string
+     */
+    std::string fwVersion;
+
+    /**
+     * @brief The sibling's provisioning status
+     */
+    bool provisioned = false;
+
+    /**
+     * @brief The sibling's redundancy enabled field
+     */
+    bool redEnabled = false;
+
+    /**
+     * @brief If sibling failovers are paused
+     */
+    bool failoversPaused = false;
+
+    /**
+     * @brief The sibling's BMC state
+     */
+    BMCState bmcState{};
+
+    /**
+     * @brief The sibling's role
+     */
+    Role role = Role::Unknown;
+
+    /**
+     * @brief If the sibling can talk to this BMC
+     */
+    bool commsOK = false;
+
+    /**
+     * @brief If the sibling heartbeat is active.
+     */
+    bool heartbeat = false;
+
+    /**
+     * @brief The D-Bus object path for the sibling.
+     */
+    std::string objectPath;
+};
+
+} // namespace rbmc

--- a/redundant-bmc/test/role_determination_test.cpp
+++ b/redundant-bmc/test/role_determination_test.cpp
@@ -8,13 +8,90 @@ using namespace role_determination;
 
 TEST(RoleDeterminationTest, RoleDeterminationTest)
 {
+    using enum ErrorCase;
+    using enum Role;
+
+    // BMC pos 0 with sibling healthy
     {
-        Input input{.bmcPosition = 0};
-        EXPECT_EQ(run(input), Role::Active);
+        Input input{.bmcPosition = 0,
+                    .siblingPosition = 1,
+                    .siblingRole = Unknown,
+                    .siblingHeartbeat = true,
+                    .siblingProvisioned = true};
+
+        RoleInfo info{Active, noError};
+        EXPECT_EQ(run(input), info);
     }
 
+    // BMC pos 1 with sibling healthy
     {
-        Input input{.bmcPosition = 1};
-        EXPECT_EQ(run(input), Role::Passive);
+        Input input{.bmcPosition = 1,
+                    .siblingPosition = 0,
+                    .siblingRole = Unknown,
+                    .siblingHeartbeat = true,
+                    .siblingProvisioned = true};
+
+        RoleInfo info{Passive, noError};
+        EXPECT_EQ(run(input), info);
+    }
+
+    // No Sibling heartbeat, BMC pos 1
+    {
+        Input input{.bmcPosition = 1,
+                    .siblingPosition = 0,
+                    .siblingRole = Unknown,
+                    .siblingHeartbeat = false,
+                    .siblingProvisioned = true};
+
+        RoleInfo info{Active, noError};
+        EXPECT_EQ(run(input), info);
+    }
+
+    // Both BMCs report the same position
+    {
+        Input input{.bmcPosition = 0,
+                    .siblingPosition = 0,
+                    .siblingRole = Unknown,
+                    .siblingHeartbeat = true,
+                    .siblingProvisioned = true};
+
+        RoleInfo info{Passive, samePositions};
+        EXPECT_EQ(run(input), info);
+    }
+
+    // Sibling not provisioned
+    {
+        Input input{.bmcPosition = 1,
+                    .siblingPosition = 0,
+                    .siblingRole = Unknown,
+                    .siblingHeartbeat = true,
+                    .siblingProvisioned = false};
+
+        RoleInfo info{Active, noError};
+        EXPECT_EQ(run(input), info);
+    }
+
+    // Sibling already active, this pos = 0
+    {
+        Input input{.bmcPosition = 0,
+                    .siblingPosition = 1,
+                    .siblingRole = Active,
+                    .siblingHeartbeat = true,
+                    .siblingProvisioned = true};
+
+        RoleInfo info{Passive, noError};
+        EXPECT_EQ(run(input), info);
+    }
+
+    // Sibling already passive, this pos = 1
+    {
+        Input input{.bmcPosition = 1,
+                    .siblingPosition = 0,
+                    .siblingRole = Passive,
+                    .siblingHeartbeat = true,
+                    .siblingProvisioned = true};
+
+        RoleInfo info{Active, noError};
+        EXPECT_EQ(run(input), info);
     }
 }


### PR DESCRIPTION
The first commit starts looking at the xyz.openbmc_project.State.BMC.Redundancy.Sibling D-Bus interface.  It creates a class around it that can provide access to the properties.

The second commit starts using the sibling fields in active vs passive role determination.