### PR TITLE
RBMC: Support DisableRedundancyOverride property

### DIFF
--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -40,6 +40,17 @@ class ActiveRoleHandler : public RoleHandler
      */
     sdbusplus::async::task<> start() override;
 
+    /**
+     * @brief Called when the DisableRedundancyOverride D-Bus property
+     *        is updated.
+     *
+     * May disable or enable redundancy at this time if possible.
+     *
+     * @param[in] disable - If redundancy should be disabled
+     *                      or enabled.
+     */
+    void disableRedPropChanged(bool disable) override;
+
   private:
     /**
      * @brief Enables or disables redundancy based on the

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -6,6 +6,7 @@
 #include "persistent_data.hpp"
 
 #include <phosphor-logging/lg2.hpp>
+#include <xyz/openbmc_project/Common/error.hpp>
 
 namespace rbmc
 {
@@ -250,6 +251,19 @@ void Manager::updateRole(const role_determination::RoleInfo& roleInfo)
         lg2::info("Could not serialize RoleReason value of {REASON}: {ERROR}",
                   "REASON", reasonDesc, "ERROR", e);
     }
+}
+
+void Manager::disableRedPropChanged(bool disable)
+{
+    if (!handler)
+    {
+        lg2::error(
+            "DisableRedundancy property cannot be changed to {VALUE} yet",
+            "VALUE", disable);
+        throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
+    }
+
+    handler->disableRedPropChanged(disable);
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -52,7 +52,8 @@ Manager::Manager(sdbusplus::async::context& ctx,
 // NOLINTNEXTLINE
 sdbusplus::async::task<> Manager::startup()
 {
-    co_await sibling->init();
+    co_await sdbusplus::async::execution::when_all(services->init(),
+                                                   sibling->init());
 
     // If we know the role must be passive, set that now,
     // before starting the heartbeat or waiting for the sibling.

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -39,6 +39,16 @@ class Manager
             std::unique_ptr<Services>&& services,
             std::unique_ptr<Sibling>&& sibling);
 
+    /**
+     * @brief Handler for the DisableRedundancyOverride
+     *        property changing.
+     *
+     * Passes the value through to the role handler.
+     *
+     * @param[in] disable - The property value
+     */
+    void disableRedPropChanged(bool disable);
+
   private:
     /**
      * @brief Kicks off the Manager startup

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -4,6 +4,7 @@
 #include "persistent_data.hpp"
 
 #include <phosphor-logging/lg2.hpp>
+#include <xyz/openbmc_project/Common/error.hpp>
 
 namespace rbmc
 {
@@ -65,6 +66,12 @@ void PassiveRoleHandler::siblingRedEnabledHandler(bool enable)
     {
         redundancyInterface.redundancy_enabled(enable);
     }
+}
+
+void PassiveRoleHandler::disableRedPropChanged(bool /*disable*/)
+{
+    lg2::error("Cannot modify DisableRedundancy property on passive BMC");
+    throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/passive_role_handler.hpp
+++ b/redundant-bmc/src/passive_role_handler.hpp
@@ -63,6 +63,17 @@ class PassiveRoleHandler : public RoleHandler
      * interface if the other BMC is Active.
      */
     void siblingRedEnabledHandler(bool enable) override;
+
+    /**
+     * @brief Handler for the DisableRedundancyOverride
+     *        property changing.
+     *
+     * Not supported on the passive BMC so an error will
+     * be thrown.
+     *
+     * @param[in] disable - The new disable value.
+     */
+    void disableRedPropChanged(bool disable) override;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/redundancy_interface.cpp
+++ b/redundant-bmc/src/redundancy_interface.cpp
@@ -40,8 +40,7 @@ bool RedundancyInterface::set_property(
     lg2::info("Request to change DisableRedundancy property to {VALUE}",
               "VALUE", disable);
 
-    // TODO: Actually disable redundancy
-    // manager.disableRedPropChanged(disable);
+    manager.disableRedPropChanged(disable);
 
     try
     {

--- a/redundant-bmc/src/role_handler.hpp
+++ b/redundant-bmc/src/role_handler.hpp
@@ -53,6 +53,14 @@ class RoleHandler
      */
     virtual void siblingRedEnabledHandler(bool /*enable*/) {};
 
+    /**
+     * @brief Handler for the DisableRedundancyOverride
+     *        property changing.
+     *
+     * @param[in] disable - The new disable value.
+     */
+    virtual void disableRedPropChanged(bool disable) = 0;
+
   protected:
     /**
      * @brief The async context object

--- a/redundant-bmc/src/role_handler.hpp
+++ b/redundant-bmc/src/role_handler.hpp
@@ -47,6 +47,12 @@ class RoleHandler
      */
     virtual sdbusplus::async::task<> start() = 0;
 
+    /**
+     * @brief Handler for the RedundancyEnabled property
+     *        on the sibling's D-Bus interface changing.
+     */
+    virtual void siblingRedEnabledHandler(bool /*enable*/) {};
+
   protected:
     /**
      * @brief The async context object

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -27,6 +27,13 @@ class Services
     Services& operator=(Services&&) = delete;
 
     /**
+     * @brief Sets up the D-Bus matches
+     *
+     * @return - The task object
+     */
+    virtual sdbusplus::async::task<> init() = 0;
+
+    /**
      * @brief Returns this BMC's position.
      *
      * @return - The position
@@ -68,6 +75,13 @@ class Services
      * @return - The version hash
      */
     virtual std::string getFWVersion() const = 0;
+
+    /**
+     * @brief Says if main power is on.
+     *
+     * @return If power is on
+     */
+    virtual bool isPoweredOn() const = 0;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -31,6 +31,11 @@ class ServicesImpl : public Services
     explicit ServicesImpl(sdbusplus::async::context& ctx) : ctx(ctx) {}
 
     /**
+     * @brief Sets up watches on the host state
+     */
+    sdbusplus::async::task<> init() override;
+
+    /**
      * @brief Returns this BMC's position.
      *
      * @return - The position
@@ -73,6 +78,13 @@ class ServicesImpl : public Services
      */
     std::string getFWVersion() const override;
 
+    /**
+     * @brief Says if main power is on.
+     *
+     * @return If power is on
+     */
+    bool isPoweredOn() const override;
+
   private:
     /**
      * @brief Returns the D-Bus object path for the unit in the
@@ -86,9 +98,32 @@ class ServicesImpl : public Services
         getUnitPath(const std::string& unitName) const;
 
     /**
+     * @brief Starts the InterfacesAdded watch for the host state
+     */
+    sdbusplus::async::task<> watchHostInterfacesAdded();
+
+    /**
+     * @brief Starts the PropertiesChanged watch for the host state
+     */
+    sdbusplus::async::task<> watchHostPropertiesChanged();
+
+    /**
+     * @brief Reads the CurrentHostState property
+     */
+    sdbusplus::async::task<> readHostState();
+
+    /**
      * @brief The async context object
      */
     sdbusplus::async::context& ctx;
+
+    /**
+     * @brief If the host is powered on
+     *
+     * Only valid after the host state service has been started.
+     * Will throw if called before then.
+     */
+    std::optional<bool> poweredOn;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -28,6 +28,7 @@ class Sibling
         sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy::Role;
     using BMCState =
         sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState;
+    using RedundancyEnabledCallback = std::function<void(bool)>;
 
     Sibling() = default;
     virtual ~Sibling() = default;
@@ -135,5 +136,34 @@ class Sibling
      * @return bool - if present
      */
     virtual bool isBMCPresent() = 0;
+
+    /**
+     * @brief Clears callbacks held by the name
+     *
+     * @param[in] role - The role to clear
+     */
+    void clearCallbacks(Role role)
+    {
+        redEnabledCBs.erase(role);
+    }
+
+    /**
+     * @brief Adds a callback function to invoke when the sibling's
+     *        RedundancyEnabled property changes
+     *
+     * @param[in] role - The role, used as a key into the map
+     * @param[in] callback - The callback function
+     */
+    void addRedundancyEnabledCallback(Role role,
+                                      RedundancyEnabledCallback callback)
+    {
+        redEnabledCBs.emplace(role, std::move(callback));
+    }
+
+  protected:
+    /**
+     * @brief Callbacks for RedundancyEnabled
+     */
+    std::map<Role, RedundancyEnabledCallback> redEnabledCBs;
 };
 } // namespace rbmc

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -4,6 +4,8 @@
 #include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/ObjectMapper/client.hpp>
 
+#include <ranges>
+
 namespace rbmc
 {
 
@@ -118,7 +120,16 @@ void SiblingImpl::loadFromPropertyMap(
     it = propertyMap.find("RedundancyEnabled");
     if (it != propertyMap.end())
     {
+        auto old = redEnabled;
         redEnabled = std::get<bool>(it->second);
+        if (redEnabled != old)
+        {
+            for (const auto& callback :
+                 std::ranges::views::values(redEnabledCBs))
+            {
+                callback(redEnabled);
+            }
+        }
     }
 
     it = propertyMap.find("FailoversPaused");


### PR DESCRIPTION
This PR has 3 commits:
- Mirror the RedundancyEnabled property on the passive BMC
- Add support to read the chassis power state
- Support the DisableRedundancyOverride property so redundancy can be manually disabled