### PR TITLE
phosphor-state-manager: Add -Dbindings=cxx to libgpiod dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -84,7 +84,7 @@ sdbusplus = dependency('sdbusplus')
 sdeventplus = dependency('sdeventplus')
 phosphorlogging = dependency('phosphor-logging')
 phosphordbusinterfaces = dependency('phosphor-dbus-interfaces')
-libgpiod = dependency('libgpiod', version : '>=1.4.1')
+libgpiod = dependency('libgpiod', version : '>=1.4.1', default_options: ['bindings=cxx'])
 
 if cpp.has_header('CLI/CLI.hpp')
     CLI11 = declare_dependency()


### PR DESCRIPTION
This option should be specified by default so that `meson setup build` can work out-of-the-box, or else the `libgpiod` dependency won't provide `libgpiodcxx`.

Several other repositories are doing this already:

```
$ rg -t meson "bindings=cxx"
host-error-monitor/meson.build
30:  default_options: ['bindings=cxx'],

openpower-vpd-parser/meson.build
121:            default_options: ['bindings=cxx'],

intel-ipmi-oem/meson.build
65:      default_options: ['bindings=cxx'],

openpower-vpd-parser/test/meson.build
16:libgpiodcxx = dependency('libgpiodcxx', default_options: ['bindings=cxx'])

dbus-sensors/meson.build
39:gpiodcxx = dependency('libgpiodcxx', default_options: ['bindings=cxx'])

openpower-proc-control/meson.build
143:libgpiodcxx_dep = dependency('libgpiodcxx', default_options: ['bindings=cxx'])

x86-power-control/meson.build
43:  dependency('libgpiodcxx', default_options: ['bindings=cxx']),

phosphor-power/meson.build
71:    default_options: ['bindings=cxx'])

YAAP/meson.build
23:    default_options: ['bindings=cxx'],
```

Tested:

Before:
```
$ rm -rf build subprojects
$ git restore subprojects
$ meson setup build --wipe --reconfigure
....
Dependency gpioplus from subproject subprojects/gpioplus found: YES 0.1
WARNING: Variable 'gpiodcxx_dep' in the subproject 'subprojects/libgpiod-1.6.3' is not found
Dependency libgpiodcxx from subproject subprojects/libgpiod-1.6.3 found: NO

host_condition_gpio/meson.build:5:11: ERROR: Dependency 'libgpiodcxx' is required but not found.
```

After:

```
$ rm -rf build subprojects
$ git restore subprojects
$ meson setup build --wipe --reconfigure
...
Dependency libgpiodcxx from subproject subprojects/libgpiod-1.6.3 found: YES 1.1.2
...
````

Fixes: ba2241c63673 ("Support checking host status via GPIO pins")
Change-Id: I238f785a381b7d0cb4f7002afdd7a2ed3ae2d926