### PR TITLE
RBMC: Trace the time to wait for sibling

### DIFF
--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -283,9 +283,11 @@ sdbusplus::async::task<>
     {
         if (!waiting)
         {
-            lg2::info("Waiting for sibling interface and/or heartbeat: "
-                      "Present = {PRES}, Heartbeat = {HB}",
-                      "PRES", interfacePresent, "HB", heartbeat);
+            lg2::info(
+                "Waiting up to {TIME}s for sibling interface and/or heartbeat: "
+                "Present = {PRES}, Heartbeat = {HB}",
+                "TIME", timeout.count(), "PRES", interfacePresent, "HB",
+                heartbeat);
             waiting = true;
         }
 


### PR DESCRIPTION
Add the maximum amount of time the BMC will for its sibling to show up to the journal.

Tested:
```
Waiting up to 360s for sibling interface and/or heartbeat: Present = True, Heartbeat = False
 ```