### PR TITLE
RBMC: rbmctool: Don't print RoleReason if no role

### DIFF
--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -96,10 +96,13 @@ sdbusplus::async::task<>
                                      services.getFWVersion());
             std::cout << std::format("Provisioned:         {}\n",
                                      services.getProvisioned());
-            std::cout << std::format(
-                "Role Reason:         {}\n",
-                data::read<std::string>(data::key::roleReason)
-                    .value_or("No reason found"));
+            if (role != "Unknown")
+            {
+                std::cout << std::format(
+                    "Role Reason:         {}\n",
+                    data::read<std::string>(data::key::roleReason)
+                        .value_or("No reason found"));
+            }
 
             if ((role == "Active") && !enabled)
             {


### PR DESCRIPTION
If the role hasn't been determined yet, then displaying the role reason isn't helpful.

Tested:

No Role:
```
Local BMC
-----------------------------
Role:                Unknown
BMC Position:        1
Redundancy Enabled:  false
BMC State:           Ready
Failovers Paused:    false
FW version hash:     6B442E99
Provisioned:         true

```

Role:
```
Local BMC
-----------------------------
Role:                Active
BMC Position:        1
Redundancy Enabled:  true
BMC State:           Ready
Failovers Paused:    false
FW version hash:     6B442E99
Provisioned:         true
Role Reason:         Resuming previous role

```