### PR TITLE
RBMC: Create active-bmc-only.conf file

### DIFF
--- a/service_files/active-bmc-only.conf
+++ b/service_files/active-bmc-only.conf
@@ -1,0 +1,7 @@
+[Unit]
+ConditionPathExists=/run/openbmc/active-bmc
+After=phosphor-broadcast-active-bmc-role.service
+PartOf=obmc-bmc-active.target
+
+# Break an ordering dependency
+DefaultDependencies=no

--- a/service_files/meson.build
+++ b/service_files/meson.build
@@ -22,6 +22,7 @@ unit_files = [
     'phosphor-set-host-transition-to-running@.service',
     'phosphor-chassis-check-power-status@.service',
     'phosphor-bmc-security-check.service',
+    'phosphor-broadcast-active-bmc-role.service',
     'phosphor-create-chassis-poweron-log@.service',
     'phosphor-set-chassis-transition-to-on@.service',
     'phosphor-set-chassis-transition-to-off@.service'

--- a/service_files/phosphor-broadcast-active-bmc-role.service
+++ b/service_files/phosphor-broadcast-active-bmc-role.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Start/Stop the active BMC target helper
+After=obmc-bmc-active.target
+PartOf=obmc-bmc-active.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStartPre=mkdir -p /run/openbmc/
+ExecStart=/bin/touch /run/openbmc/active-bmc
+ExecStop=/bin/rm -f /run/openbmc/active-bmc

--- a/target_files/obmc-bmc-active.target
+++ b/target_files/obmc-bmc-active.target
@@ -1,3 +1,4 @@
 [Unit]
 Description=Active BMC Target
 Conflicts=obmc-bmc-passive.target
+BindsTo=phosphor-broadcast-active-bmc-role.service


### PR DESCRIPTION
Create the active-bmc-only.conf per design document: https://gerrit.openbmc.org/c/openbmc/docs/+/70233

To be used by the rbmc bbclass during the building of the image.

Change-Id: I96d8cc945586da79468a0bf2c3836b4385bb2125