### PR TITLE
RBMC: Take actions on passive BMC failures.

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -85,3 +85,10 @@ items to see if redundancy can be enabled:
 1. The sibling's 'sibling communication OK' property is true, meaning it is able
    to talk to the active BMC.
 1. The firmware versions are the same on the BMCs.
+
+## Scenarios
+
+### Passive BMC goes to the Quiesced state
+
+If redundancy was enabled, it would be disabled.  It would take rebooting the
+passive BMC before redundancy could possibly be re-enabled.

--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -90,5 +90,31 @@ items to see if redundancy can be enabled:
 
 ### Passive BMC goes to the Quiesced state
 
-If redundancy was enabled, it would be disabled.  It would take rebooting the
+If redundancy was enabled, it would be disabled. It would take rebooting the
 passive BMC before redundancy could possibly be re-enabled.
+
+### Passive BMC heartbeat changes
+
+The passive BMC's heartbeat could be lost due to events like:
+
+- The passive BMC is rebooted
+- The passive BMC dies
+- A cable is pulled
+- The RBMC management application on the passive BMC dies
+
+When the passive heartbeat stops, redundancy is functionally disabled as there
+is no passive BMC alive to handle the failover method. The active BMC will not
+do anything for five minutes to allow time for the passive BMC to come back
+after a reboot. At five minutes, it is assumed that the BMC won't come back and
+RedundancyEnabled will be set to false and an event log will be created.
+
+The active BMC will always notice when the passive BMC's heartbeat starts,
+either after a recovery or for the first time if added late. It will wait for
+the passive BMC to assume the passive role and then do the same checks as on
+startup to see if redundancy can be enabled. If redundancy can be enabled, a
+full sync will be done to handle any files that changed when the passive BMC
+wasn't running.
+
+Note that redundancy cannot be enabled at runtime if the system wasn't booted
+with redundancy enabled. A concurrent maintenance operation would be necessary
+in that case.

--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -36,7 +36,18 @@ sdbusplus::async::task<> ActiveRoleHandler::start()
 
     // TODO: Create an error if no redundancy
 
+    startSiblingWatches();
+
     co_return;
+}
+
+void ActiveRoleHandler::siblingStateChange(BMCState state)
+{
+    if (state == BMCState::Quiesced)
+    {
+        lg2::error("Sibling BMC went to Quiesce, disabling redundancy");
+        redMgr.determineAndSetRedundancy();
+    }
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -7,6 +7,7 @@ namespace rbmc
 {
 
 constexpr auto bmcActiveTarget = "obmc-bmc-active.target";
+const std::chrono::minutes siblingHBTimeout{5};
 
 // NOLINTNEXTLINE
 sdbusplus::async::task<> ActiveRoleHandler::start()
@@ -48,6 +49,52 @@ void ActiveRoleHandler::siblingStateChange(BMCState state)
         lg2::error("Sibling BMC went to Quiesce, disabling redundancy");
         redMgr.determineAndSetRedundancy();
     }
+}
+
+void ActiveRoleHandler::siblingHBChange(bool hb)
+{
+    if (hb)
+    {
+        siblingHBTimer.stop();
+        ctx.spawn(siblingHBStarted());
+    }
+    else
+    {
+        lg2::info("Sibling BMC heartbeat lost");
+        if (redundancyInterface.redundancy_enabled())
+        {
+            lg2::info(
+                "Disabling redundancy in {TIME} minutes if sibling heartbeat doesn't recover",
+                "TIME", siblingHBTimeout.count());
+            siblingHBTimer.start(siblingHBTimeout);
+        }
+    }
+}
+
+void ActiveRoleHandler::siblingHBCritical()
+{
+    lg2::error("Sibling heartbeat timer expired, disabling redundancy");
+    redMgr.determineAndSetRedundancy();
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> ActiveRoleHandler::siblingHBStarted()
+{
+    lg2::info("Passive BMC heartbeat started");
+
+    stopSiblingWatches();
+
+    co_await sdbusplus::async::execution::when_all(
+        sibling.waitForSiblingRole(), sibling.waitForBMCSteadyState());
+
+    lg2::info("Attempting to enable redundancy now that sibling is back");
+    redMgr.determineAndSetRedundancy();
+
+    // TODO: full sync, etc
+
+    startSiblingWatches();
+
+    co_return;
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -15,7 +15,6 @@ namespace rbmc
 class ActiveRoleHandler : public RoleHandler
 {
   public:
-    ActiveRoleHandler() = delete;
     ActiveRoleHandler(const ActiveRoleHandler&) = delete;
     ActiveRoleHandler& operator=(const ActiveRoleHandler&) = delete;
     ActiveRoleHandler(ActiveRoleHandler&&) = delete;
@@ -34,6 +33,14 @@ class ActiveRoleHandler : public RoleHandler
         RoleHandler(ctx, services, sibling, iface),
         redMgr(ctx, services, sibling, iface)
     {}
+
+    /**
+     * @brief Destructor
+     */
+    ~ActiveRoleHandler() override
+    {
+        sibling.clearCallbacks(Role::Active);
+    }
 
     /**
      * @brief Starts the handler.
@@ -55,6 +62,35 @@ class ActiveRoleHandler : public RoleHandler
     }
 
   private:
+    /**
+     * @brief Starts the Sibling property watches/callbacks
+     */
+    inline void startSiblingWatches()
+    {
+        sibling.addBMCStateCallback(
+            Role::Active,
+            std::bind_front(&ActiveRoleHandler::siblingStateChange, this));
+    }
+
+    /**
+     * @brief Stops the sibling property callbacks/watches
+     */
+    inline void stopSiblingWatches()
+    {
+        sibling.clearBMCStateCallback(Role::Active);
+    }
+
+    using BMCState =
+        sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState;
+
+    /**
+     * @brief Called when the sibling's BMC state changes
+     *        assuming the callback has been enabled.
+     *
+     * @param[in] state - The new state value
+     */
+    void siblingStateChange(BMCState state);
+
     /**
      * @brief Redundancy manager object
      */

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -30,6 +30,7 @@ class Sibling
         sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState;
     using RedundancyEnabledCallback = std::function<void(bool)>;
     using BMCStateCallback = std::function<void(BMCState)>;
+    using HeartbeatCallback = std::function<void(bool)>;
 
     Sibling() = default;
     virtual ~Sibling() = default;
@@ -139,7 +140,7 @@ class Sibling
     virtual bool isBMCPresent() = 0;
 
     /**
-     * @brief Clears callbacks held by the name
+     * @brief Clears callbacks held based on role
      *
      * @param[in] role - The role to clear
      */
@@ -147,6 +148,7 @@ class Sibling
     {
         redEnabledCBs.erase(role);
         clearBMCStateCallback(role);
+        clearHeartbeatCallback(role);
     }
 
     /**
@@ -157,6 +159,16 @@ class Sibling
     void clearBMCStateCallback(Role role)
     {
         bmcStateCBs.erase(role);
+    }
+
+    /**
+     * @brief Clears the heartbeat callback
+     *
+     * @param[in] role - The role to clear
+     */
+    void clearHeartbeatCallback(Role role)
+    {
+        heartbeatCBs.erase(role);
     }
 
     /**
@@ -184,6 +196,18 @@ class Sibling
         bmcStateCBs.emplace(role, std::move(callback));
     }
 
+    /**
+     * @brief Adds a callback function to invoke when the sibling's
+     *        Heartbeat property changes
+     *
+     * @param[in] role - The role to register with
+     * @param[in] callback - The callback function
+     */
+    void addHeartbeatCallback(Role role, HeartbeatCallback callback)
+    {
+        heartbeatCBs.emplace(role, std::move(callback));
+    }
+
   protected:
     /**
      * @brief Callbacks for RedundancyEnabled
@@ -194,5 +218,10 @@ class Sibling
      * @brief Callbacks for BMCState
      */
     std::map<Role, BMCStateCallback> bmcStateCBs;
+
+    /**
+     * @brief Callbacks for Heartbeat
+     */
+    std::map<Role, HeartbeatCallback> heartbeatCBs;
 };
 } // namespace rbmc

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -29,6 +29,7 @@ class Sibling
     using BMCState =
         sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState;
     using RedundancyEnabledCallback = std::function<void(bool)>;
+    using BMCStateCallback = std::function<void(BMCState)>;
 
     Sibling() = default;
     virtual ~Sibling() = default;
@@ -145,13 +146,24 @@ class Sibling
     void clearCallbacks(Role role)
     {
         redEnabledCBs.erase(role);
+        clearBMCStateCallback(role);
+    }
+
+    /**
+     * @brief Clears the BMC state callback
+     *
+     * @param[in] role - The role to clear
+     */
+    void clearBMCStateCallback(Role role)
+    {
+        bmcStateCBs.erase(role);
     }
 
     /**
      * @brief Adds a callback function to invoke when the sibling's
      *        RedundancyEnabled property changes
      *
-     * @param[in] role - The role, used as a key into the map
+     * @param[in] role - The role to register with
      * @param[in] callback - The callback function
      */
     void addRedundancyEnabledCallback(Role role,
@@ -160,10 +172,27 @@ class Sibling
         redEnabledCBs.emplace(role, std::move(callback));
     }
 
+    /**
+     * @brief Adds a callback function to invoke when the sibling's
+     *        Heartbeat property changes
+     *
+     * @param[in] role - The role to register with
+     * @param[in] callback - The callback function
+     */
+    void addBMCStateCallback(Role role, BMCStateCallback callback)
+    {
+        bmcStateCBs.emplace(role, std::move(callback));
+    }
+
   protected:
     /**
      * @brief Callbacks for RedundancyEnabled
      */
     std::map<Role, RedundancyEnabledCallback> redEnabledCBs;
+
+    /**
+     * @brief Callbacks for BMCState
+     */
+    std::map<Role, BMCStateCallback> bmcStateCBs;
 };
 } // namespace rbmc

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -141,7 +141,15 @@ void SiblingImpl::loadFromPropertyMap(
     it = propertyMap.find("BMCState");
     if (it != propertyMap.end())
     {
+        auto old = bmcState;
         bmcState = std::get<BMCState>(it->second);
+        if (bmcState != old)
+        {
+            for (const auto& callback : std::ranges::views::values(bmcStateCBs))
+            {
+                callback(bmcState);
+            }
+        }
     }
 
     it = propertyMap.find("Role");

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -167,7 +167,16 @@ void SiblingImpl::loadFromPropertyMap(
     it = propertyMap.find("Heartbeat");
     if (it != propertyMap.end())
     {
+        auto old = heartbeat;
         heartbeat = std::get<bool>(it->second);
+        if (old != heartbeat)
+        {
+            for (const auto& callback :
+                 std::ranges::views::values(heartbeatCBs))
+            {
+                callback(heartbeat);
+            }
+        }
     }
 }
 

--- a/redundant-bmc/src/timer.hpp
+++ b/redundant-bmc/src/timer.hpp
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <sdbusplus/async.hpp>
+
+namespace rbmc
+{
+
+/**
+ * @class Timer
+ *
+ * A single shot timer that works with sdbusplus::async::context's event loop.
+ */
+class Timer :
+    private sdbusplus::async::context_ref,
+    sdbusplus::async::details::context_friend
+{
+  public:
+    /**
+     * @brief Constructor
+     *
+     * @param[in] ctx - The async context object
+     * @param[in] callback - Function to call on expiration
+     */
+    Timer(sdbusplus::async::context& ctx, std::function<void()>&& callback) :
+        context_ref(ctx), callback(std::move(callback))
+    {}
+
+    /**
+     * @brief Called by sd-event when time expires. Invokes the
+     *        chosen callback function.
+     */
+    static int handler([[maybe_unused]] sd_event_source* s,
+                       [[maybe_unused]] uint64_t usec, void* userdata)
+    {
+        Timer* t = static_cast<Timer*>(userdata);
+        t->callback();
+        t->source.reset();
+        return 0;
+    }
+
+    /**
+     * @brief Starts the timer
+     *
+     * @param[in] timeout - The timeout value
+     */
+    void start(const std::chrono::microseconds& timeout)
+    {
+        source.reset();
+
+        auto s = get_event_loop(ctx).add_oneshot_timer(Timer::handler, this,
+                                                       timeout);
+        source = std::make_unique<Source>(std::move(s));
+    }
+
+    /**
+     * @brief Stops the timer
+     */
+    void stop()
+    {
+        source.reset();
+    }
+
+  private:
+    /**
+     * @brief RAII wrapper for sdbusplus::source
+     */
+    struct Source
+    {
+        Source(sdbusplus::event::source&& s) : source(std::move(s)) {}
+
+      private:
+        sdbusplus::event::source source;
+    };
+
+    /**
+     * @brief Function to run on timeout
+     */
+    std::function<void()> callback;
+
+    /**
+     * @brief Event source object
+     */
+    std::unique_ptr<Source> source;
+};
+
+} // namespace rbmc


### PR DESCRIPTION
The first commit when will disable redundancy when the passive BMC goes to the Quiesce state.  We could still keep syncs running here if we wanted to.

The second commit disables redundancy when contact with the passive is lost for 5 minutes.  Anytime the passive come back, even if less than 5 minutes, there will be an attempt to re-enabled redundancy, which would include a full sync when available.