### PR TITLE
Bring phosphor-rbmc-state-manager into 1120

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -278,13 +278,28 @@ build_tests = get_option('tests')
 # If test coverage of source files within the root directory are wanted,
 # need to define and build the tests from here
 if build_tests.allowed()
-    gtest = dependency(
-        'gtest',
-        main: true,
-        disabler: true,
-        required: build_tests,
-    )
-    gmock = dependency('gmock', disabler: true, required: build_tests)
+    gtest = dependency('gtest', main: true, disabler: true, required: false)
+    gmock = dependency('gmock', disabler: true, required: false)
+
+    if not gtest.found() or not gmock.found()
+        gtest_proj = import('cmake').subproject('googletest', required: false)
+        if gtest_proj.found()
+            gtest = declare_dependency(
+                dependencies: [
+                    dependency('threads'),
+                    gtest_proj.dependency('gtest'),
+                    gtest_proj.dependency('gtest_main'),
+                ],
+            )
+            gmock = gtest_proj.dependency('gmock')
+        else
+            assert(
+                not get_option('tests').enabled(),
+                'Googletest is required if tests are enabled',
+            )
+        endif
+    endif
+
     test(
         'test_systemd_parser',
         executable(

--- a/meson.build
+++ b/meson.build
@@ -365,3 +365,7 @@ if build_tests.allowed()
         ),
     )
 endif
+
+if get_option('rbmc-state-management').allowed()
+    subdir('redundant-bmc')
+endif

--- a/meson.options
+++ b/meson.options
@@ -146,3 +146,10 @@ option(
     value: 'enabled',
     description: 'Only do transition request when no firmware being updated',
 )
+
+option(
+    'rbmc-state-management',
+    type: 'feature',
+    value: 'enabled',
+    description: 'Enable redundant BMC state management',
+)

--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -1,0 +1,21 @@
+# Redundant BMC Management
+
+The phosphor-rbmc-state-manager application manages redundant BMC functionality.
+
+It hosts an xyz.openbmc_project.State.BMC.Redundancy interface on a service of
+the same name, on the /xyz/openbmc_project/state/bmc0 object path. This
+interface provides the Active vs Passive role property as well as some other
+redundancy related properties.
+
+## Startup
+
+So far on startup the application will just immediately determine its role.
+
+## Role Determination Rules
+
+The current rules for role determination are:
+
+1. If BMC position zero choose the active role, otherwise passive.
+
+If there is an internal failure during role determination, like an exception,
+the BMC will also have to become passive.

--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -9,13 +9,22 @@ redundancy related properties.
 
 ## Startup
 
-So far on startup the application will just immediately determine its role.
+On startup, the code will wait for up to six minutes for the sibling BMC's
+heartbeat to start, assuming the BMC is present. After that it will determine
+its role.
 
 ## Role Determination Rules
 
 The current rules for role determination are:
 
-1. If BMC position zero choose the active role, otherwise passive.
+1. If the sibling BMC doesn't have a heartbeat, choose active. It could be the
+   sibling isn't even present.
+1. If the sibling BMC's position matches this BMC's position, choose passive.
+   This is an error case.
+1. If the sibling isn't provisioned, choose active.
+1. If the sibling is already passive, choose active.
+1. If the sibling is already active, choose passive.
+1. If this BMC's position is zero choose active, otherwise passive.
 
 If there is an internal failure during role determination, like an exception,
 the BMC will also have to become passive.

--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -19,3 +19,11 @@ The current rules for role determination are:
 
 If there is an internal failure during role determination, like an exception,
 the BMC will also have to become passive.
+
+## After the role is determined
+
+After the role has been determined, the code will
+
+1. Update the Role property on D-Bus.
+1. Start either the obmc-bmc-active.target or obmc-bmc-passive.target systemd
+   target.

--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -28,8 +28,20 @@ The current rules for role determination are:
    just due to an error.
 1. Finally, if this BMC's position is zero choose active, otherwise passive.
 
-If there is an internal failure during role determination, like an exception,
-the BMC will also have to become passive.
+### Cases that require a BMC must be passive
+
+There are some error cases that require that the BMC is passive regardless of
+what the sibling is doing. These are:
+
+1. The BMC is not provisioned.
+1. The systemd service that maintains the sibling API isn't running. Without
+   this service running, the sibling BMC will think this BMC is dead and will
+   become active.
+1. There is an internal failure during role determination, like an exception.
+
+The passive role in all but the last of these cases can be set before the
+heartbeat is even started, and waiting for the sibling won't even need to be
+done as it doesn't need that info for full role determination.
 
 ## After the role is determined
 

--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -13,6 +13,14 @@ On startup, the code will wait for up to six minutes for the sibling BMC's
 heartbeat to start, assuming the BMC is present. After that it will determine
 its role.
 
+If the BMCs happen to get to determining the role at the same time, the BMC that
+was previously passive will wait for the other BMC to determine its role first
+to lessen the likelihood of a role switch or each them each thinking they should
+be active. One example is when BMC 0 was forced to passive before but isn't
+anymore and so would default to active based on its position, and BMC 1 was
+active last time and would default to just restoring its role. Letting BMC 1 go
+first in this case would ensure BMC 0 remains passive.
+
 ## Role Determination Rules
 
 The current rules for role determination are:

--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -92,3 +92,29 @@ items to see if redundancy can be enabled:
 
 If redundancy was enabled, it would be disabled. It would take rebooting the
 passive BMC before redundancy could possibly be re-enabled.
+
+### Passive BMC heartbeat changes
+
+The passive BMC's heartbeat could be lost due to events like:
+
+- The passive BMC is rebooted
+- The passive BMC dies
+- A cable is pulled
+- The RBMC management application on the passive BMC dies
+
+When the passive heartbeat stops, redundancy is functionally disabled as there
+is no passive BMC alive to handle the failover method. The active BMC will not
+do anything for five minutes to allow time for the passive BMC to come back
+after a reboot. At five minutes, it is assumed that the BMC won't come back and
+RedundancyEnabled will be set to false and an event log will be created.
+
+The active BMC will always notice when the passive BMC's heartbeat starts,
+either after a recovery or for the first time if added late. It will wait for
+the passive BMC to assume the passive role and then do the same checks as on
+startup to see if redundancy can be enabled. If redundancy can be enabled, a
+full sync will be done to handle any files that changed when the passive BMC
+wasn't running.
+
+Note that redundancy cannot be enabled at runtime if the system wasn't booted
+with redundancy enabled. A concurrent maintenance operation would be necessary
+in that case.

--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -36,6 +36,9 @@ The current rules for role determination are:
    just due to an error.
 1. Finally, if this BMC's position is zero choose active, otherwise passive.
 
+The actual reason the code used to determine the role is saved in the
+`RoleReason` field in `/var/lib/phosphor-state-manager/redundant-bmc/data.json`.
+
 ### Cases that require a BMC must be passive
 
 There are some error cases that require that the BMC is passive regardless of

--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -61,3 +61,27 @@ After the role has been determined, the code will
 1. Update the Role property on D-Bus.
 1. Start either the obmc-bmc-active.target or obmc-bmc-passive.target systemd
    target.
+1. The active BMC will attempt to enable redundancy.
+
+## Enabling Redundancy
+
+One of the requirements for enabling redundancy is that the passive BMC must be
+in the `Ready` state. As the roles can be determined before that state is
+reached, the active BMC may need to wait for the passive BMC to get there. It
+will wait up to ten minutes total for the passive BMC to get to a steady state
+(assuming the passive BMC is alive), which would either be `Ready` or
+`Quiesced`.
+
+After the passive BMC reaches steady state, it will then check the following
+items to see if redundancy can be enabled:
+
+1. The BMC does have the active role.
+1. The sibling BMC is present and is alive (has a heartbeat).
+1. The sibling is at the Ready state.
+1. The sibling BMC has the Passive role.
+1. Redundancy hasn't been manually disabled with the D-bus property that does
+   so.
+1. The sibling BMC has been provisioned.
+1. The sibling's 'sibling communication OK' property is true, meaning it is able
+   to talk to the active BMC.
+1. The firmware versions are the same on the BMCs.

--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -85,3 +85,10 @@ items to see if redundancy can be enabled:
 1. The sibling's 'sibling communication OK' property is true, meaning it is able
    to talk to the active BMC.
 1. The firmware versions are the same on the BMCs.
+
+## Scenarios
+
+### Passive BMC goes to the Quiesced state
+
+If redundancy was enabled, it would be disabled. It would take rebooting the
+passive BMC before redundancy could possibly be re-enabled.

--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -24,7 +24,9 @@ The current rules for role determination are:
 1. If the sibling isn't provisioned, choose active.
 1. If the sibling is already passive, choose active.
 1. If the sibling is already active, choose passive.
-1. If this BMC's position is zero choose active, otherwise passive.
+1. If the previous role isn't unknown, choose that assuming it wasn't passive
+   just due to an error.
+1. Finally, if this BMC's position is zero choose active, otherwise passive.
 
 If there is an internal failure during role determination, like an exception,
 the BMC will also have to become passive.

--- a/redundant-bmc/meson.build
+++ b/redundant-bmc/meson.build
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+subdir('src')

--- a/redundant-bmc/meson.build
+++ b/redundant-bmc/meson.build
@@ -1,2 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 subdir('src')
+
+if get_option('tests').allowed()
+    subdir('test')
+endif

--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "active_role_handler.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+namespace rbmc
+{
+
+constexpr auto bmcActiveTarget = "obmc-bmc-active.target";
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> ActiveRoleHandler::start()
+{
+    try
+    {
+        // NOLINTNEXTLINE
+        co_await services->startUnit(bmcActiveTarget);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        // TODO: error log
+        lg2::error("Failed while starting BMC active target: {ERROR}", "ERROR",
+                   e);
+    }
+
+    co_return;
+}
+
+} // namespace rbmc

--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -36,7 +36,18 @@ sdbusplus::async::task<> ActiveRoleHandler::start()
 
     // TODO: Create an error if no redundancy
 
+    startSiblingWatches();
+
     co_return;
+}
+
+void ActiveRoleHandler::siblingStateChange(BMCState state)
+{
+    if (state == BMCState::Quiesced)
+    {
+        lg2::error("Sibling BMC went to Quiesce, disabling redundancy");
+        redMgr.determineAndSetRedundancy();
+    }
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "active_role_handler.hpp"
 
+#include "redundancy.hpp"
+
+#include <persistent_data.hpp>
 #include <phosphor-logging/lg2.hpp>
 
 namespace rbmc
@@ -13,8 +16,17 @@ sdbusplus::async::task<> ActiveRoleHandler::start()
 {
     try
     {
+        data::remove(data::key::noRedDetails);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed removing NoRedundancyDetails: {ERROR}", "ERROR", e);
+    }
+
+    try
+    {
         // NOLINTNEXTLINE
-        co_await services->startUnit(bmcActiveTarget);
+        co_await services.startUnit(bmcActiveTarget);
     }
     catch (const sdbusplus::exception_t& e)
     {
@@ -23,7 +35,83 @@ sdbusplus::async::task<> ActiveRoleHandler::start()
                    e);
     }
 
+    if (sibling.hasHeartbeat())
+    {
+        // Make sure the sibling had time to get its role assigned, and
+        // also wait for it to hit steady state as redundancy can only
+        // be enabled if the sibling BMC is at the Ready state.
+        co_await sdbusplus::async::execution::when_all(
+            sibling.waitForSiblingRole(), sibling.waitForBMCSteadyState());
+    }
+
+    determineAndSetRedundancy();
+
+    // TODO: error log if redundancy is disabled
+
     co_return;
+}
+
+// NOLINTNEXTLINE
+void ActiveRoleHandler::determineAndSetRedundancy()
+{
+    enableOrDisableRedundancy(getNoRedundancyReasons());
+    redundancyDetermined = true;
+}
+
+redundancy::NoRedundancyReasons ActiveRoleHandler::getNoRedundancyReasons()
+{
+    redundancy::Input input{
+        .role = redundancyInterface.role(),
+        .siblingPresent = sibling.isBMCPresent(),
+        .siblingHeartbeat = sibling.hasHeartbeat(),
+        .siblingProvisioned = sibling.getProvisioned().value_or(false),
+        .siblingHasSiblingComm = sibling.getSiblingCommsOK().value_or(false),
+        .siblingRole = sibling.getRole().value_or(Role::Unknown),
+        .siblingState = sibling.getBMCState().value_or(BMCState::NotReady),
+        .codeVersionsMatch =
+            services.getFWVersion() == sibling.getFWVersion().value_or(""),
+        .manualDisable = manualDisable};
+
+    auto reasons = redundancy::getNoRedundancyReasons(input);
+
+    std::map<redundancy::NoRedundancyReason, std::string> details;
+
+    std::ranges::transform(
+        reasons, std::inserter(details, details.begin()),
+        [](const auto& reason) {
+            auto desc = redundancy::getNoRedundancyDescription(reason);
+            lg2::info("No redundancy because: {DESC}", "DESC", desc);
+            return std::pair{reason, desc};
+        });
+
+    try
+    {
+        data::write(data::key::noRedDetails, details);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed serializing NoRedundancyReasons: {ERROR}", "ERROR",
+                   e);
+    }
+
+    return reasons;
+}
+
+void ActiveRoleHandler::enableOrDisableRedundancy(
+    const redundancy::NoRedundancyReasons& disableReasons)
+{
+    auto enable = disableReasons.empty();
+
+    if (enable)
+    {
+        lg2::info("Enabling redundancy");
+    }
+    else
+    {
+        lg2::info("Redundancy must be disabled");
+    }
+
+    redundancyInterface.redundancy_enabled(enable);
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -7,6 +7,7 @@ namespace rbmc
 {
 
 constexpr auto bmcActiveTarget = "obmc-bmc-active.target";
+const std::chrono::minutes siblingHBTimeout{5};
 
 // NOLINTNEXTLINE
 sdbusplus::async::task<> ActiveRoleHandler::start()
@@ -48,6 +49,52 @@ void ActiveRoleHandler::siblingStateChange(BMCState state)
         lg2::error("Sibling BMC went to Quiesce, disabling redundancy");
         redMgr.determineAndSetRedundancy();
     }
+}
+
+void ActiveRoleHandler::siblingHBChange(bool hb)
+{
+    if (hb)
+    {
+        siblingHBTimer.stop();
+        ctx.spawn(siblingHBStarted());
+    }
+    else
+    {
+        lg2::info("Sibling BMC heartbeat lost");
+        if (redundancyInterface.redundancy_enabled())
+        {
+            lg2::info(
+                "Disabling redundancy in {TIME} minutes if sibling heartbeat doesn't recover",
+                "TIME", siblingHBTimeout.count());
+            siblingHBTimer.start(siblingHBTimeout);
+        }
+    }
+}
+
+void ActiveRoleHandler::siblingHBCritical()
+{
+    lg2::error("Sibling heartbeat timer expired, disabling redundancy");
+    redMgr.determineAndSetRedundancy();
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> ActiveRoleHandler::siblingHBStarted()
+{
+    lg2::info("Passive BMC heartbeat started");
+
+    stopSiblingWatches();
+
+    co_await sdbusplus::async::execution::when_all(
+        sibling.waitForSiblingRole(), sibling.waitForBMCSteadyState());
+
+    lg2::info("Attempting to enable redundancy now that sibling is back");
+    redMgr.determineAndSetRedundancy();
+
+    // TODO: full sync, etc
+
+    startSiblingWatches();
+
+    co_return;
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -1,11 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "active_role_handler.hpp"
 
-#include "redundancy.hpp"
-
-#include <persistent_data.hpp>
 #include <phosphor-logging/lg2.hpp>
-#include <xyz/openbmc_project/Common/error.hpp>
 
 namespace rbmc
 {
@@ -15,15 +11,6 @@ constexpr auto bmcActiveTarget = "obmc-bmc-active.target";
 // NOLINTNEXTLINE
 sdbusplus::async::task<> ActiveRoleHandler::start()
 {
-    try
-    {
-        data::remove(data::key::noRedDetails);
-    }
-    catch (const std::exception& e)
-    {
-        lg2::error("Failed removing NoRedundancyDetails: {ERROR}", "ERROR", e);
-    }
-
     try
     {
         // NOLINTNEXTLINE
@@ -45,114 +32,11 @@ sdbusplus::async::task<> ActiveRoleHandler::start()
             sibling.waitForSiblingRole(), sibling.waitForBMCSteadyState());
     }
 
-    determineAndSetRedundancy();
+    redMgr.determineAndSetRedundancy();
 
-    // TODO: error log if redundancy is disabled
+    // TODO: Create an error if no redundancy
 
     co_return;
-}
-
-// NOLINTNEXTLINE
-void ActiveRoleHandler::determineAndSetRedundancy()
-{
-    enableOrDisableRedundancy(getNoRedundancyReasons());
-    redundancyDetermined = true;
-}
-
-redundancy::NoRedundancyReasons ActiveRoleHandler::getNoRedundancyReasons()
-{
-    redundancy::Input input{
-        .role = redundancyInterface.role(),
-        .siblingPresent = sibling.isBMCPresent(),
-        .siblingHeartbeat = sibling.hasHeartbeat(),
-        .siblingProvisioned = sibling.getProvisioned().value_or(false),
-        .siblingHasSiblingComm = sibling.getSiblingCommsOK().value_or(false),
-        .siblingRole = sibling.getRole().value_or(Role::Unknown),
-        .siblingState = sibling.getBMCState().value_or(BMCState::NotReady),
-        .codeVersionsMatch =
-            services.getFWVersion() == sibling.getFWVersion().value_or(""),
-        .manualDisable = manualDisable};
-
-    auto reasons = redundancy::getNoRedundancyReasons(input);
-
-    std::map<redundancy::NoRedundancyReason, std::string> details;
-
-    std::ranges::transform(
-        reasons, std::inserter(details, details.begin()),
-        [](const auto& reason) {
-            auto desc = redundancy::getNoRedundancyDescription(reason);
-            lg2::info("No redundancy because: {DESC}", "DESC", desc);
-            return std::pair{reason, desc};
-        });
-
-    try
-    {
-        data::write(data::key::noRedDetails, details);
-    }
-    catch (const std::exception& e)
-    {
-        lg2::error("Failed serializing NoRedundancyReasons: {ERROR}", "ERROR",
-                   e);
-    }
-
-    return reasons;
-}
-
-void ActiveRoleHandler::enableOrDisableRedundancy(
-    const redundancy::NoRedundancyReasons& disableReasons)
-{
-    auto enable = disableReasons.empty();
-
-    if (enable)
-    {
-        lg2::info("Enabling redundancy");
-    }
-    else
-    {
-        lg2::info("Redundancy must be disabled");
-    }
-
-    redundancyInterface.redundancy_enabled(enable);
-}
-
-void ActiveRoleHandler::disableRedPropChanged(bool disable)
-{
-    try
-    {
-        if (services.isPoweredOn())
-        {
-            lg2::error("Cannot modify DisableRedundancy prop when powered on");
-            throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
-        }
-    }
-    catch (const std::exception& e)
-    {
-        lg2::error("Call to isPoweredOn failed: {ERROR}", "ERROR", e);
-        throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
-    }
-
-    manualDisable = disable;
-
-    if (!redundancyDetermined)
-    {
-        // Must be before we've handled redundancy, it should happen soon
-        lg2::info(
-            "Redundancy has not been determined yet, will not change redundancy now.");
-        return;
-    }
-
-    if (disable == !redundancyInterface.redundancy_enabled())
-    {
-        // No changes necessary now
-        lg2::info("No change to redundancy necessary");
-        return;
-    }
-
-    lg2::info(
-        "Revisiting redundancy after manual override of disable to {DISABLE}",
-        "DISABLE", disable);
-
-    determineAndSetRedundancy();
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "role_handler.hpp"
+
+namespace rbmc
+{
+
+/**
+ * @class ActiveRoleHandler
+ *
+ * This class handles operation specific to the active role.
+ */
+class ActiveRoleHandler : public RoleHandler
+{
+  public:
+    ActiveRoleHandler() = delete;
+    ~ActiveRoleHandler() override = default;
+    ActiveRoleHandler(const ActiveRoleHandler&) = delete;
+    ActiveRoleHandler& operator=(const ActiveRoleHandler&) = delete;
+    ActiveRoleHandler(ActiveRoleHandler&&) = delete;
+    ActiveRoleHandler& operator=(ActiveRoleHandler&&) = delete;
+
+    /**
+     * @brief Constructor
+     *
+     * @param[in] ctx - The async context object
+     * @param[in] services - The services object
+     */
+    ActiveRoleHandler(sdbusplus::async::context& ctx,
+                      std::unique_ptr<Services>& services) :
+        RoleHandler(ctx, services)
+    {}
+
+    /**
+     * @brief Starts the handler.
+     */
+    sdbusplus::async::task<> start() override;
+};
+
+} // namespace rbmc

--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -40,6 +40,17 @@ class ActiveRoleHandler : public RoleHandler
      */
     sdbusplus::async::task<> start() override;
 
+    /**
+     * @brief Called when the DisableRedundancyOverride D-Bus property
+     *        is updated.
+     *
+     * May disable or enable redundancy at this time if possible.
+     *
+     * @param[in] disable - If redundancy should be disabled
+     *                      or enabled.
+     */
+    void disableRedPropChanged(bool disable) override;
+
   private:
     /**
      * @brief Enables or disables redundancy based on the

--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
-#include "redundancy.hpp"
+#include "redundancy_mgr.hpp"
 #include "role_handler.hpp"
 
 namespace rbmc
@@ -32,7 +32,7 @@ class ActiveRoleHandler : public RoleHandler
     ActiveRoleHandler(sdbusplus::async::context& ctx, Services& services,
                       Sibling& sibling, RedundancyInterface& iface) :
         RoleHandler(ctx, services, sibling, iface),
-        manualDisable(iface.disable_redundancy_override())
+        redMgr(ctx, services, sibling, iface)
     {}
 
     /**
@@ -49,43 +49,16 @@ class ActiveRoleHandler : public RoleHandler
      * @param[in] disable - If redundancy should be disabled
      *                      or enabled.
      */
-    void disableRedPropChanged(bool disable) override;
+    void disableRedPropChanged(bool disable) override
+    {
+        redMgr.disableRedPropChanged(disable);
+    }
 
   private:
     /**
-     * @brief Enables or disables redundancy based on the
-     *        system config.
+     * @brief Redundancy manager object
      */
-    void determineAndSetRedundancy();
-
-    /**
-     * @brief Returns the reasons that redundancy cannnot be
-     *        enabled, if any.
-     *
-     * @return The reasons.  If empty, then redundancy can be enabled.
-     */
-    redundancy::NoRedundancyReasons getNoRedundancyReasons();
-
-    /**
-     * @brief Based on if disableReasons is empty or not, disables
-     *        or enables redundancy.
-     *
-     * @param[in] disableReasons - The reasons redundancy must be
-     *            disabled, if any.
-     */
-    void enableOrDisableRedundancy(
-        const redundancy::NoRedundancyReasons& disableReasons);
-
-    /**
-     * @brief If determineAndSetRedundancy() has ran yet or not.
-     */
-    bool redundancyDetermined = false;
-
-    /**
-     * @brief If redundancy has been manually disabled via the
-     *        D-Bus property.
-     */
-    bool manualDisable = false;
+    RedundancyMgr redMgr;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "redundancy.hpp"
 #include "role_handler.hpp"
 
 namespace rbmc
@@ -15,7 +16,6 @@ class ActiveRoleHandler : public RoleHandler
 {
   public:
     ActiveRoleHandler() = delete;
-    ~ActiveRoleHandler() override = default;
     ActiveRoleHandler(const ActiveRoleHandler&) = delete;
     ActiveRoleHandler& operator=(const ActiveRoleHandler&) = delete;
     ActiveRoleHandler(ActiveRoleHandler&&) = delete;
@@ -26,16 +26,55 @@ class ActiveRoleHandler : public RoleHandler
      *
      * @param[in] ctx - The async context object
      * @param[in] services - The services object
+     * @param[in] sibling - The sibling object
+     * @param[in] iface - The redundancy D-Bus interface object
      */
-    ActiveRoleHandler(sdbusplus::async::context& ctx,
-                      std::unique_ptr<Services>& services) :
-        RoleHandler(ctx, services)
+    ActiveRoleHandler(sdbusplus::async::context& ctx, Services& services,
+                      Sibling& sibling, RedundancyInterface& iface) :
+        RoleHandler(ctx, services, sibling, iface),
+        manualDisable(iface.disable_redundancy_override())
     {}
 
     /**
      * @brief Starts the handler.
      */
     sdbusplus::async::task<> start() override;
+
+  private:
+    /**
+     * @brief Enables or disables redundancy based on the
+     *        system config.
+     */
+    void determineAndSetRedundancy();
+
+    /**
+     * @brief Returns the reasons that redundancy cannnot be
+     *        enabled, if any.
+     *
+     * @return The reasons.  If empty, then redundancy can be enabled.
+     */
+    redundancy::NoRedundancyReasons getNoRedundancyReasons();
+
+    /**
+     * @brief Based on if disableReasons is empty or not, disables
+     *        or enables redundancy.
+     *
+     * @param[in] disableReasons - The reasons redundancy must be
+     *            disabled, if any.
+     */
+    void enableOrDisableRedundancy(
+        const redundancy::NoRedundancyReasons& disableReasons);
+
+    /**
+     * @brief If determineAndSetRedundancy() has ran yet or not.
+     */
+    bool redundancyDetermined = false;
+
+    /**
+     * @brief If redundancy has been manually disabled via the
+     *        D-Bus property.
+     */
+    bool manualDisable = false;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -15,7 +15,6 @@ namespace rbmc
 class ActiveRoleHandler : public RoleHandler
 {
   public:
-    ActiveRoleHandler() = delete;
     ActiveRoleHandler(const ActiveRoleHandler&) = delete;
     ActiveRoleHandler& operator=(const ActiveRoleHandler&) = delete;
     ActiveRoleHandler(ActiveRoleHandler&&) = delete;
@@ -34,6 +33,14 @@ class ActiveRoleHandler : public RoleHandler
         RoleHandler(ctx, services, sibling, iface),
         redMgr(ctx, services, sibling, iface)
     {}
+
+    /**
+     * @brief Destructor
+     */
+    ~ActiveRoleHandler() override
+    {
+        sibling.clearCallbacks(Role::Active);
+    }
 
     /**
      * @brief Starts the handler.
@@ -55,6 +62,35 @@ class ActiveRoleHandler : public RoleHandler
     }
 
   private:
+    /**
+     * @brief Starts the Sibling property watches/callbacks
+     */
+    inline void startSiblingWatches()
+    {
+        sibling.addBMCStateCallback(
+            Role::Active,
+            std::bind_front(&ActiveRoleHandler::siblingStateChange, this));
+    }
+
+    /**
+     * @brief Stops the sibling property callbacks/watches
+     */
+    inline void stopSiblingWatches()
+    {
+        sibling.clearBMCStateCallback(Role::Active);
+    }
+
+    using BMCState =
+        sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState;
+
+    /**
+     * @brief Called when the sibling's BMC state changes
+     *        assuming the callback has been enabled.
+     *
+     * @param[in] state - The new state value
+     */
+    void siblingStateChange(BMCState state);
+
     /**
      * @brief Redundancy manager object
      */

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -1,0 +1,45 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#include "manager.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+namespace rbmc
+{
+
+Manager::Manager(sdbusplus::async::context& ctx) :
+    ctx(ctx),
+    redundancyInterface(ctx.get_bus(), RedundancyInterface::instance_path)
+{
+    ctx.spawn(startup());
+}
+
+// clang-tidy currently mangles this into something unreadable
+// NOLINTNEXTLINE
+sdbusplus::async::task<> Manager::startup()
+{
+    // TODO: Actually figure out the role
+    lg2::info("Setting role to passive");
+    redundancyInterface.role(RedundancyInterface::Role::Passive);
+
+    ctx.spawn(doHeartBeat());
+
+    co_return;
+}
+
+// clang-tidy currently mangles this into something unreadable
+// NOLINTNEXTLINE
+sdbusplus::async::task<> Manager::doHeartBeat()
+{
+    using namespace std::chrono_literals;
+    lg2::info("Starting heartbeat");
+
+    while (!ctx.stop_requested())
+    {
+        redundancyInterface.heartbeat();
+        co_await sdbusplus::async::sleep_for(ctx, 1s);
+    }
+
+    co_return;
+}
+
+} // namespace rbmc

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -6,6 +6,7 @@
 #include "persistent_data.hpp"
 
 #include <phosphor-logging/lg2.hpp>
+#include <xyz/openbmc_project/Common/error.hpp>
 
 namespace rbmc
 {
@@ -250,6 +251,19 @@ void Manager::updateRole(const role_determination::RoleInfo& roleInfo)
         lg2::info("Could not serialize RoleReason value of {REASON}: {ERROR}",
                   "REASON", reasonDesc, "ERROR", e);
     }
+}
+
+void Manager::disableRedPropChanged(bool disable)
+{
+    if (!handler)
+    {
+        lg2::error(
+            "DisableRedundancy property cannot be changed to {VALUE} yet",
+            "VALUE", disable);
+        throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
+    }
+
+    handler->disableRedPropChanged(disable);
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -63,7 +63,7 @@ sdbusplus::async::task<> Manager::startup()
         updateRole(*passiveRoleInfo);
     }
 
-    ctx.spawn(doHeartBeat());
+    startHeartbeat();
 
     if (!passiveRoleInfo)
     {
@@ -101,12 +101,20 @@ void Manager::spawnRoleHandler()
     ctx.spawn(handler->start());
 }
 
+void Manager::startHeartbeat()
+{
+    lg2::info("Starting heartbeat");
+
+    // Emit one now and let the spawn handle the rest.
+    redundancyInterface.heartbeat();
+    ctx.spawn(doHeartBeat());
+}
+
 // clang-tidy currently mangles this into something unreadable
 // NOLINTNEXTLINE
 sdbusplus::async::task<> Manager::doHeartBeat()
 {
     using namespace std::chrono_literals;
-    lg2::info("Starting heartbeat");
 
     while (!ctx.stop_requested())
     {

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -88,11 +88,13 @@ void Manager::spawnRoleHandler()
 {
     if (redundancyInterface.role() == Role::Active)
     {
-        handler = std::make_unique<ActiveRoleHandler>(ctx, services);
+        handler = std::make_unique<ActiveRoleHandler>(ctx, *services, *sibling,
+                                                      redundancyInterface);
     }
     else if (redundancyInterface.role() == Role::Passive)
     {
-        handler = std::make_unique<PassiveRoleHandler>(ctx, services);
+        handler = std::make_unique<PassiveRoleHandler>(ctx, *services, *sibling,
+                                                       redundancyInterface);
     }
     else
     {

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -15,9 +15,8 @@ const std::chrono::minutes siblingTimeout{6};
 Manager::Manager(sdbusplus::async::context& ctx,
                  std::unique_ptr<Services>&& services,
                  std::unique_ptr<Sibling>&& sibling) :
-    ctx(ctx),
-    redundancyInterface(ctx.get_bus(), RedundancyInterface::instance_path),
-    services(std::move(services)), sibling(std::move(sibling))
+    ctx(ctx), redundancyInterface(ctx, *this), services(std::move(services)),
+    sibling(std::move(sibling))
 {
     try
     {

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -70,6 +70,11 @@ sdbusplus::async::task<> Manager::startup()
         if (sibling->isBMCPresent())
         {
             co_await sibling->waitForSiblingUp(siblingTimeout);
+
+            if (previousRole == Role::Passive)
+            {
+                co_await sibling->waitForSiblingRole();
+            }
         }
 
         updateRole(determineRole());

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -160,7 +160,7 @@ role_determination::RoleInfo Manager::determineRole()
             input.previousRole = Role::Unknown;
         }
 
-        roleInfo = role_determination::run(input);
+        roleInfo = role_determination::determineRole(input);
     }
     catch (const std::exception& e)
     {

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -80,26 +80,42 @@ sdbusplus::async::task<> Manager::doHeartBeat()
 
 Role Manager::determineRole()
 {
-    Role role{Role::Unknown};
+    using namespace role_determination;
+
+    RoleInfo roleInfo{Role::Unknown, ErrorCase::noError};
 
     try
     {
-        role_determination::Input input{
-            .bmcPosition = services->getBMCPosition()};
+        // Note:  If these returned nullopts, the algorithm wouldn't use
+        //        them anyway because there would be no heartbeat.
+        auto siblingRole = sibling->getRole().value_or(Role::Unknown);
+        auto siblingProvisioned = sibling->getProvisioned().value_or(false);
+        auto siblingPosition = sibling->getPosition().value_or(0xFF);
 
-        role = role_determination::run(input);
+        role_determination::Input input{
+            .bmcPosition = services->getBMCPosition(),
+            .siblingPosition = siblingPosition,
+            .siblingRole = siblingRole,
+            .siblingHeartbeat = sibling->hasHeartbeat(),
+            .siblingProvisioned = siblingProvisioned};
+
+        roleInfo = role_determination::run(input);
     }
     catch (const std::exception& e)
     {
         lg2::error("Exception while determining, role.  Will have to be "
                    "passive. Error = {ERROR}",
                    "ERROR", e);
-        role = Role::Passive;
+        roleInfo.role = Role::Passive;
+        roleInfo.error = ErrorCase::internalError;
     }
 
-    lg2::info("Role Determined: {ROLE}", "ROLE", role);
+    if (roleInfo.error != role_determination::ErrorCase::noError)
+    {
+        // TODO: Create an error log
+    }
 
-    return role;
+    return roleInfo.role;
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -52,7 +52,8 @@ Manager::Manager(sdbusplus::async::context& ctx,
 // NOLINTNEXTLINE
 sdbusplus::async::task<> Manager::startup()
 {
-    co_await sibling->init();
+    co_await sdbusplus::async::execution::when_all(services->init(),
+                                                   sibling->init());
 
     // If we know the role must be passive, set that now,
     // before starting the heartbeat or waiting for the sibling.

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -1,6 +1,9 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 #pragma once
 
+#include "role_determination.hpp"
+#include "services.hpp"
+
 #include <sdbusplus/async.hpp>
 #include <xyz/openbmc_project/State/BMC/Redundancy/server.hpp>
 
@@ -31,8 +34,10 @@ class Manager
      * @brief Constructor
      *
      * @param[in] ctx - The async context object
+     * @param[in] services - The services object to interface with system data.
      */
-    explicit Manager(sdbusplus::async::context& ctx);
+    Manager(sdbusplus::async::context& ctx,
+            std::unique_ptr<Services>&& services);
 
   private:
     /**
@@ -49,6 +54,13 @@ class Manager
     sdbusplus::async::task<> doHeartBeat();
 
     /**
+     * @brief Determines the BMC role
+     *
+     * @return Role - The role
+     */
+    Role determineRole();
+
+    /**
      * @brief The async context object
      */
     sdbusplus::async::context& ctx;
@@ -57,6 +69,13 @@ class Manager
      * @brief The Redundancy D-Bus interface
      */
     RedundancyInterface redundancyInterface;
+
+    /**
+     * @brief The services object
+     *
+     * Wraps system interfaces.
+     */
+    std::unique_ptr<Services> services;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -4,6 +4,7 @@
 #include "role_determination.hpp"
 #include "role_handler.hpp"
 #include "services.hpp"
+#include "sibling.hpp"
 
 #include <sdbusplus/async.hpp>
 #include <xyz/openbmc_project/State/BMC/Redundancy/server.hpp>
@@ -36,9 +37,11 @@ class Manager
      *
      * @param[in] ctx - The async context object
      * @param[in] services - The services object to interface with system data.
+     * @param[in] sibling - The sibling access object
      */
     Manager(sdbusplus::async::context& ctx,
-            std::unique_ptr<Services>&& services);
+            std::unique_ptr<Services>&& services,
+            std::unique_ptr<Sibling>&& sibling);
 
   private:
     /**
@@ -89,6 +92,11 @@ class Manager
      * @brief The role handler class
      */
     std::unique_ptr<RoleHandler> handler;
+
+    /**
+     * @brief Object to handle sibling BMC access
+     */
+    std::unique_ptr<Sibling> sibling;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -1,0 +1,62 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#pragma once
+
+#include <sdbusplus/async.hpp>
+#include <xyz/openbmc_project/State/BMC/Redundancy/server.hpp>
+
+namespace rbmc
+{
+
+using RedundancyIntf =
+    sdbusplus::xyz::openbmc_project::State::BMC::server::Redundancy;
+using RedundancyInterface = sdbusplus::server::object_t<RedundancyIntf>;
+
+/**
+ * @class Manager
+ *
+ * Manages the high level operations of the redundant
+ * BMC functionality.
+ */
+class Manager
+{
+  public:
+    Manager() = delete;
+    ~Manager() = default;
+    Manager(const Manager&) = delete;
+    Manager& operator=(const Manager&) = delete;
+    Manager(Manager&&) = delete;
+    Manager& operator=(Manager&&) = delete;
+
+    /**
+     * @brief Constructor
+     *
+     * @param[in] ctx - The async context object
+     */
+    explicit Manager(sdbusplus::async::context& ctx);
+
+  private:
+    /**
+     * @brief Kicks off the Manager startup
+     */
+    sdbusplus::async::task<> startup();
+
+    /**
+     * @brief Emits a heartbeat signal every second
+     *
+     * The sibling gets this via the sibling app to
+     * know all's well.
+     */
+    sdbusplus::async::task<> doHeartBeat();
+
+    /**
+     * @brief The async context object
+     */
+    sdbusplus::async::context& ctx;
+
+    /**
+     * @brief The Redundancy D-Bus interface
+     */
+    RedundancyInterface redundancyInterface;
+};
+
+} // namespace rbmc

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "role_determination.hpp"
+#include "role_handler.hpp"
 #include "services.hpp"
 
 #include <sdbusplus/async.hpp>
@@ -61,6 +62,13 @@ class Manager
     Role determineRole();
 
     /**
+     * @brief Creates either an ActiveRoleHandler or
+     *        PassiveRoleHandler object depending on
+     *        the role and spawns handler->start().
+     */
+    void spawnRoleHandler();
+
+    /**
      * @brief The async context object
      */
     sdbusplus::async::context& ctx;
@@ -76,6 +84,11 @@ class Manager
      * Wraps system interfaces.
      */
     std::unique_ptr<Services> services;
+
+    /**
+     * @brief The role handler class
+     */
+    std::unique_ptr<RoleHandler> handler;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -50,6 +50,11 @@ class Manager
     sdbusplus::async::task<> startup();
 
     /**
+     * @brief Starts the heartbeat.
+     */
+    void startHeartbeat();
+
+    /**
      * @brief Emits a heartbeat signal every second
      *
      * The sibling gets this via the sibling app to

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -39,6 +39,16 @@ class Manager
             std::unique_ptr<Services>&& services,
             std::unique_ptr<Sibling>&& sibling);
 
+    /**
+     * @brief Handler for the DisableRedundancyOverride
+     *        property changing.
+     *
+     * Passes the value through to the role handler.
+     *
+     * @param[in] disable - The property value
+     */
+    void disableRedPropChanged(bool disable);
+
   private:
     /**
      * @brief Kicks off the Manager startup

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -65,6 +65,17 @@ class Manager
     role_determination::RoleInfo determineRole();
 
     /**
+     * @brief Determine if the BMC must be passive due to a problem.
+     *
+     * If so, the role will be set before the heartbeat is started, so
+     * the sibling BMC can know it should be active if possible.
+     *
+     * @return roleInfo - The passive role + error if must be passive.
+     */
+    sdbusplus::async::task<std::optional<role_determination::RoleInfo>>
+        determinePassiveRoleIfRequired();
+
+    /**
      * @brief Updates D-Bus with and serializes the new role
      *
      * @param[in] roleInfo - The new role and error if any

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -60,9 +60,16 @@ class Manager
     /**
      * @brief Determines the BMC role
      *
-     * @return Role - The role
+     * @return roleInfo - The role + role error if any
      */
-    Role determineRole();
+    role_determination::RoleInfo determineRole();
+
+    /**
+     * @brief Updates D-Bus with and serializes the new role
+     *
+     * @param[in] roleInfo - The new role and error if any
+     */
+    void updateRole(const role_determination::RoleInfo& roleInfo);
 
     /**
      * @brief Creates either an ActiveRoleHandler or
@@ -97,6 +104,20 @@ class Manager
      * @brief Object to handle sibling BMC access
      */
     std::unique_ptr<Sibling> sibling;
+
+    /**
+     * @brief The previously serialized role value.
+     *
+     * Read from the filesystem in the constructor.
+     */
+    Role previousRole{Role::Unknown};
+
+    /**
+     * @brief If previous passive role was selected due to an error case.
+     *
+     * Read from the filesystem in the constructor.
+     */
+    bool chosePassiveDueToError{false};
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -1,20 +1,16 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 #pragma once
 
+#include "redundancy_interface.hpp"
 #include "role_determination.hpp"
 #include "role_handler.hpp"
 #include "services.hpp"
 #include "sibling.hpp"
 
 #include <sdbusplus/async.hpp>
-#include <xyz/openbmc_project/State/BMC/Redundancy/server.hpp>
 
 namespace rbmc
 {
-
-using RedundancyIntf =
-    sdbusplus::xyz::openbmc_project::State::BMC::server::Redundancy;
-using RedundancyInterface = sdbusplus::server::object_t<RedundancyIntf>;
 
 /**
  * @class Manager

--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -18,6 +18,7 @@ executable(
     'passive_role_handler.cpp',
     'persistent_data.cpp',
     'rbmc_manager_main.cpp',
+    'redundancy.cpp',
     'role_determination.cpp',
     'services_impl.cpp',
     'sibling_impl.cpp',

--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -5,6 +5,8 @@ executable(
     'phosphor-rbmc-state-manager',
     'manager.cpp',
     'rbmc_manager_main.cpp',
+    'role_determination.cpp',
+    'services_impl.cpp',
     dependencies: [phosphordbusinterfaces, phosphorlogging, sdbusplus],
     install: true,
     install_dir: execinstalldir,

--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -3,7 +3,9 @@ execinstalldir = join_paths(get_option('libexecdir'), 'phosphor-state-manager')
 
 executable(
     'phosphor-rbmc-state-manager',
+    'active_role_handler.cpp',
     'manager.cpp',
+    'passive_role_handler.cpp',
     'rbmc_manager_main.cpp',
     'role_determination.cpp',
     'services_impl.cpp',

--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -20,6 +20,7 @@ executable(
     'rbmc_manager_main.cpp',
     'redundancy.cpp',
     'redundancy_interface.cpp',
+    'redundancy_mgr.cpp',
     'role_determination.cpp',
     'services_impl.cpp',
     'sibling_impl.cpp',

--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -28,6 +28,7 @@ executable(
 
 executable(
     'rbmctool',
+    'persistent_data.cpp',
     'rbmc_tool.cpp',
     'services_impl.cpp',
     dependencies: [rbmc_deps, CLI11],

--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+execinstalldir = join_paths(get_option('libexecdir'), 'phosphor-state-manager')
+
+executable(
+    'phosphor-rbmc-state-manager',
+    'manager.cpp',
+    'rbmc_manager_main.cpp',
+    dependencies: [phosphordbusinterfaces, phosphorlogging, sdbusplus],
+    install: true,
+    install_dir: execinstalldir,
+)

--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -19,6 +19,7 @@ executable(
     'persistent_data.cpp',
     'rbmc_manager_main.cpp',
     'redundancy.cpp',
+    'redundancy_interface.cpp',
     'role_determination.cpp',
     'services_impl.cpp',
     'sibling_impl.cpp',

--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -6,11 +6,17 @@ executable(
     'active_role_handler.cpp',
     'manager.cpp',
     'passive_role_handler.cpp',
+    'persistent_data.cpp',
     'rbmc_manager_main.cpp',
     'role_determination.cpp',
     'services_impl.cpp',
     'sibling_impl.cpp',
-    dependencies: [phosphordbusinterfaces, phosphorlogging, sdbusplus],
+    dependencies: [
+        nlohmann_json_dep,
+        phosphordbusinterfaces,
+        phosphorlogging,
+        sdbusplus,
+    ],
     install: true,
     install_dir: execinstalldir,
 )

--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -1,6 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 execinstalldir = join_paths(get_option('libexecdir'), 'phosphor-state-manager')
 
+ssl_dep = dependency('openssl')
+
+rbmc_deps = [
+    nlohmann_json_dep,
+    phosphordbusinterfaces,
+    phosphorlogging,
+    sdbusplus,
+    ssl_dep,
+]
+
 executable(
     'phosphor-rbmc-state-manager',
     'active_role_handler.cpp',
@@ -11,12 +21,15 @@ executable(
     'role_determination.cpp',
     'services_impl.cpp',
     'sibling_impl.cpp',
-    dependencies: [
-        nlohmann_json_dep,
-        phosphordbusinterfaces,
-        phosphorlogging,
-        sdbusplus,
-    ],
+    dependencies: rbmc_deps,
     install: true,
     install_dir: execinstalldir,
+)
+
+executable(
+    'rbmctool',
+    'rbmc_tool.cpp',
+    'services_impl.cpp',
+    dependencies: [rbmc_deps, CLI11],
+    install: true,
 )

--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -9,6 +9,7 @@ executable(
     'rbmc_manager_main.cpp',
     'role_determination.cpp',
     'services_impl.cpp',
+    'sibling_impl.cpp',
     dependencies: [phosphordbusinterfaces, phosphorlogging, sdbusplus],
     install: true,
     install_dir: execinstalldir,

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "passive_role_handler.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+namespace rbmc
+{
+
+constexpr auto bmcPassiveTarget = "obmc-bmc-passive.target";
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> PassiveRoleHandler::start()
+{
+    try
+    {
+        // NOLINTNEXTLINE
+        co_await services->startUnit(bmcPassiveTarget);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        // TODO: error log
+        lg2::error("Failed while starting BMC passive target: {ERROR}", "ERROR",
+                   e);
+    }
+
+    co_return;
+}
+
+} // namespace rbmc

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "passive_role_handler.hpp"
 
+#include "persistent_data.hpp"
+
 #include <phosphor-logging/lg2.hpp>
 
 namespace rbmc
@@ -14,7 +16,7 @@ sdbusplus::async::task<> PassiveRoleHandler::start()
     try
     {
         // NOLINTNEXTLINE
-        co_await services->startUnit(bmcPassiveTarget);
+        co_await services.startUnit(bmcPassiveTarget);
     }
     catch (const sdbusplus::exception_t& e)
     {
@@ -23,6 +25,17 @@ sdbusplus::async::task<> PassiveRoleHandler::start()
                    e);
     }
 
+    try
+    {
+        // Only the active needs NoRedundancyDetails persisted.
+        data::remove(data::key::noRedDetails);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error(
+            "Failed while removing NoRedundancyDetails saved value: {ERROR}",
+            "ERROR", e);
+    }
     co_return;
 }
 

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -4,6 +4,7 @@
 #include "persistent_data.hpp"
 
 #include <phosphor-logging/lg2.hpp>
+#include <xyz/openbmc_project/Common/error.hpp>
 
 namespace rbmc
 {
@@ -65,6 +66,12 @@ void PassiveRoleHandler::siblingRedEnabledHandler(bool enable)
     {
         redundancyInterface.redundancy_enabled(enable);
     }
+}
+
+void PassiveRoleHandler::disableRedPropChanged(bool /*disable*/)
+{
+    lg2::error("Cannot modify DisableRedundancy property on passive BMC");
+    throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/passive_role_handler.hpp
+++ b/redundant-bmc/src/passive_role_handler.hpp
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "role_handler.hpp"
+
+namespace rbmc
+{
+
+/**
+ * @class PassiveRoleHandler
+ *
+ * This class handles operation specific to the passive role.
+ */
+class PassiveRoleHandler : public RoleHandler
+{
+  public:
+    PassiveRoleHandler() = delete;
+    ~PassiveRoleHandler() override = default;
+    PassiveRoleHandler(const PassiveRoleHandler&) = delete;
+    PassiveRoleHandler& operator=(const PassiveRoleHandler&) = delete;
+    PassiveRoleHandler(PassiveRoleHandler&&) = delete;
+    PassiveRoleHandler& operator=(PassiveRoleHandler&&) = delete;
+
+    /**
+     * @brief Constructor
+     *
+     * @param[in] ctx - The async context object
+     * @param[in] services - The services object
+     */
+    PassiveRoleHandler(sdbusplus::async::context& ctx,
+                       std::unique_ptr<Services>& services) :
+        RoleHandler(ctx, services)
+    {}
+
+    /**
+     * @brief Starts the handler.
+     */
+    sdbusplus::async::task<> start() override;
+};
+
+} // namespace rbmc

--- a/redundant-bmc/src/passive_role_handler.hpp
+++ b/redundant-bmc/src/passive_role_handler.hpp
@@ -63,6 +63,17 @@ class PassiveRoleHandler : public RoleHandler
      * interface if the other BMC is Active.
      */
     void siblingRedEnabledHandler(bool enable) override;
+
+    /**
+     * @brief Handler for the DisableRedundancyOverride
+     *        property changing.
+     *
+     * Not supported on the passive BMC so an error will
+     * be thrown.
+     *
+     * @param[in] disable - The new disable value.
+     */
+    void disableRedPropChanged(bool disable) override;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/passive_role_handler.hpp
+++ b/redundant-bmc/src/passive_role_handler.hpp
@@ -25,9 +25,9 @@ class PassiveRoleHandler : public RoleHandler
      * @param[in] ctx - The async context object
      * @param[in] services - The services object
      */
-    PassiveRoleHandler(sdbusplus::async::context& ctx,
-                       std::unique_ptr<Services>& services) :
-        RoleHandler(ctx, services)
+    PassiveRoleHandler(sdbusplus::async::context& ctx, Services& services,
+                       Sibling& sibling, RedundancyInterface& iface) :
+        RoleHandler(ctx, services, sibling, iface)
     {}
 
     /**

--- a/redundant-bmc/src/persistent_data.cpp
+++ b/redundant-bmc/src/persistent_data.cpp
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "persistent_data.hpp"
+
+#include "phosphor-logging/lg2.hpp"
+
+#include <format>
+#include <fstream>
+
+namespace data::util
+{
+
+std::optional<nlohmann::json> readFile(const std::filesystem::path& path)
+{
+    if (std::filesystem::exists(path))
+    {
+        std::ifstream stream{path};
+        try
+        {
+            return nlohmann::json::parse(stream, nullptr, true);
+        }
+        catch (const std::exception& e)
+        {
+            lg2::error("Error parsing JSON in {FILE}: {ERROR}", "FILE", path,
+                       "ERROR", e);
+        }
+    }
+
+    return std::nullopt;
+}
+
+void writeFile(const nlohmann::json& json, const std::filesystem::path& path)
+{
+    if (!std::filesystem::exists(path))
+    {
+        std::filesystem::create_directories(path.parent_path());
+    }
+
+    std::ofstream stream{path};
+    stream << std::setw(4) << json;
+    if (stream.fail())
+    {
+        throw std::runtime_error{
+            std::format("Failed writing {}", path.string())};
+    }
+}
+
+} // namespace data::util

--- a/redundant-bmc/src/persistent_data.cpp
+++ b/redundant-bmc/src/persistent_data.cpp
@@ -7,7 +7,9 @@
 #include <format>
 #include <fstream>
 
-namespace data::util
+namespace data
+{
+namespace util
 {
 
 std::optional<nlohmann::json> readFile(const std::filesystem::path& path)
@@ -45,4 +47,20 @@ void writeFile(const nlohmann::json& json, const std::filesystem::path& path)
     }
 }
 
-} // namespace data::util
+} // namespace util
+
+void remove(std::string_view name, const std::filesystem::path& path)
+{
+    auto json = util::readFile(path);
+    if (!json)
+    {
+        return;
+    }
+
+    if (json->erase(name) != 0)
+    {
+        util::writeFile(json.value(), path);
+    }
+}
+
+} // namespace data

--- a/redundant-bmc/src/persistent_data.hpp
+++ b/redundant-bmc/src/persistent_data.hpp
@@ -17,6 +17,7 @@ namespace key
 constexpr auto role = "Role";
 constexpr auto passiveError = "PassiveDueToError";
 constexpr auto roleReason = "RoleReason";
+constexpr auto disableRed = "DisableRedundancy";
 } // namespace key
 
 namespace util

--- a/redundant-bmc/src/persistent_data.hpp
+++ b/redundant-bmc/src/persistent_data.hpp
@@ -17,6 +17,7 @@ namespace key
 constexpr auto role = "Role";
 constexpr auto passiveError = "PassiveDueToError";
 constexpr auto roleReason = "RoleReason";
+constexpr auto noRedDetails = "NoRedundancyDetails";
 constexpr auto disableRed = "DisableRedundancy";
 } // namespace key
 

--- a/redundant-bmc/src/persistent_data.hpp
+++ b/redundant-bmc/src/persistent_data.hpp
@@ -12,6 +12,12 @@ namespace data
 const std::filesystem::path dataFile{
     "/var/lib/phosphor-state-manager/redundant-bmc/data.json"};
 
+namespace key
+{
+constexpr auto role = "Role";
+constexpr auto passiveError = "PassiveDueToError";
+} // namespace key
+
 namespace util
 {
 

--- a/redundant-bmc/src/persistent_data.hpp
+++ b/redundant-bmc/src/persistent_data.hpp
@@ -16,6 +16,7 @@ namespace key
 {
 constexpr auto role = "Role";
 constexpr auto passiveError = "PassiveDueToError";
+constexpr auto roleReason = "RoleReason";
 } // namespace key
 
 namespace util

--- a/redundant-bmc/src/persistent_data.hpp
+++ b/redundant-bmc/src/persistent_data.hpp
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include <filesystem>
+#include <optional>
+
+namespace data
+{
+
+const std::filesystem::path dataFile{
+    "/var/lib/phosphor-state-manager/redundant-bmc/data.json"};
+
+namespace util
+{
+
+/**
+ * @brief Helper function to read a JSON file
+ *
+ * @param[in] path - The path to the file
+ *
+ * @return optional<json> - The JSON data, or std::nullopt if it
+ *                          didn't exist or was corrupt.
+ */
+std::optional<nlohmann::json> readFile(const std::filesystem::path& path);
+
+/**
+ * @brief Helper function to write a JSON file
+ *
+ * @param[in] json - The JSON to write
+ * @param[in] path - The path to the file
+ */
+void writeFile(const nlohmann::json& json, const std::filesystem::path& path);
+
+} // namespace util
+
+/**
+ * @brief Writes "name": <value>  JSON to the file specified
+ *
+ * Throws an exception on error.
+ *
+ * @tparam - The data type
+ * @param[in] name - The key to save the value under
+ * @param[in] value - The value to save
+ */
+template <typename T>
+void write(std::string_view name, const T& value,
+           const std::filesystem::path& path = dataFile)
+{
+    auto json = util::readFile(path).value_or(nlohmann::json::object());
+    if constexpr (std::is_enum_v<T>)
+    {
+        json[name] = std::to_underlying(value);
+    }
+    else
+    {
+        json[name] = value;
+    }
+
+    util::writeFile(json, path);
+}
+
+/**
+ * @brief Reads the value of the key specified in the file specified
+ *
+ * Throws an exception on error.
+ *
+ * @tparam T - The data type
+ * @param[in] name - The key the value is saved under
+ * @param[in] path - The path to the file
+ *
+ * @return optional<T> - The value, or std::nullopt if the file or
+ *                       key isn't present.
+ */
+template <typename T>
+std::optional<T> read(std::string_view name,
+                      const std::filesystem::path& path = dataFile)
+{
+    auto json = util::readFile(path);
+    if (!json)
+    {
+        return std::nullopt;
+    }
+
+    auto it = json->find(name);
+    if (it != json->end())
+    {
+        if constexpr (std::is_enum_v<T>)
+        {
+            auto value = it->get<std::underlying_type_t<T>>();
+            return static_cast<T>(value);
+        }
+        else
+        {
+            return it->get<T>();
+        }
+    }
+
+    return std::nullopt;
+}
+
+} // namespace data

--- a/redundant-bmc/src/persistent_data.hpp
+++ b/redundant-bmc/src/persistent_data.hpp
@@ -107,4 +107,14 @@ std::optional<T> read(std::string_view name,
     return std::nullopt;
 }
 
+/**
+ * @brief Remove an entry from the file
+ *
+ * @param[in] name - The key for the entry to remove
+ *
+ * @param[in] path - The path to the file
+ */
+void remove(std::string_view name,
+            const std::filesystem::path& path = dataFile);
+
 } // namespace data

--- a/redundant-bmc/src/rbmc_manager_main.cpp
+++ b/redundant-bmc/src/rbmc_manager_main.cpp
@@ -2,6 +2,7 @@
 
 #include "manager.hpp"
 #include "services_impl.hpp"
+#include "sibling_impl.hpp"
 
 #include <sdbusplus/async/context.hpp>
 #include <sdbusplus/server/manager.hpp>
@@ -17,8 +18,10 @@ int main()
 
     std::unique_ptr<rbmc::Services> services =
         std::make_unique<rbmc::ServicesImpl>(ctx);
+    std::unique_ptr<rbmc::Sibling> sibling =
+        std::make_unique<rbmc::SiblingImpl>(ctx);
 
-    rbmc::Manager manager{ctx, std::move(services)};
+    rbmc::Manager manager{ctx, std::move(services), std::move(sibling)};
 
     // clang-tidy currently mangles this into something unreadable
     // NOLINTNEXTLINE

--- a/redundant-bmc/src/rbmc_manager_main.cpp
+++ b/redundant-bmc/src/rbmc_manager_main.cpp
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "manager.hpp"
+
+#include <sdbusplus/async/context.hpp>
+#include <sdbusplus/server/manager.hpp>
+#include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
+
+using Redundancy =
+    sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy;
+
+int main()
+{
+    sdbusplus::async::context ctx;
+    sdbusplus::server::manager_t objMgr{ctx, "/xyz/openbmc_project/state"};
+
+    rbmc::Manager manager{ctx};
+
+    // clang-tidy currently mangles this into something unreadable
+    // NOLINTNEXTLINE
+    ctx.spawn([](sdbusplus::async::context& ctx) -> sdbusplus::async::task<> {
+        ctx.request_name(Redundancy::interface);
+        co_return;
+    }(ctx));
+
+    ctx.run();
+
+    return 0;
+}

--- a/redundant-bmc/src/rbmc_manager_main.cpp
+++ b/redundant-bmc/src/rbmc_manager_main.cpp
@@ -16,7 +16,7 @@ int main()
     sdbusplus::server::manager_t objMgr{ctx, "/xyz/openbmc_project/state"};
 
     std::unique_ptr<rbmc::Services> services =
-        std::make_unique<rbmc::ServicesImpl>();
+        std::make_unique<rbmc::ServicesImpl>(ctx);
 
     rbmc::Manager manager{ctx, std::move(services)};
 

--- a/redundant-bmc/src/rbmc_manager_main.cpp
+++ b/redundant-bmc/src/rbmc_manager_main.cpp
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include "manager.hpp"
+#include "services_impl.hpp"
 
 #include <sdbusplus/async/context.hpp>
 #include <sdbusplus/server/manager.hpp>
@@ -14,7 +15,10 @@ int main()
     sdbusplus::async::context ctx;
     sdbusplus::server::manager_t objMgr{ctx, "/xyz/openbmc_project/state"};
 
-    rbmc::Manager manager{ctx};
+    std::unique_ptr<rbmc::Services> services =
+        std::make_unique<rbmc::ServicesImpl>();
+
+    rbmc::Manager manager{ctx, std::move(services)};
 
     // clang-tidy currently mangles this into something unreadable
     // NOLINTNEXTLINE

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#include "persistent_data.hpp"
 #include "services_impl.hpp"
 
 #include <CLI/CLI.hpp>
@@ -94,6 +95,10 @@ sdbusplus::async::task<> displayLocalBMCInfo(sdbusplus::async::context& ctx,
                                      services.getFWVersion());
             std::cout << std::format("Provisioned:         {}\n",
                                      services.getProvisioned());
+            std::cout << std::format(
+                "Role Reason:         {}\n",
+                data::read<std::string>(data::key::roleReason)
+                    .value_or("No reason found"));
         }
     }
     catch (const std::exception& e)

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "persistent_data.hpp"
+#include "redundancy.hpp"
 #include "services_impl.hpp"
 
 #include <CLI/CLI.hpp>
@@ -99,6 +100,26 @@ sdbusplus::async::task<> displayLocalBMCInfo(sdbusplus::async::context& ctx,
                 "Role Reason:         {}\n",
                 data::read<std::string>(data::key::roleReason)
                     .value_or("No reason found"));
+
+            if ((role == "Active") && !enabled)
+            {
+                using NoRedDetails =
+                    std::map<rbmc::redundancy::NoRedundancyReason, std::string>;
+                auto details = data::read<NoRedDetails>(data::key::noRedDetails)
+                                   .value_or(NoRedDetails{});
+                std::cout << std::format("Reasons for no BMC redundancy:\n");
+                if (!details.empty())
+                {
+                    for (const auto& d : std::views::values(details))
+                    {
+                        std::cout << std::format("    {}\n", d);
+                    }
+                }
+                else
+                {
+                    std::cout << std::format("    Unknown\n");
+                }
+            }
         }
     }
     catch (const std::exception& e)

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -96,10 +96,13 @@ sdbusplus::async::task<> displayLocalBMCInfo(sdbusplus::async::context& ctx,
                                      services.getFWVersion());
             std::cout << std::format("Provisioned:         {}\n",
                                      services.getProvisioned());
-            std::cout << std::format(
-                "Role Reason:         {}\n",
-                data::read<std::string>(data::key::roleReason)
-                    .value_or("No reason found"));
+            if (role != "Unknown")
+            {
+                std::cout << std::format(
+                    "Role Reason:         {}\n",
+                    data::read<std::string>(data::key::roleReason)
+                        .value_or("No reason found"));
+            }
 
             if ((role == "Active") && !enabled)
             {

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "services_impl.hpp"
+
+#include <CLI/CLI.hpp>
+#include <xyz/openbmc_project/ObjectMapper/client.hpp>
+#include <xyz/openbmc_project/State/BMC/Redundancy/Sibling/client.hpp>
+#include <xyz/openbmc_project/State/BMC/Redundancy/client.hpp>
+#include <xyz/openbmc_project/State/BMC/client.hpp>
+
+#include <format>
+#include <iostream>
+
+using Sibling =
+    sdbusplus::client::xyz::openbmc_project::state::bmc::redundancy::Sibling<>;
+using Redundancy =
+    sdbusplus::client::xyz::openbmc_project::state::bmc::Redundancy<>;
+using BMCState = sdbusplus::client::xyz::openbmc_project::state::BMC<>;
+using Role = Redundancy::Role;
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<std::string> getBMCState(sdbusplus::async::context& ctx)
+{
+    using ObjectMapper =
+        sdbusplus::client::xyz::openbmc_project::ObjectMapper<>;
+    using StateMgr = sdbusplus::client::xyz::openbmc_project::state::BMC<>;
+
+    try
+    {
+        auto mapper = ObjectMapper(ctx)
+                          .service(ObjectMapper::default_service)
+                          .path(ObjectMapper::instance_path);
+
+        std::string statePath = std::string{BMCState::namespace_path::value} +
+                                '/' + BMCState::namespace_path::bmc;
+        std::vector<std::string> stateIface{BMCState::interface};
+
+        auto object = co_await mapper.get_object(statePath, stateIface);
+        auto service = object.begin()->first;
+
+        auto stateMgr = StateMgr(ctx).service(service).path(statePath);
+        auto bmcState = co_await stateMgr.current_bmc_state();
+
+        auto stateString = BMCState::convertBMCStateToString(bmcState);
+        co_return stateString.substr(stateString.find_last_of('.') + 1);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        // Just show the error in the state field
+        co_return e.what();
+    }
+}
+
+// NOLINTBEGIN
+sdbusplus::async::task<> displayLocalBMCInfo(sdbusplus::async::context& ctx,
+                                             bool extended)
+// NOLINTEND
+{
+    auto redundancy = sdbusplus::async::proxy()
+                          .service("xyz.openbmc_project.State.BMC.Redundancy")
+                          .path(Redundancy::instance_path)
+                          .interface(Redundancy::interface);
+
+    std::cout << "Local BMC\n";
+    std::cout << "-----------------------------\n";
+
+    try
+    {
+        auto props =
+            co_await redundancy
+                .get_all_properties<Redundancy::PropertiesVariant>(ctx);
+
+        auto role =
+            Redundancy::convertRoleToString(std::get<Role>(props.at("Role")));
+        // Strip off the sdbusplus prefix to get the final part, e.g. 'Active'.
+        role = role.substr(role.find_last_of('.') + 1);
+        std::cout << std::format("Role:                {}\n", role);
+
+        rbmc::ServicesImpl services{ctx};
+        std::cout << std::format("BMC Position:        {}\n",
+                                 services.getBMCPosition());
+
+        auto enabled = std::get<bool>(props.at("RedundancyEnabled"));
+        std::cout << std::format("Redundancy Enabled:  {}\n", enabled);
+
+        if (extended)
+        {
+            auto bmcState = co_await getBMCState(ctx);
+            std::cout << std::format("BMC State:           {}\n", bmcState);
+
+            std::cout << std::format("Failovers Paused:    {}\n",
+                                     false); // TODO
+            std::cout << std::format("FW version hash:     {}\n",
+                                     services.getFWVersion());
+            std::cout << std::format("Provisioned:         {}\n",
+                                     services.getProvisioned());
+        }
+    }
+    catch (const std::exception& e)
+    {
+        std::cout << "Cannot get to Redundancy interface on D-Bus: " << e.what()
+                  << "\n";
+    }
+
+    co_return;
+}
+
+// NOLINTBEGIN
+sdbusplus::async::task<> displaySiblingBMCInfo(sdbusplus::async::context& ctx,
+                                               bool extended)
+// NOLINTEND
+{
+    std::string path = std::string{Sibling::namespace_path::value} + '/' +
+                       Sibling::namespace_path::bmc;
+    auto sibling =
+        sdbusplus::async::proxy()
+            .service("xyz.openbmc_project.State.BMC.Redundancy.Sibling")
+            .path(path)
+            .interface(Sibling::interface);
+
+    std::cout << "Sibling BMC\n";
+    std::cout << "-----------------------------\n";
+
+    try
+    {
+        auto props =
+            co_await sibling.get_all_properties<Sibling::PropertiesVariant>(
+                ctx);
+
+        if (!std::get<bool>(props.at("Heartbeat")))
+        {
+            std::cout << "No sibling heartbeat\n";
+            co_return;
+        }
+
+        auto role =
+            Redundancy::convertRoleToString(std::get<Role>(props.at("Role")));
+        role = role.substr(role.find_last_of('.') + 1);
+        std::cout << std::format("Role:                {}\n", role);
+
+        if (!extended)
+        {
+            co_return;
+        }
+
+        auto bmcState = BMCState::convertBMCStateToString(
+            std::get<BMCState::BMCState>(props.at("BMCState")));
+        bmcState = bmcState.substr(bmcState.find_last_of('.') + 1);
+        auto pos = std::get<size_t>(props.at("BMCPosition"));
+        auto provisioned = std::get<bool>(props.at("Provisioned"));
+        auto commOK = std::get<bool>(props.at("CommunicationOK"));
+        auto fwVersion = std::get<std::string>(props.at("FWVersion"));
+        auto paused = std::get<bool>(props.at("FailoversPaused"));
+        auto enabled = std::get<bool>(props.at("RedundancyEnabled"));
+
+        std::cout << std::format("BMC Position:        {}\n", pos);
+        std::cout << std::format("BMC State:           {}\n", bmcState);
+        std::cout << std::format("Redundancy Enabled:  {}\n", enabled);
+        std::cout << std::format("Failovers Paused:    {}\n", paused);
+        std::cout << std::format("Sibling Comm OK:     {}\n", commOK);
+        std::cout << std::format("FW version hash:     {}\n", fwVersion);
+        std::cout << std::format("Provisioned:         {}\n", provisioned);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        std::cout << "Cannot get to Sibling interface on D-Bus: " << e.what()
+                  << "\n";
+    }
+
+    co_return;
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> displayInfo(sdbusplus::async::context& ctx,
+                                     bool extended)
+{
+    std::cout << "\n";
+    co_await displayLocalBMCInfo(ctx, extended);
+    std::cout << "\n";
+    co_await displaySiblingBMCInfo(ctx, extended);
+    std::cout << "\n";
+    co_return;
+}
+
+int main(int argc, char** argv)
+{
+    CLI::App app{"RBMC Tool"};
+    bool info{};
+    bool extended{};
+    sdbusplus::async::context ctx;
+
+    auto* flag = app.add_flag("-d", info, "Display RBMC Information");
+    app.add_flag("-e", extended, "Add extended RBMC details to the display")
+        ->needs(flag);
+
+    CLI11_PARSE(app, argc, argv);
+
+    if (info)
+    {
+        ctx.spawn(displayInfo(ctx, extended));
+    }
+    else
+    {
+        std::cout << app.help();
+    }
+
+    ctx.spawn(
+        sdbusplus::async::execution::just() |
+        sdbusplus::async::execution::then([&ctx]() { ctx.request_stop(); }));
+    ctx.run();
+
+    return 0;
+}

--- a/redundant-bmc/src/redundancy.cpp
+++ b/redundant-bmc/src/redundancy.cpp
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "redundancy.hpp"
+
+namespace rbmc::redundancy
+{
+
+NoRedundancyReasons getNoRedundancyReasons(const Input& input)
+{
+    using enum NoRedundancyReason;
+    NoRedundancyReasons reasons;
+
+    // TODO:
+    // - Network and/or sync health
+    // - Can't enable redundancy if system wasn't booted with it enabled
+
+    if (input.role != Role::Active)
+    {
+        reasons.insert(bmcNotActive);
+    }
+
+    if (input.manualDisable)
+    {
+        reasons.insert(manuallyDisabled);
+    }
+
+    if (!input.siblingPresent)
+    {
+        reasons.insert(siblingMissing);
+    }
+    else
+    {
+        if (!input.siblingHeartbeat)
+        {
+            reasons.insert(noSiblingHeartbeat);
+        }
+        else
+        {
+            if (!input.siblingProvisioned)
+            {
+                reasons.insert(siblingNotProvisioned);
+            }
+
+            if (input.siblingRole != Role::Passive)
+            {
+                reasons.insert(siblingNotPassive);
+            }
+
+            if (!input.siblingHasSiblingComm)
+            {
+                reasons.insert(siblingNoCommunication);
+            }
+
+            if (!input.codeVersionsMatch)
+            {
+                reasons.insert(codeMismatch);
+            }
+
+            if (input.siblingState != BMCState::Ready)
+            {
+                reasons.insert(siblingNotAtReady);
+            }
+        }
+    }
+
+    return reasons;
+}
+
+std::string getNoRedundancyDescription(NoRedundancyReason reason)
+{
+    using enum NoRedundancyReason;
+    using namespace std::string_literals;
+    std::string desc;
+
+    // Use a switch so that the compiler will catch missing enums.
+    switch (reason)
+    {
+        case none:
+            desc = "None"s;
+            break;
+        case bmcNotActive:
+            desc = "BMC is not active"s;
+            break;
+        case manuallyDisabled:
+            desc = "Manually disabled"s;
+            break;
+        case siblingMissing:
+            desc = "Sibling is missing"s;
+            break;
+        case noSiblingHeartbeat:
+            desc = "No sibling heartbeat"s;
+            break;
+        case siblingNotProvisioned:
+            desc = "Sibling is not provisioned"s;
+            break;
+        case siblingNotPassive:
+            desc = "Sibling is not passive"s;
+            break;
+        case siblingNoCommunication:
+            desc = "Sibling has no communication with this BMC"s;
+            break;
+        case codeMismatch:
+            desc = "Firmware version mismatch"s;
+            break;
+        case siblingNotAtReady:
+            desc = "Sibling is not at ready state"s;
+            break;
+        case systemHardwareConfigIssue:
+            desc = "System hardware configuration issue"s;
+            break;
+        case other:
+            desc = "Other";
+            break;
+    }
+    return desc;
+}
+
+} // namespace rbmc::redundancy

--- a/redundant-bmc/src/redundancy.hpp
+++ b/redundant-bmc/src/redundancy.hpp
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
+#include <xyz/openbmc_project/State/BMC/common.hpp>
+
+namespace rbmc
+{
+
+using Role =
+    sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy::Role;
+
+using BMCState = sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState;
+
+namespace redundancy
+{
+
+/**
+ * @brief Inputs to the getNoRedundancyReasons function
+ */
+struct Input
+{
+    Role role;
+    bool siblingPresent;
+    bool siblingHeartbeat;
+    bool siblingProvisioned;
+    bool siblingHasSiblingComm;
+    Role siblingRole;
+    BMCState siblingState;
+    bool codeVersionsMatch;
+    bool manualDisable;
+};
+
+// TODO: Move this to PDI Enums
+/**
+ * @brief Reasons why redundancy can't be enabled
+ */
+enum class NoRedundancyReason
+{
+    none,
+    bmcNotActive,
+    manuallyDisabled,
+    siblingMissing,
+    noSiblingHeartbeat,
+    siblingNotProvisioned,
+    siblingNotPassive,
+    siblingNoCommunication,
+    codeMismatch,
+    siblingNotAtReady,
+    systemHardwareConfigIssue,
+    other
+};
+
+using NoRedundancyReasons = std::set<NoRedundancyReason>;
+
+/**
+ * @brief Returns the reasons that redundancy can't be enabled.
+ *
+ * @return The reasons.  Empty if it can be enabled.
+ */
+NoRedundancyReasons getNoRedundancyReasons(const Input& input);
+
+/**
+ * @brief Return the string description of the reason
+ *
+ * @return The human readable description.
+ */
+std::string getNoRedundancyDescription(NoRedundancyReason reason);
+
+} // namespace redundancy
+} // namespace rbmc

--- a/redundant-bmc/src/redundancy_interface.cpp
+++ b/redundant-bmc/src/redundancy_interface.cpp
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "redundancy_interface.hpp"
+
+#include "manager.hpp"
+#include "persistent_data.hpp"
+#include "phosphor-logging/lg2.hpp"
+
+namespace rbmc
+{
+
+RedundancyInterface::RedundancyInterface(sdbusplus::async::context& ctx,
+                                         Manager& manager) :
+    sdbusplus::aserver::xyz::openbmc_project::state::bmc::Redundancy<
+        RedundancyInterface>(ctx,
+                             RedundancyInterface::Redundancy::instance_path),
+    manager(manager)
+{
+    try
+    {
+        disable_redundancy_override_ =
+            data::read<bool>(data::key::disableRed).value_or(false);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error(
+            "Failed trying to obtain previous value of DisableRedundancy");
+    }
+
+    emit_added();
+}
+
+bool RedundancyInterface::set_property(
+    [[maybe_unused]] disable_redundancy_override_t type, bool disable)
+{
+    if (disable == disable_redundancy_override())
+    {
+        return false;
+    }
+
+    lg2::info("Request to change DisableRedundancy property to {VALUE}",
+              "VALUE", disable);
+
+    // TODO: Actually disable redundancy
+    // manager.disableRedPropChanged(disable);
+
+    try
+    {
+        data::write(data::key::disableRed, disable);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::info(
+            "Could not serialize DisableRedundancy value of {DISABLE}: {ERROR}",
+            "DISABLE", disable, "ERROR", e);
+    }
+
+    disable_redundancy_override_ = disable;
+    return true;
+}
+
+} // namespace rbmc

--- a/redundant-bmc/src/redundancy_interface.cpp
+++ b/redundant-bmc/src/redundancy_interface.cpp
@@ -40,8 +40,7 @@ bool RedundancyInterface::set_property(
     lg2::info("Request to change DisableRedundancy property to {VALUE}",
               "VALUE", disable);
 
-    // TODO: Actually disable redundancy
-    // manager.disableRedPropChanged(disable);
+    manager.disableRedPropChanged(disable);
 
     try
     {

--- a/redundant-bmc/src/redundancy_interface.hpp
+++ b/redundant-bmc/src/redundancy_interface.hpp
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <sdbusplus/async.hpp>
+#include <xyz/openbmc_project/State/BMC/Redundancy/aserver.hpp>
+
+namespace rbmc
+{
+
+class Manager;
+
+/**
+ * @class RedundancyInterface
+ *
+ * Has the necessary overrides for the Redundancy D-Bus interface
+ */
+class RedundancyInterface :
+    public sdbusplus::aserver::xyz::openbmc_project::state::bmc::Redundancy<
+        RedundancyInterface>
+{
+  public:
+    RedundancyInterface(const RedundancyInterface&) = delete;
+    RedundancyInterface& operator=(const RedundancyInterface&) = delete;
+    RedundancyInterface(RedundancyInterface&&) = delete;
+    RedundancyInterface& operator=(RedundancyInterface&&) = delete;
+
+    /**
+     * @brief Constructor
+     *
+     * @param[in] ctx - The async context object
+     *
+     * @param[in] manager - Reference to the Manager class
+     */
+    RedundancyInterface(sdbusplus::async::context& ctx, Manager& manager);
+
+    /**
+     * @brief Implements property set for the
+     *        DisableRedundancyOverride property
+     *
+     * @param[in] disable_redundancy_override_t - The type
+     * @param[in] disable - the value being set
+     *
+     * @return If the property value changed
+     */
+    bool set_property(disable_redundancy_override_t type, bool disable);
+
+  private:
+    /**
+     * @brief Reference to the Manager class
+     */
+    Manager& manager;
+};
+
+} // namespace rbmc

--- a/redundant-bmc/src/redundancy_mgr.cpp
+++ b/redundant-bmc/src/redundancy_mgr.cpp
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "redundancy_mgr.hpp"
+
+#include <persistent_data.hpp>
+#include <phosphor-logging/lg2.hpp>
+#include <xyz/openbmc_project/Common/error.hpp>
+
+namespace rbmc
+{
+
+RedundancyMgr::RedundancyMgr(sdbusplus::async::context& ctx, Services& services,
+                             Sibling& sibling, RedundancyInterface& iface) :
+    ctx(ctx), services(services), sibling(sibling), redundancyInterface(iface),
+    manualDisable(iface.disable_redundancy_override())
+{
+    try
+    {
+        data::remove(data::key::noRedDetails);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed removing NoRedundancyDetails: {ERROR}", "ERROR", e);
+    }
+}
+
+// NOLINTNEXTLINE
+void RedundancyMgr::determineAndSetRedundancy()
+{
+    enableOrDisableRedundancy(getNoRedundancyReasons());
+    redundancyDetermined = true;
+}
+
+redundancy::NoRedundancyReasons RedundancyMgr::getNoRedundancyReasons()
+{
+    redundancy::Input input{
+        .role = redundancyInterface.role(),
+        .siblingPresent = sibling.isBMCPresent(),
+        .siblingHeartbeat = sibling.hasHeartbeat(),
+        .siblingProvisioned = sibling.getProvisioned().value_or(false),
+        .siblingHasSiblingComm = sibling.getSiblingCommsOK().value_or(false),
+        .siblingRole = sibling.getRole().value_or(Role::Unknown),
+        .siblingState = sibling.getBMCState().value_or(BMCState::NotReady),
+        .codeVersionsMatch =
+            services.getFWVersion() == sibling.getFWVersion().value_or(""),
+        .manualDisable = manualDisable};
+
+    auto reasons = redundancy::getNoRedundancyReasons(input);
+
+    std::map<redundancy::NoRedundancyReason, std::string> details;
+
+    std::ranges::transform(
+        reasons, std::inserter(details, details.begin()),
+        [](const auto& reason) {
+            auto desc = redundancy::getNoRedundancyDescription(reason);
+            lg2::info("No redundancy because: {DESC}", "DESC", desc);
+            return std::pair{reason, desc};
+        });
+
+    try
+    {
+        data::write(data::key::noRedDetails, details);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed serializing NoRedundancyReasons: {ERROR}", "ERROR",
+                   e);
+    }
+
+    return reasons;
+}
+
+void RedundancyMgr::enableOrDisableRedundancy(
+    const redundancy::NoRedundancyReasons& disableReasons)
+{
+    auto enable = disableReasons.empty();
+
+    if (enable)
+    {
+        lg2::info("Enabling redundancy");
+    }
+    else
+    {
+        lg2::info("Redundancy must be disabled");
+    }
+
+    redundancyInterface.redundancy_enabled(enable);
+}
+
+void RedundancyMgr::disableRedPropChanged(bool disable)
+{
+    try
+    {
+        if (services.isPoweredOn())
+        {
+            lg2::error("Cannot modify DisableRedundancy prop when powered on");
+            throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
+        }
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Call to isPoweredOn failed: {ERROR}", "ERROR", e);
+        throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
+    }
+
+    manualDisable = disable;
+
+    if (!redundancyDetermined)
+    {
+        // Must be before we've handled redundancy, it should happen soon
+        lg2::info(
+            "Redundancy has not been determined yet, will not change redundancy now.");
+        return;
+    }
+
+    if (disable == !redundancyInterface.redundancy_enabled())
+    {
+        // No changes necessary now
+        lg2::info("No change to redundancy necessary");
+        return;
+    }
+
+    lg2::info(
+        "Revisiting redundancy after manual override of disable to {DISABLE}",
+        "DISABLE", disable);
+
+    determineAndSetRedundancy();
+}
+
+} // namespace rbmc

--- a/redundant-bmc/src/redundancy_mgr.hpp
+++ b/redundant-bmc/src/redundancy_mgr.hpp
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "redundancy.hpp"
+#include "redundancy_interface.hpp"
+#include "services.hpp"
+#include "sibling.hpp"
+
+namespace rbmc
+{
+
+/**
+ * @class RedundancyMgr
+ *
+ * This class manages the redundancy related functionality.
+ */
+class RedundancyMgr
+{
+  public:
+    ~RedundancyMgr() = default;
+    RedundancyMgr(const RedundancyMgr&) = delete;
+    RedundancyMgr& operator=(const RedundancyMgr&) = delete;
+    RedundancyMgr(RedundancyMgr&&) = delete;
+    RedundancyMgr& operator=(RedundancyMgr&&) = delete;
+
+    /**
+     * @brief Constructor
+     *
+     * @param[in] ctx - The async context object
+     * @param[in] services - The services object
+     * @param[in] sibling - The sibling object
+     * @param[in] iface - The redundancy D-Bus interface object
+     */
+    RedundancyMgr(sdbusplus::async::context& ctx, Services& services,
+                  Sibling& sibling, RedundancyInterface& iface);
+
+    /**
+     * @brief Enables or disables redundancy based on the
+     *        system config.
+     */
+    void determineAndSetRedundancy();
+
+    /**
+     * @brief Called when the DisableRedundancyOverride D-Bus property
+     *        is updated.
+     *
+     * May disable or enable redundancy at this time if possible.
+     *
+     * @param[in] disable - If redundancy should be disabled
+     *                      or enabled.
+     */
+    void disableRedPropChanged(bool disable);
+
+  private:
+    /**
+     * @brief Returns the reasons that redundancy cannnot be
+     *        enabled, if any.
+     *
+     * @return The reasons.  If empty, then redundancy can be enabled.
+     */
+    redundancy::NoRedundancyReasons getNoRedundancyReasons();
+
+    /**
+     * @brief Based on if disableReasons is empty or not, disables
+     *        or enables redundancy.
+     *
+     * @param[in] disableReasons - The reasons redundancy must be
+     *            disabled, if any.
+     */
+    void enableOrDisableRedundancy(
+        const redundancy::NoRedundancyReasons& disableReasons);
+
+    /**
+     * @brief The async context object
+     */
+    sdbusplus::async::context& ctx;
+
+    /**
+     * @brief The services object
+     */
+    Services& services;
+
+    /**
+     * @brief The Sibling object
+     */
+    Sibling& sibling;
+
+    /**
+     * @brief The Redundancy D-Bus interface
+     */
+    RedundancyInterface& redundancyInterface;
+
+    /**
+     * @brief If determineAndSetRedundancy() has ran yet or not.
+     */
+    bool redundancyDetermined = false;
+
+    /**
+     * @brief If redundancy has been manually disabled via the
+     *        D-Bus property.
+     */
+    bool manualDisable = false;
+};
+
+} // namespace rbmc

--- a/redundant-bmc/src/role_determination.cpp
+++ b/redundant-bmc/src/role_determination.cpp
@@ -7,14 +7,50 @@
 namespace rbmc::role_determination
 {
 
-Role run(const Input& input)
+RoleInfo run(const Input& input)
 {
+    // Must check this before any other sibling fields
+    if (!input.siblingHeartbeat)
+    {
+        lg2::info("Role = active due to no sibling heartbeat");
+        return {Role::Active, ErrorCase::noError};
+    }
+
+    if (input.bmcPosition == input.siblingPosition)
+    {
+        lg2::error(
+            "Role = passive due to both BMC's having the same position {POSITION}",
+            "POSITION", input.bmcPosition);
+        return {Role::Passive, ErrorCase::samePositions};
+    }
+
+    if (!input.siblingProvisioned)
+    {
+        lg2::info("Role = active due to the sibling not being provisioned");
+        return {Role::Active, ErrorCase::noError};
+    }
+
+    if (input.siblingRole == Role::Passive)
+    {
+        lg2::info("Role = active due to the sibling already being passive");
+        return {Role::Active, ErrorCase::noError};
+    }
+
+    if (input.siblingRole == Role::Active)
+    {
+        lg2::info("Role = passive due to the sibling already being active");
+        return {Role::Passive, ErrorCase::noError};
+    }
+
     if (input.bmcPosition == 0)
     {
         lg2::info("Role = active due to BMC position 0");
-        return Role::Active;
+        return {Role::Active, ErrorCase::noError};
     }
-    return Role::Passive;
+
+    lg2::info("Role = passive due to BMC position {POSITION}", "POSITION",
+              input.bmcPosition);
+    return {Role::Passive, ErrorCase::noError};
 }
 
 } // namespace rbmc::role_determination

--- a/redundant-bmc/src/role_determination.cpp
+++ b/redundant-bmc/src/role_determination.cpp
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "role_determination.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+namespace rbmc::role_determination
+{
+
+Role run(const Input& input)
+{
+    if (input.bmcPosition == 0)
+    {
+        lg2::info("Role = active due to BMC position 0");
+        return Role::Active;
+    }
+    return Role::Passive;
+}
+
+} // namespace rbmc::role_determination

--- a/redundant-bmc/src/role_determination.cpp
+++ b/redundant-bmc/src/role_determination.cpp
@@ -16,7 +16,7 @@ RoleInfo run(const Input& input)
         return {Role::Active, ErrorCase::noError};
     }
 
-    if (input.bmcPosition == input.siblingPosition)
+    else if (input.bmcPosition == input.siblingPosition)
     {
         lg2::error(
             "Role = passive due to both BMC's having the same position {POSITION}",
@@ -24,25 +24,37 @@ RoleInfo run(const Input& input)
         return {Role::Passive, ErrorCase::samePositions};
     }
 
-    if (!input.siblingProvisioned)
+    else if (!input.siblingProvisioned)
     {
         lg2::info("Role = active due to the sibling not being provisioned");
         return {Role::Active, ErrorCase::noError};
     }
 
-    if (input.siblingRole == Role::Passive)
+    else if (input.siblingRole == Role::Passive)
     {
         lg2::info("Role = active due to the sibling already being passive");
         return {Role::Active, ErrorCase::noError};
     }
 
-    if (input.siblingRole == Role::Active)
+    else if (input.siblingRole == Role::Active)
     {
         lg2::info("Role = passive due to the sibling already being active");
         return {Role::Passive, ErrorCase::noError};
     }
 
-    if (input.bmcPosition == 0)
+    else if (input.previousRole == Role::Active)
+    {
+        lg2::info("Role = active due to that was the previous role");
+        return {Role::Active, ErrorCase::noError};
+    }
+
+    else if (input.previousRole == Role::Passive)
+    {
+        lg2::info("Role = passive due to that was the previous role");
+        return {Role::Passive, ErrorCase::noError};
+    }
+
+    else if (input.bmcPosition == 0)
     {
         lg2::info("Role = active due to BMC position 0");
         return {Role::Active, ErrorCase::noError};

--- a/redundant-bmc/src/role_determination.cpp
+++ b/redundant-bmc/src/role_determination.cpp
@@ -5,7 +5,7 @@
 namespace rbmc::role_determination
 {
 
-RoleInfo run(const Input& input)
+RoleInfo determineRole(const Input& input)
 {
     RoleInfo result;
 

--- a/redundant-bmc/src/role_determination.hpp
+++ b/redundant-bmc/src/role_determination.hpp
@@ -18,6 +18,32 @@ namespace role_determination
 struct Input
 {
     size_t bmcPosition;
+    size_t siblingPosition;
+    Role siblingRole;
+    bool siblingHeartbeat;
+    bool siblingProvisioned;
+};
+
+/**
+ * @brief Role determination error cases.
+ */
+enum class ErrorCase
+{
+    noError,
+    internalError,
+    samePositions
+};
+
+/**
+ * @brief The role and the error reason returned from run()
+ */
+struct RoleInfo
+{
+    Role role;
+    ErrorCase error;
+
+    // use the default <, ==, > operators for compares
+    auto operator<=>(const RoleInfo&) const = default;
 };
 
 /**
@@ -25,9 +51,9 @@ struct Input
  *
  * @param[in] input  - The structure of inputs
  *
- * @return The role
+ * @return The role and error case
  */
-Role run(const Input& input);
+RoleInfo run(const Input& input);
 
 } // namespace role_determination
 

--- a/redundant-bmc/src/role_determination.hpp
+++ b/redundant-bmc/src/role_determination.hpp
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
+
+namespace rbmc
+{
+
+using Role =
+    sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy::Role;
+
+namespace role_determination
+{
+
+/**
+ * @brief Inputs to the role determination function.
+ */
+struct Input
+{
+    size_t bmcPosition;
+};
+
+/**
+ * @brief Determines if this BMC should claim the Active or Passive role.
+ *
+ * @param[in] input  - The structure of inputs
+ *
+ * @return The role
+ */
+Role run(const Input& input);
+
+} // namespace role_determination
+
+} // namespace rbmc

--- a/redundant-bmc/src/role_determination.hpp
+++ b/redundant-bmc/src/role_determination.hpp
@@ -18,6 +18,7 @@ namespace role_determination
 struct Input
 {
     size_t bmcPosition;
+    Role previousRole;
     size_t siblingPosition;
     Role siblingRole;
     bool siblingHeartbeat;

--- a/redundant-bmc/src/role_determination.hpp
+++ b/redundant-bmc/src/role_determination.hpp
@@ -26,24 +26,31 @@ struct Input
 };
 
 /**
- * @brief Role determination error cases.
+ * @brief The reason the role is what it is.
  */
-enum class ErrorCase
+enum class RoleReason
 {
-    noError,
-    internalError,
+    unknown,
+    noSiblingHeartbeat,
     samePositions,
+    siblingNotProvisioned,
+    siblingPassive,
+    siblingActive,
+    resumePrevious,
+    positionZero,
+    positionNonzero,
     notProvisioned,
-    noSiblingService
+    siblingServiceNotRunning,
+    exception
 };
 
 /**
- * @brief The role and the error reason returned from run()
+ * @brief The role and the reason returned from run()
  */
 struct RoleInfo
 {
     Role role;
-    ErrorCase error;
+    RoleReason reason;
 
     // use the default <, ==, > operators for compares
     auto operator<=>(const RoleInfo&) const = default;
@@ -57,6 +64,19 @@ struct RoleInfo
  * @return The role and error case
  */
 RoleInfo run(const Input& input);
+
+/**
+ * @brief Return the string description of the reason
+ *
+ * @return The human readable description.
+ */
+std::string getRoleReasonDescription(RoleReason reason);
+
+/**
+ * @brief If the reason is an error case that requires the
+ *        BMC to be passive.
+ */
+bool isErrorReason(RoleReason reason);
 
 } // namespace role_determination
 

--- a/redundant-bmc/src/role_determination.hpp
+++ b/redundant-bmc/src/role_determination.hpp
@@ -45,7 +45,7 @@ enum class RoleReason
 };
 
 /**
- * @brief The role and the reason returned from run()
+ * @brief The role and the reason returned from determineRole()
  */
 struct RoleInfo
 {
@@ -63,7 +63,7 @@ struct RoleInfo
  *
  * @return The role and error case
  */
-RoleInfo run(const Input& input);
+RoleInfo determineRole(const Input& input);
 
 /**
  * @brief Return the string description of the reason

--- a/redundant-bmc/src/role_determination.hpp
+++ b/redundant-bmc/src/role_determination.hpp
@@ -32,7 +32,9 @@ enum class ErrorCase
 {
     noError,
     internalError,
-    samePositions
+    samePositions,
+    notProvisioned,
+    noSiblingService
 };
 
 /**

--- a/redundant-bmc/src/role_handler.hpp
+++ b/redundant-bmc/src/role_handler.hpp
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "services.hpp"
+
+#include <sdbusplus/async.hpp>
+
+namespace rbmc
+{
+
+/**
+ * @class RoleHandler
+ *
+ * This is the base class for the active and passive role
+ * handler classes, which will handle all of the role specific
+ * code.
+ */
+class RoleHandler
+{
+  public:
+    RoleHandler() = delete;
+    virtual ~RoleHandler() = default;
+    RoleHandler(const RoleHandler&) = delete;
+    RoleHandler& operator=(const RoleHandler&) = delete;
+    RoleHandler(RoleHandler&&) = delete;
+    RoleHandler& operator=(RoleHandler&&) = delete;
+
+    /**
+     * @brief Constructor
+     *
+     * @param[in] ctx - The async context object
+     * @param[in] services - The services object
+     */
+    RoleHandler(sdbusplus::async::context& ctx,
+                std::unique_ptr<Services>& services) :
+        ctx(ctx), services(services)
+    {}
+
+    /**
+     * @brief Pure virtual function to start the handler
+     *        in an async context.
+     */
+    virtual sdbusplus::async::task<> start() = 0;
+
+  protected:
+    /**
+     * @brief The async context object
+     */
+    sdbusplus::async::context& ctx;
+
+    /**
+     * @brief The services object
+     */
+    std::unique_ptr<Services>& services;
+};
+
+} // namespace rbmc

--- a/redundant-bmc/src/role_handler.hpp
+++ b/redundant-bmc/src/role_handler.hpp
@@ -53,6 +53,14 @@ class RoleHandler
      */
     virtual void siblingRedEnabledHandler(bool /*enable*/) {};
 
+    /**
+     * @brief Handler for the DisableRedundancyOverride
+     *        property changing.
+     *
+     * @param[in] disable - The new disable value.
+     */
+    virtual void disableRedPropChanged(bool disable) = 0;
+
   protected:
     /**
      * @brief The async context object

--- a/redundant-bmc/src/role_handler.hpp
+++ b/redundant-bmc/src/role_handler.hpp
@@ -47,6 +47,12 @@ class RoleHandler
      */
     virtual sdbusplus::async::task<> start() = 0;
 
+    /**
+     * @brief Handler for the RedundancyEnabled property
+     *        on the sibling's D-Bus interface changing.
+     */
+    virtual void siblingRedEnabledHandler(bool /*enable*/) {};
+
   protected:
     /**
      * @brief The async context object

--- a/redundant-bmc/src/role_handler.hpp
+++ b/redundant-bmc/src/role_handler.hpp
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "redundancy_interface.hpp"
 #include "services.hpp"
-
-#include <sdbusplus/async.hpp>
+#include "sibling.hpp"
 
 namespace rbmc
 {
+using Role =
+    sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy::Role;
 
 /**
  * @class RoleHandler
@@ -30,10 +32,13 @@ class RoleHandler
      *
      * @param[in] ctx - The async context object
      * @param[in] services - The services object
+     * @param[in] sibling - The sibling object
+     * @param[in] iface - The redundancy D-Bus interface object
      */
-    RoleHandler(sdbusplus::async::context& ctx,
-                std::unique_ptr<Services>& services) :
-        ctx(ctx), services(services)
+    RoleHandler(sdbusplus::async::context& ctx, Services& services,
+                Sibling& sibling, RedundancyInterface& iface) :
+        ctx(ctx), services(services), sibling(sibling),
+        redundancyInterface(iface)
     {}
 
     /**
@@ -51,7 +56,17 @@ class RoleHandler
     /**
      * @brief The services object
      */
-    std::unique_ptr<Services>& services;
+    Services& services;
+
+    /**
+     * @brief The Sibling object
+     */
+    Sibling& sibling;
+
+    /**
+     * @brief The Redundancy D-Bus interface
+     */
+    RedundancyInterface& redundancyInterface;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -1,0 +1,37 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#pragma once
+#include <sdbusplus/async.hpp>
+
+namespace rbmc
+{
+
+/**
+ * @class Services
+ *
+ * This is the base class interface for dealing with system
+ * information, so that the details on how to obtain the data
+ * are abtracted away from the business logic.
+ *
+ * In addition to a derived class the implements the functionality,
+ * a mock version of the class can be used in unit test.
+ *
+ */
+class Services
+{
+  public:
+    Services() = default;
+    virtual ~Services() = default;
+    Services(const Services&) = delete;
+    Services& operator=(const Services&) = delete;
+    Services(Services&&) = delete;
+    Services& operator=(Services&&) = delete;
+
+    /**
+     * @brief Returns this BMC's position.
+     *
+     * @return - The position
+     */
+    virtual size_t getBMCPosition() const = 0;
+};
+
+} // namespace rbmc

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -27,6 +27,13 @@ class Services
     Services& operator=(Services&&) = delete;
 
     /**
+     * @brief Sets up the D-Bus matches
+     *
+     * @return - The task object
+     */
+    virtual sdbusplus::async::task<> init() = 0;
+
+    /**
      * @brief Returns this BMC's position.
      *
      * @return - The position
@@ -68,6 +75,13 @@ class Services
      * @return - The version hash
      */
     virtual std::string getFWVersion() const = 0;
+
+    /**
+     * @brief Says if main power is on.
+     *
+     * @return If power is on
+     */
+    virtual bool isPoweredOn() const = 0;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -42,6 +42,23 @@ class Services
      */
     virtual sdbusplus::async::task<> startUnit(
         const std::string& unitName) const = 0;
+
+    /**
+     * @brief Gets the systemd unit state
+     *
+     * @param[in] - The unit/service name
+     *
+     * @return state - The systemd unit state
+     */
+    virtual sdbusplus::async::task<std::string> getUnitState(
+        const std::string& unitName) const = 0;
+
+    /**
+     * @brief If this BMC has been provisioned
+     *
+     * @return bool - If provisioned or not.
+     */
+    virtual bool getProvisioned() const = 0;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -59,6 +59,15 @@ class Services
      * @return bool - If provisioned or not.
      */
     virtual bool getProvisioned() const = 0;
+
+    /**
+     * @brief Returns an 8 character hash of the FW version
+     *
+     * It's read out of the VERSION_ID field in /etc/os-release.
+     *
+     * @return - The version hash
+     */
+    virtual std::string getFWVersion() const = 0;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -32,6 +32,16 @@ class Services
      * @return - The position
      */
     virtual size_t getBMCPosition() const = 0;
+
+    /**
+     * @brief Starts a systemd unit
+     *
+     * Waits for it to be active or failed before returning.
+     *
+     * @param[in] unitName - The unit name
+     */
+    virtual sdbusplus::async::task<> startUnit(
+        const std::string& unitName) const = 0;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#include "services_impl.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+namespace rbmc
+{
+
+size_t ServicesImpl::getBMCPosition() const
+{
+    size_t bmcPosition = 0;
+
+    // NOTE:  This a temporary solution for simulation until the
+    // daemon that should be providing this information is in place.
+    // Most likely, this will then have to return a task<uint32_t>.
+
+    // Read it out of the bmc_position uboot environment variable
+    // This was written by a simulation script.
+    std::string cmd{"/sbin/fw_printenv -n bmc_position"};
+
+    // NOLINTBEGIN(cert-env33-c)
+    FILE* pipe = popen(cmd.c_str(), "r");
+    // NOLINTEND(cert-env33-c)
+    if (pipe == nullptr)
+    {
+        throw std::runtime_error("Error calling popen to get bmc_position");
+    }
+
+    std::string output;
+    std::array<char, 128> buffer;
+    while (fgets(buffer.data(), buffer.size(), pipe) != nullptr)
+    {
+        output.append(buffer.data());
+    }
+
+    int rc = pclose(pipe);
+    if (WEXITSTATUS(rc) != 0)
+    {
+        throw std::runtime_error{std::format(
+            "Error running cmd: {}, output = {}, rc = {}", cmd, output, rc)};
+    }
+
+    auto [_,
+          ec] = std::from_chars(&*output.begin(), &*output.end(), bmcPosition);
+    if (ec != std::errc())
+    {
+        throw std::runtime_error{
+            std::format("Could not extract position from {}: rc {}", output,
+                        std::to_underlying(ec))};
+    }
+
+    return bmcPosition;
+}
+
+} // namespace rbmc

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -6,6 +6,22 @@
 namespace rbmc
 {
 
+namespace object_path
+{
+constexpr auto systemd = "/org/freedesktop/systemd1";
+} // namespace object_path
+
+namespace interface
+{
+constexpr auto systemdMgr = "org.freedesktop.systemd1.Manager";
+constexpr auto systemdUnit = "org.freedesktop.systemd1.Unit";
+} // namespace interface
+
+namespace service
+{
+constexpr auto systemd = "org.freedesktop.systemd1";
+} // namespace service
+
 size_t ServicesImpl::getBMCPosition() const
 {
     size_t bmcPosition = 0;
@@ -50,6 +66,87 @@ size_t ServicesImpl::getBMCPosition() const
     }
 
     return bmcPosition;
+}
+
+// NOLINTBEGIN
+sdbusplus::async::task<sdbusplus::message::object_path>
+    ServicesImpl::getUnitPath(const std::string& unitName) const
+// NOLINTEND
+{
+    constexpr auto systemd = sdbusplus::async::proxy()
+                                 .service(service::systemd)
+                                 .path(object_path::systemd)
+                                 .interface(interface::systemdMgr);
+
+    co_return co_await systemd.call<sdbusplus::message::object_path>(
+        ctx, "GetUnit", unitName);
+}
+
+// NOLINTBEGIN
+sdbusplus::async::task<std::string> ServicesImpl::getUnitState(
+    const std::string& unitName) const
+// NOLINTEND
+{
+    try
+    {
+        auto unitPath = co_await getUnitPath(unitName);
+
+        auto systemd = sdbusplus::async::proxy()
+                           .service(service::systemd)
+                           .path(unitPath.str)
+                           .interface(interface::systemdUnit);
+        auto state =
+            co_await systemd.get_property<std::string>(ctx, "ActiveState");
+
+        co_return state;
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        // For some units systemd returns NoSuchUnit if it isn't running.
+        if ((e.name() == nullptr) ||
+            (std::string{e.name()} != "org.freedesktop.systemd1.NoSuchUnit"))
+        {
+            lg2::error(
+                "Unable to determine if {UNIT} is running: {ERROR}. Assuming it isn't.",
+                "UNIT", unitName, "ERROR", e.what());
+        }
+        else
+        {
+            lg2::debug("Got a NoSuchUnit error for {UNIT}", "UNIT", unitName);
+        }
+    }
+
+    co_return "inactive";
+}
+
+// NOLINTBEGIN
+sdbusplus::async::task<> ServicesImpl::startUnit(
+    const std::string& unitName) const
+// NOLINTEND
+{
+    using namespace std::chrono_literals;
+    constexpr auto systemd = sdbusplus::async::proxy()
+                                 .service(service::systemd)
+                                 .path(object_path::systemd)
+                                 .interface(interface::systemdMgr);
+
+    lg2::info("Starting unit {UNIT}", "UNIT", unitName);
+
+    co_await systemd.call<sdbusplus::message::object_path>(
+        ctx, "StartUnit", unitName, std::string{"replace"});
+
+    std::string state;
+
+    while ((state != "active") && (state != "failed"))
+    {
+        co_await sdbusplus::async::sleep_for(ctx, 1s);
+        state = co_await getUnitState(unitName);
+    }
+
+    lg2::info("Finished waiting for {UNIT} to start (result = {STATE})", "UNIT",
+              unitName, "STATE", state);
+
+    co_return;
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -149,4 +149,10 @@ sdbusplus::async::task<> ServicesImpl::startUnit(
     co_return;
 }
 
+bool ServicesImpl::getProvisioned() const
+{
+    // TODO: Eventually get this from somewhere.
+    return true;
+}
+
 } // namespace rbmc

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#pragma once
+
+#include "services.hpp"
+
+namespace rbmc
+{
+
+/**
+ * @class ServicesImpl
+ *
+ * Implements the Services functions to interact
+ * with the system.
+ *
+ */
+class ServicesImpl : public Services
+{
+  public:
+    ServicesImpl() = default;
+    ~ServicesImpl() override = default;
+    ServicesImpl(const ServicesImpl&) = delete;
+    ServicesImpl& operator=(const ServicesImpl&) = delete;
+    ServicesImpl(ServicesImpl&&) = delete;
+    ServicesImpl& operator=(ServicesImpl&&) = delete;
+
+    /**
+     * @brief Returns this BMC's position.
+     *
+     * @return - The position
+     */
+    size_t getBMCPosition() const override;
+};
+
+} // namespace rbmc

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -47,6 +47,23 @@ class ServicesImpl : public Services
     sdbusplus::async::task<> startUnit(
         const std::string& unitName) const override;
 
+    /**
+     * @brief Gets the systemd unit state
+     *
+     * @param[in] - The unit/service name
+     *
+     * @return state - The systemd unit state
+     */
+    sdbusplus::async::task<std::string> getUnitState(
+        const std::string& name) const override;
+
+    /**
+     * @brief If this BMC has been provisioned
+     *
+     * @return bool - If provisioned or not.
+     */
+    bool getProvisioned() const override;
+
   private:
     /**
      * @brief Returns the D-Bus object path for the unit in the
@@ -58,16 +75,6 @@ class ServicesImpl : public Services
      */
     sdbusplus::async::task<sdbusplus::message::object_path> getUnitPath(
         const std::string& unitName) const;
-
-    /**
-     * @brief Gets the systemd unit state
-     *
-     * @param[in] - The unit/service name
-     *
-     * @return state - The systemd unit state
-     */
-    sdbusplus::async::task<std::string> getUnitState(
-        const std::string& name) const;
 
     /**
      * @brief The async context object

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -31,6 +31,11 @@ class ServicesImpl : public Services
     explicit ServicesImpl(sdbusplus::async::context& ctx) : ctx(ctx) {}
 
     /**
+     * @brief Sets up watches on the host state
+     */
+    sdbusplus::async::task<> init() override;
+
+    /**
      * @brief Returns this BMC's position.
      *
      * @return - The position
@@ -73,6 +78,13 @@ class ServicesImpl : public Services
      */
     std::string getFWVersion() const override;
 
+    /**
+     * @brief Says if main power is on.
+     *
+     * @return If power is on
+     */
+    bool isPoweredOn() const override;
+
   private:
     /**
      * @brief Returns the D-Bus object path for the unit in the
@@ -86,9 +98,32 @@ class ServicesImpl : public Services
         const std::string& unitName) const;
 
     /**
+     * @brief Starts the InterfacesAdded watch for the host state
+     */
+    sdbusplus::async::task<> watchHostInterfacesAdded();
+
+    /**
+     * @brief Starts the PropertiesChanged watch for the host state
+     */
+    sdbusplus::async::task<> watchHostPropertiesChanged();
+
+    /**
+     * @brief Reads the CurrentHostState property
+     */
+    sdbusplus::async::task<> readHostState();
+
+    /**
      * @brief The async context object
      */
     sdbusplus::async::context& ctx;
+
+    /**
+     * @brief If the host is powered on
+     *
+     * Only valid after the host state service has been started.
+     * Will throw if called before then.
+     */
+    std::optional<bool> poweredOn;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -64,6 +64,15 @@ class ServicesImpl : public Services
      */
     bool getProvisioned() const override;
 
+    /**
+     * @brief Returns an 8 character hash of the FW version
+     *
+     * It's read out of the VERSION_ID field in /etc/os-release.
+     *
+     * @return - The version hash
+     */
+    std::string getFWVersion() const override;
+
   private:
     /**
      * @brief Returns the D-Bus object path for the unit in the

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -16,7 +16,7 @@ namespace rbmc
 class ServicesImpl : public Services
 {
   public:
-    ServicesImpl() = default;
+    ServicesImpl() = delete;
     ~ServicesImpl() override = default;
     ServicesImpl(const ServicesImpl&) = delete;
     ServicesImpl& operator=(const ServicesImpl&) = delete;
@@ -24,11 +24,55 @@ class ServicesImpl : public Services
     ServicesImpl& operator=(ServicesImpl&&) = delete;
 
     /**
+     * @brief Constructor
+     *
+     * @param[in] ctx - The async context object
+     */
+    explicit ServicesImpl(sdbusplus::async::context& ctx) : ctx(ctx) {}
+
+    /**
      * @brief Returns this BMC's position.
      *
      * @return - The position
      */
     size_t getBMCPosition() const override;
+
+    /**
+     * @brief Starts a systemd unit
+     *
+     * Waits for it to be active or failed before returning.
+     *
+     * @param[in] unitName - The unit name
+     */
+    sdbusplus::async::task<> startUnit(
+        const std::string& unitName) const override;
+
+  private:
+    /**
+     * @brief Returns the D-Bus object path for the unit in the
+     *        systemd namespace.
+     *
+     * @param[in] unitName - The unit name, like obmc-bmc-active.target
+     *
+     * @return object_path - The systemd D-Bus object path
+     */
+    sdbusplus::async::task<sdbusplus::message::object_path> getUnitPath(
+        const std::string& unitName) const;
+
+    /**
+     * @brief Gets the systemd unit state
+     *
+     * @param[in] - The unit/service name
+     *
+     * @return state - The systemd unit state
+     */
+    sdbusplus::async::task<std::string> getUnitState(
+        const std::string& name) const;
+
+    /**
+     * @brief The async context object
+     */
+    sdbusplus::async::context& ctx;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -69,6 +69,12 @@ class Sibling
         const std::chrono::seconds& timeout) = 0;
 
     /**
+     * @brief Waits for the sibling role to change, assuming that the
+     *        sibling is alive and hasn't determined a role yet.
+     */
+    virtual sdbusplus::async::task<> waitForSiblingRole() = 0;
+
+    /**
      * @brief Returns the sibling BMC's position
      *
      * @return - The position or nullopt if not available

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -30,6 +30,7 @@ class Sibling
         sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState;
     using RedundancyEnabledCallback = std::function<void(bool)>;
     using BMCStateCallback = std::function<void(BMCState)>;
+    using HeartbeatCallback = std::function<void(bool)>;
 
     Sibling() = default;
     virtual ~Sibling() = default;
@@ -139,7 +140,7 @@ class Sibling
     virtual bool isBMCPresent() = 0;
 
     /**
-     * @brief Clears callbacks held by the name
+     * @brief Clears callbacks held based on role
      *
      * @param[in] role - The role to clear
      */
@@ -147,6 +148,7 @@ class Sibling
     {
         redEnabledCBs.erase(role);
         clearBMCStateCallback(role);
+        clearHeartbeatCallback(role);
     }
 
     /**
@@ -157,6 +159,16 @@ class Sibling
     void clearBMCStateCallback(Role role)
     {
         bmcStateCBs.erase(role);
+    }
+
+    /**
+     * @brief Clears the heartbeat callback
+     *
+     * @param[in] role - The role to clear
+     */
+    void clearHeartbeatCallback(Role role)
+    {
+        heartbeatCBs.erase(role);
     }
 
     /**
@@ -184,6 +196,18 @@ class Sibling
         bmcStateCBs.emplace(role, std::move(callback));
     }
 
+    /**
+     * @brief Adds a callback function to invoke when the sibling's
+     *        Heartbeat property changes
+     *
+     * @param[in] role - The role to register with
+     * @param[in] callback - The callback function
+     */
+    void addHeartbeatCallback(Role role, HeartbeatCallback callback)
+    {
+        heartbeatCBs.emplace(role, std::move(callback));
+    }
+
   protected:
     /**
      * @brief Callbacks for RedundancyEnabled
@@ -194,5 +218,10 @@ class Sibling
      * @brief Callbacks for BMCState
      */
     std::map<Role, BMCStateCallback> bmcStateCBs;
+
+    /**
+     * @brief Callbacks for Heartbeat
+     */
+    std::map<Role, HeartbeatCallback> heartbeatCBs;
 };
 } // namespace rbmc

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -28,6 +28,7 @@ class Sibling
         sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy::Role;
     using BMCState =
         sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState;
+    using RedundancyEnabledCallback = std::function<void(bool)>;
 
     Sibling() = default;
     virtual ~Sibling() = default;
@@ -135,5 +136,34 @@ class Sibling
      * @return bool - if present
      */
     virtual bool isBMCPresent() = 0;
+
+    /**
+     * @brief Clears callbacks held by the name
+     *
+     * @param[in] role - The role to clear
+     */
+    void clearCallbacks(Role role)
+    {
+        redEnabledCBs.erase(role);
+    }
+
+    /**
+     * @brief Adds a callback function to invoke when the sibling's
+     *        RedundancyEnabled property changes
+     *
+     * @param[in] role - The role, used as a key into the map
+     * @param[in] callback - The callback function
+     */
+    void addRedundancyEnabledCallback(Role role,
+                                      RedundancyEnabledCallback callback)
+    {
+        redEnabledCBs.emplace(role, std::move(callback));
+    }
+
+  protected:
+    /**
+     * @brief Callbacks for RedundancyEnabled
+     */
+    std::map<Role, RedundancyEnabledCallback> redEnabledCBs;
 };
 } // namespace rbmc

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -29,6 +29,7 @@ class Sibling
     using BMCState =
         sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState;
     using RedundancyEnabledCallback = std::function<void(bool)>;
+    using BMCStateCallback = std::function<void(BMCState)>;
 
     Sibling() = default;
     virtual ~Sibling() = default;
@@ -145,13 +146,24 @@ class Sibling
     void clearCallbacks(Role role)
     {
         redEnabledCBs.erase(role);
+        clearBMCStateCallback(role);
+    }
+
+    /**
+     * @brief Clears the BMC state callback
+     *
+     * @param[in] role - The role to clear
+     */
+    void clearBMCStateCallback(Role role)
+    {
+        bmcStateCBs.erase(role);
     }
 
     /**
      * @brief Adds a callback function to invoke when the sibling's
      *        RedundancyEnabled property changes
      *
-     * @param[in] role - The role, used as a key into the map
+     * @param[in] role - The role to register with
      * @param[in] callback - The callback function
      */
     void addRedundancyEnabledCallback(Role role,
@@ -160,10 +172,27 @@ class Sibling
         redEnabledCBs.emplace(role, std::move(callback));
     }
 
+    /**
+     * @brief Adds a callback function to invoke when the sibling's
+     *        Heartbeat property changes
+     *
+     * @param[in] role - The role to register with
+     * @param[in] callback - The callback function
+     */
+    void addBMCStateCallback(Role role, BMCStateCallback callback)
+    {
+        bmcStateCBs.emplace(role, std::move(callback));
+    }
+
   protected:
     /**
      * @brief Callbacks for RedundancyEnabled
      */
     std::map<Role, RedundancyEnabledCallback> redEnabledCBs;
+
+    /**
+     * @brief Callbacks for BMCState
+     */
+    std::map<Role, BMCStateCallback> bmcStateCBs;
 };
 } // namespace rbmc

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -1,0 +1,121 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#pragma once
+#include <sdbusplus/async.hpp>
+#include <xyz/openbmc_project/State/BMC/Redundancy/Sibling/client.hpp>
+#include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
+#include <xyz/openbmc_project/State/BMC/common.hpp>
+
+namespace rbmc
+{
+
+/**
+ * @class Sibling
+ *
+ * Provides information about the Sibling BMC, getting it from
+ * xyz.openbmc_project.State.BMC.Redundancy.Sibling.
+ *
+ * Will only provide data value when that Sibling interface is
+ * present with the heartbeat property true, meaning the code
+ * running on the sibling is alive.
+ *
+ * This is a pure virtual base class, so that these functions can
+ * be mocked in test.
+ */
+class Sibling
+{
+  public:
+    using Role =
+        sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy::Role;
+    using BMCState =
+        sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState;
+
+    Sibling() = default;
+    virtual ~Sibling() = default;
+    Sibling(const Sibling&) = delete;
+    Sibling& operator=(const Sibling&) = delete;
+    Sibling(Sibling&&) = delete;
+    Sibling& operator=(Sibling&&) = delete;
+
+    /**
+     * @brief Returns if the Sibling interface is on D-Bus
+     */
+    virtual bool getInterfacePresent() const = 0;
+
+    /**
+     * @brief Sets up the D-Bus matches
+     *
+     * @return - The task object
+     */
+    virtual sdbusplus::async::task<> init() = 0;
+
+    /**
+     * @brief Returns if the sibling heartbeat is active
+     */
+    virtual bool hasHeartbeat() const = 0;
+
+    /**
+     * @brief Waits up to 'timeout' for the sibling interface to
+     *        be on D-Bus and have the heartbeat property active.
+     *
+     * @return - The task object
+     */
+    virtual sdbusplus::async::task<> waitForSiblingUp(
+        const std::chrono::seconds& timeout) = 0;
+
+    /**
+     * @brief Returns the sibling BMC's position
+     *
+     * @return - The position or nullopt if not available
+     */
+    virtual std::optional<size_t> getPosition() const = 0;
+
+    /**
+     * @brief Returns the sibling BMC's state
+     *
+     * @return - The state or nullopt if not available
+     */
+    virtual std::optional<BMCState> getBMCState() const = 0;
+
+    /**
+     * @brief Returns the sibling BMC's role
+     *
+     * @return - The role, or nullopt if not available
+     */
+    virtual std::optional<Role> getRole() const = 0;
+
+    /**
+     * @brief Returns if the sibling has redundancy enabled.
+     *
+     * @return - If enabled, or nullopt if not available
+     */
+    virtual std::optional<bool> getRedundancyEnabled() const = 0;
+
+    /**
+     * @brief Returns the sibling BMC's provisioning status
+     *
+     * @return - The status, or nullopt if not available
+     */
+    virtual std::optional<bool> getProvisioned() const = 0;
+
+    /**
+     * @brief Returns the sibling BMC's FW version representation
+     *
+     * @return - The version, or nullopt if not available
+     */
+    virtual std::optional<std::string> getFWVersion() const = 0;
+
+    /**
+     * @brief Returns the sibling BMC's commsOK value
+     *
+     * @return - The value, or nullopt if not available
+     */
+    virtual std::optional<bool> getSiblingCommsOK() const = 0;
+
+    /**
+     * @brief Returns if the sibling BMC is plugged in
+     *
+     * @return bool - if present
+     */
+    virtual bool isBMCPresent() = 0;
+};
+} // namespace rbmc

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -75,6 +75,12 @@ class Sibling
     virtual sdbusplus::async::task<> waitForSiblingRole() = 0;
 
     /**
+     * @brief Waits for up to 10 minutes for the sibling BMC to
+     *        reach steady state - either Ready or Quiesced.
+     */
+    virtual sdbusplus::async::task<> waitForBMCSteadyState() const = 0;
+
+    /**
      * @brief Returns the sibling BMC's position
      *
      * @return - The position or nullopt if not available

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -37,6 +37,12 @@ class Sibling
     Sibling& operator=(Sibling&&) = delete;
 
     /**
+     * @brief The name of the unit/service.
+     */
+    static constexpr auto unitName =
+        "xyz.openbmc_project.State.BMC.Redundancy.Sibling.service";
+
+    /**
      * @brief Returns if the Sibling interface is on D-Bus
      */
     virtual bool getInterfacePresent() const = 0;

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -141,7 +141,15 @@ void SiblingImpl::loadFromPropertyMap(
     it = propertyMap.find("BMCState");
     if (it != propertyMap.end())
     {
+        auto old = bmcState;
         bmcState = std::get<BMCState>(it->second);
+        if (bmcState != old)
+        {
+            for (const auto& callback : std::ranges::views::values(bmcStateCBs))
+            {
+                callback(bmcState);
+            }
+        }
     }
 
     it = propertyMap.find("Role");

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -167,7 +167,16 @@ void SiblingImpl::loadFromPropertyMap(
     it = propertyMap.find("Heartbeat");
     if (it != propertyMap.end())
     {
+        auto old = heartbeat;
         heartbeat = std::get<bool>(it->second);
+        if (old != heartbeat)
+        {
+            for (const auto& callback :
+                 std::ranges::views::values(heartbeatCBs))
+            {
+                callback(heartbeat);
+            }
+        }
     }
 }
 

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -1,0 +1,302 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#include "sibling_impl.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+#include <xyz/openbmc_project/ObjectMapper/client.hpp>
+
+namespace rbmc
+{
+
+bool SiblingImpl::isBMCPresent()
+{
+    // TODO: Actually check this.
+    // May also need to check if it has Vcs PGOOD.
+    return true;
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> SiblingImpl::init()
+{
+    if (initialized)
+    {
+        lg2::info("Sibling::init called more than once");
+        co_return;
+    }
+
+    // Start the D-Bus watches for the signals that don't
+    // need a service name.
+    ctx.spawn(watchInterfaceAdded());
+    ctx.spawn(watchInterfaceRemoved());
+    ctx.spawn(watchPropertyChanged());
+
+    // Attempt to get the D-Bus service name.  It would only
+    // be there if the sibling BMC is present.
+    serviceName = co_await getServiceName();
+
+    if (!serviceName.empty())
+    {
+        // Sibling interface is there, so start the NameOwnerChanged
+        // watch and read the initial property values.
+        interfacePresent = true;
+        ctx.spawn(watchNameOwnerChanged());
+
+        try
+        {
+            auto sibling = sdbusplus::async::proxy()
+                               .service(serviceName)
+                               .path(objectPath)
+                               .interface(redundancy_ns::Sibling::interface);
+            auto props = co_await sibling.get_all_properties<
+                redundancy_ns::Sibling::PropertiesVariant>(ctx);
+
+            loadFromPropertyMap(props);
+        }
+        catch (const sdbusplus::exception_t& e)
+        {
+            lg2::error("Failed reading sibling properties: {ERROR}", "ERROR",
+                       e);
+            interfacePresent = false;
+        }
+    }
+    else
+    {
+        // Sibling interface not on D-Bus.
+        interfacePresent = false;
+    }
+
+    lg2::info("In Sibling init, interface present is {PRESENT}", "PRESENT",
+              interfacePresent);
+
+    initialized = true;
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<std::string> SiblingImpl::getServiceName()
+{
+    using ObjectMapper =
+        sdbusplus::client::xyz::openbmc_project::ObjectMapper<>;
+
+    try
+    {
+        auto mapper = ObjectMapper(ctx)
+                          .service(ObjectMapper::default_service)
+                          .path(ObjectMapper::instance_path);
+
+        std::vector<std::string> interface{redundancy_ns::Sibling::interface};
+        auto object = co_await mapper.get_object(objectPath, interface);
+        co_return object.begin()->first;
+    }
+    catch (const sdbusplus::exception_t&)
+    {}
+
+    co_return std::string{};
+}
+
+// namespace util
+
+void SiblingImpl::loadFromPropertyMap(
+    const SiblingImpl::PropertyMap& propertyMap)
+{
+    auto it = propertyMap.find("BMCPosition");
+    if (it != propertyMap.end())
+    {
+        bmcPosition = std::get<size_t>(it->second);
+    }
+
+    it = propertyMap.find("FWVersion");
+    if (it != propertyMap.end())
+    {
+        fwVersion = std::get<std::string>(it->second);
+    }
+
+    it = propertyMap.find("Provisioned");
+    if (it != propertyMap.end())
+    {
+        provisioned = std::get<bool>(it->second);
+    }
+
+    it = propertyMap.find("RedundancyEnabled");
+    if (it != propertyMap.end())
+    {
+        redEnabled = std::get<bool>(it->second);
+    }
+
+    it = propertyMap.find("FailoversPaused");
+    if (it != propertyMap.end())
+    {
+        failoversPaused = std::get<bool>(it->second);
+    }
+
+    it = propertyMap.find("BMCState");
+    if (it != propertyMap.end())
+    {
+        bmcState = std::get<BMCState>(it->second);
+    }
+
+    it = propertyMap.find("Role");
+    if (it != propertyMap.end())
+    {
+        role = std::get<Role>(it->second);
+    }
+
+    it = propertyMap.find("CommunicationOK");
+    if (it != propertyMap.end())
+    {
+        commsOK = std::get<bool>(it->second);
+    }
+
+    it = propertyMap.find("Heartbeat");
+    if (it != propertyMap.end())
+    {
+        heartbeat = std::get<bool>(it->second);
+    }
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> SiblingImpl::watchInterfaceAdded()
+{
+    namespace rules = sdbusplus::bus::match::rules;
+    sdbusplus::async::match match(ctx,
+                                  rules::interfacesAddedAtPath(objectPath));
+
+    while (!ctx.stop_requested())
+    {
+        auto [_, interfaces] =
+            co_await match
+                .next<sdbusplus::message::object_path, InterfaceMap>();
+
+        auto it = interfaces.find(redundancy_ns::Sibling::interface);
+        if (it != interfaces.end())
+        {
+            lg2::info("Sibling D-Bus interface added");
+            loadFromPropertyMap(it->second);
+            interfacePresent = true;
+
+            // If first time seen, wait for the service name to get into
+            // the mapper and then start the nameOwnerChanged watch.
+            if (serviceName.empty())
+            {
+                const size_t mapperRetries = 200;
+                size_t count = 0;
+
+                do
+                {
+                    using namespace std::chrono_literals;
+                    co_await sdbusplus::async::sleep_for(ctx, 100ms);
+                    serviceName = co_await getServiceName();
+                    lg2::info(
+                        "After interfacesAdded, sibling service is {SERVICE}",
+                        "SERVICE", serviceName);
+                } while (serviceName.empty() && (count++ < mapperRetries));
+
+                if (!serviceName.empty())
+                {
+                    ctx.spawn(watchNameOwnerChanged());
+                }
+            }
+        }
+    }
+    co_return;
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> SiblingImpl::watchInterfaceRemoved()
+{
+    namespace rules = sdbusplus::bus::match::rules;
+    sdbusplus::async::match match(ctx,
+                                  rules::interfacesRemovedAtPath(objectPath));
+
+    while (!ctx.stop_requested())
+    {
+        auto [_, interfaces] =
+            co_await match.next<sdbusplus::message::object_path,
+                                std::vector<std::string>>();
+
+        if (std::ranges::contains(interfaces,
+                                  redundancy_ns::Sibling::interface))
+        {
+            lg2::info("Sibling D-Bus interface removed");
+            interfacePresent = false;
+            heartbeat = false;
+        }
+    }
+
+    co_return;
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> SiblingImpl::watchPropertyChanged()
+{
+    namespace rules = sdbusplus::bus::match::rules;
+    sdbusplus::async::match match(
+        ctx, rules::propertiesChanged(objectPath,
+                                      redundancy_ns::Sibling::interface));
+
+    while (!ctx.stop_requested())
+    {
+        auto [iface,
+              propertyMap] = co_await match.next<std::string, PropertyMap>();
+
+        for (const auto& [name, value] : propertyMap)
+        {
+            lg2::info("Sibling property {PROP} changed", "PROP", name);
+        }
+
+        loadFromPropertyMap(propertyMap);
+    }
+
+    co_return;
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> SiblingImpl::watchNameOwnerChanged()
+{
+    namespace rules = sdbusplus::bus::match::rules;
+    sdbusplus::async::match match(ctx, rules::nameOwnerChanged(serviceName));
+
+    while (!ctx.stop_requested())
+    {
+        auto [name, oldOwner, newOwner] =
+            co_await match.next<std::string, std::string, std::string>();
+
+        if (!oldOwner.empty() && newOwner.empty())
+        {
+            lg2::info("Sibling D-Bus name lost");
+            interfacePresent = false;
+            heartbeat = false;
+        }
+    }
+    co_return;
+}
+
+// NOLINTBEGIN
+sdbusplus::async::task<> SiblingImpl::waitForSiblingUp(
+    const std::chrono::seconds& timeout)
+// NOLINTEND
+{
+    using namespace std::chrono_literals;
+    auto start = std::chrono::steady_clock::now();
+    auto waiting = false;
+
+    while ((!interfacePresent || !heartbeat) &&
+           ((std::chrono::steady_clock::now() - start) < timeout))
+    {
+        if (!waiting)
+        {
+            lg2::info("Waiting for sibling interface and/or heartbeat: "
+                      "Present = {PRES}, Heartbeat = {HB}",
+                      "PRES", interfacePresent, "HB", heartbeat);
+            waiting = true;
+        }
+
+        co_await sdbusplus::async::sleep_for(ctx, 500ms);
+    }
+
+    lg2::info(
+        "Done waiting for sibling. Interface present = {PRES}, heartbeat = {HB}",
+        "PRES", interfacePresent, "HB", heartbeat);
+
+    co_return;
+}
+
+} // namespace rbmc

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -283,9 +283,11 @@ sdbusplus::async::task<> SiblingImpl::waitForSiblingUp(
     {
         if (!waiting)
         {
-            lg2::info("Waiting for sibling interface and/or heartbeat: "
-                      "Present = {PRES}, Heartbeat = {HB}",
-                      "PRES", interfacePresent, "HB", heartbeat);
+            lg2::info(
+                "Waiting up to {TIME}s for sibling interface and/or heartbeat: "
+                "Present = {PRES}, Heartbeat = {HB}",
+                "TIME", timeout.count(), "PRES", interfacePresent, "HB",
+                heartbeat);
             waiting = true;
         }
 

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -4,6 +4,8 @@
 #include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/ObjectMapper/client.hpp>
 
+#include <ranges>
+
 namespace rbmc
 {
 
@@ -118,7 +120,16 @@ void SiblingImpl::loadFromPropertyMap(
     it = propertyMap.find("RedundancyEnabled");
     if (it != propertyMap.end())
     {
+        auto old = redEnabled;
         redEnabled = std::get<bool>(it->second);
+        if (redEnabled != old)
+        {
+            for (const auto& callback :
+                 std::ranges::views::values(redEnabledCBs))
+            {
+                callback(redEnabled);
+            }
+        }
     }
 
     it = propertyMap.find("FailoversPaused");

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -74,6 +74,16 @@ class SiblingImpl : public Sibling
         const std::chrono::seconds& timeout) override;
 
     /**
+     * @brief Waits for the sibling role to change, assuming that the
+     *        sibling is alive and hasn't determined a role yet.
+     *
+     * This is used to give the previously active BMC a head start
+     * to be active again, which also avoids possible race conditions
+     * when they both come up at the same time.
+     */
+    sdbusplus::async::task<> waitForSiblingRole() override;
+
+    /**
      * @brief Returns the sibling BMC's position
      *
      * @return - The position or nullopt if not available

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -195,6 +195,12 @@ class SiblingImpl : public Sibling
      */
     bool isBMCPresent() override;
 
+    /**
+     * @brief Waits for up to 10 minutes for the sibling BMC to
+     *        reach steady state - either Ready or Quiesced.
+     */
+    sdbusplus::async::task<> waitForBMCSteadyState() const override;
+
   private:
     /**
      * @brief Starts a Sibling InterfacesAdded watch

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -1,0 +1,294 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#pragma once
+#include "sibling.hpp"
+
+namespace rbmc
+{
+
+namespace redundancy_ns =
+    sdbusplus::common::xyz::openbmc_project::state::bmc::redundancy;
+
+/**
+ * @class SiblingImpl
+ *
+ * Implements the Sibling functionality.  Provides cached
+ * access to the sibling data members, assuming the interface
+ * is on D-Bus and the heartbeat is active.
+ */
+class SiblingImpl : public Sibling
+{
+  public:
+    using PropertyMap =
+        std::unordered_map<std::string,
+                           redundancy_ns::Sibling::PropertiesVariant>;
+    using InterfaceMap = std::map<std::string, PropertyMap>;
+    using SiblingNP = redundancy_ns::Sibling::namespace_path;
+
+    SiblingImpl() = delete;
+    ~SiblingImpl() override = default;
+    SiblingImpl(const SiblingImpl&) = delete;
+    SiblingImpl& operator=(const SiblingImpl&) = delete;
+    SiblingImpl(SiblingImpl&&) = delete;
+    SiblingImpl& operator=(SiblingImpl&&) = delete;
+
+    /**
+     * @brief Constructor
+     *
+     * @param[in] ctx - The async context object
+     */
+    explicit SiblingImpl(sdbusplus::async::context& ctx) :
+        ctx(ctx),
+        objectPath(std::string{SiblingNP::value} + '/' + SiblingNP::bmc)
+    {}
+
+    /**
+     * @brief Returns if the Sibling interface is on D-Bus
+     */
+    bool getInterfacePresent() const override
+    {
+        return interfacePresent;
+    }
+
+    /**
+     * @brief Returns if the sibling heartbeat is active
+     */
+    bool hasHeartbeat() const override
+    {
+        return heartbeat;
+    }
+
+    /**
+     * @brief Sets up the D-Bus matches
+     *
+     * @return - The task object
+     */
+    sdbusplus::async::task<> init() override;
+
+    /**
+     * @brief Waits up to 'timeout' for the sibling interface to
+     *        be on D-Bus and have the heartbeat property active.
+     *
+     * @return - The task object
+     */
+    sdbusplus::async::task<> waitForSiblingUp(
+        const std::chrono::seconds& timeout) override;
+
+    /**
+     * @brief Returns the sibling BMC's position
+     *
+     * @return - The position or nullopt if not available
+     */
+    std::optional<size_t> getPosition() const override
+    {
+        if (interfacePresent && heartbeat)
+        {
+            return bmcPosition;
+        }
+
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Returns the sibling BMC's state
+     *
+     * @return - The state or nullopt if not available
+     */
+    std::optional<BMCState> getBMCState() const override
+    {
+        if (interfacePresent && heartbeat)
+        {
+            return bmcState;
+        }
+
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Returns the sibling BMC's role
+     *
+     * @return - The role, or nullopt if not available
+     */
+    std::optional<Role> getRole() const override
+    {
+        if (interfacePresent && heartbeat)
+        {
+            return role;
+        }
+
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Returns if the sibling has redundancy enabled.
+     *
+     * @return - If enabled, or nullopt if not available
+     */
+    std::optional<bool> getRedundancyEnabled() const override
+    {
+        if (interfacePresent && heartbeat)
+        {
+            return redEnabled;
+        }
+
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Returns the sibling BMC's provisioning status
+     *
+     * @return - The status, or nullopt if not available
+     */
+    std::optional<bool> getProvisioned() const override
+    {
+        if (interfacePresent && heartbeat)
+        {
+            return provisioned;
+        }
+
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Returns the sibling BMC's FW version representation
+     *
+     * @return - The version, or nullopt if not available
+     */
+    std::optional<std::string> getFWVersion() const override
+    {
+        if (interfacePresent && heartbeat)
+        {
+            return fwVersion;
+        }
+
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Returns the sibling BMC's commsOK value
+     *
+     * @return - The value, or nullopt if not available
+     */
+    std::optional<bool> getSiblingCommsOK() const override
+    {
+        if (interfacePresent && heartbeat)
+        {
+            return commsOK;
+        }
+
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Returns if the sibling BMC is plugged in
+     *
+     * @return bool - if present
+     */
+    bool isBMCPresent() override;
+
+  private:
+    /**
+     * @brief Starts a Sibling InterfacesAdded watch
+     */
+    sdbusplus::async::task<> watchInterfaceAdded();
+
+    /**
+     * @brief Starts a Sibling InterfacesRemoved watch
+     */
+    sdbusplus::async::task<> watchInterfaceRemoved();
+
+    /**
+     * @brief Starts a Sibling NameOwnerChanged watch
+     */
+    sdbusplus::async::task<> watchNameOwnerChanged();
+
+    /**
+     * @brief Starts a Sibling PropertyChanged watch
+     */
+    sdbusplus::async::task<> watchPropertyChanged();
+
+    /**
+     * @brief Sets data members with whatever is in the property map
+     *
+     * @param[in] propertyMap - The property name -> value map
+     */
+    void loadFromPropertyMap(const PropertyMap& propertyMap);
+
+    /**
+     * @brief Gets the sibling D-Bus service name from the mapper
+     *
+     * @return std::string - The service name
+     */
+    sdbusplus::async::task<std::string> getServiceName();
+
+    /**
+     * @brief The async context object
+     */
+    sdbusplus::async::context& ctx;
+
+    /**
+     * @brief The sibling's D-Bus service name.
+     */
+    std::string serviceName;
+
+    /**
+     * @brief If the Sibling interface is on D-Bus
+     */
+    bool interfacePresent = false;
+
+    /**
+     * @brief If init() has been called
+     */
+    bool initialized = false;
+
+    /**
+     * @brief The sibling's BMC position
+     */
+    size_t bmcPosition = 0;
+
+    /**
+     * @brief The sibling's FW version string
+     */
+    std::string fwVersion;
+
+    /**
+     * @brief The sibling's provisioning status
+     */
+    bool provisioned = false;
+
+    /**
+     * @brief The sibling's redundancy enabled field
+     */
+    bool redEnabled = false;
+
+    /**
+     * @brief If sibling failovers are paused
+     */
+    bool failoversPaused = false;
+
+    /**
+     * @brief The sibling's BMC state
+     */
+    BMCState bmcState{};
+
+    /**
+     * @brief The sibling's role
+     */
+    Role role = Role::Unknown;
+
+    /**
+     * @brief If the sibling can talk to this BMC
+     */
+    bool commsOK = false;
+
+    /**
+     * @brief If the sibling heartbeat is active.
+     */
+    bool heartbeat = false;
+
+    /**
+     * @brief The D-Bus object path for the sibling.
+     */
+    std::string objectPath;
+};
+
+} // namespace rbmc

--- a/redundant-bmc/src/timer.hpp
+++ b/redundant-bmc/src/timer.hpp
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <sdbusplus/async.hpp>
+
+namespace rbmc
+{
+
+/**
+ * @class Timer
+ *
+ * A single shot timer that works with sdbusplus::async::context's event loop.
+ */
+class Timer :
+    private sdbusplus::async::context_ref,
+    sdbusplus::async::details::context_friend
+{
+  public:
+    /**
+     * @brief Constructor
+     *
+     * @param[in] ctx - The async context object
+     * @param[in] callback - Function to call on expiration
+     */
+    Timer(sdbusplus::async::context& ctx, std::function<void()>&& callback) :
+        context_ref(ctx), callback(std::move(callback))
+    {}
+
+    /**
+     * @brief Called by sd-event when time expires. Invokes the
+     *        chosen callback function.
+     */
+    static int handler([[maybe_unused]] sd_event_source* s,
+                       [[maybe_unused]] uint64_t usec, void* userdata)
+    {
+        Timer* t = static_cast<Timer*>(userdata);
+        t->callback();
+        t->source.reset();
+        return 0;
+    }
+
+    /**
+     * @brief Starts the timer
+     *
+     * @param[in] timeout - The timeout value
+     */
+    void start(const std::chrono::microseconds& timeout)
+    {
+        source.reset();
+
+        auto s = get_event_loop(ctx).add_oneshot_timer(Timer::handler, this,
+                                                       timeout);
+        source = std::make_unique<Source>(std::move(s));
+    }
+
+    /**
+     * @brief Stops the timer
+     */
+    void stop()
+    {
+        source.reset();
+    }
+
+  private:
+    /**
+     * @brief RAII wrapper for sdbusplus::source
+     */
+    struct Source
+    {
+        Source(sdbusplus::event::source&& s) : source(std::move(s)) {}
+
+      private:
+        sdbusplus::event::source source;
+    };
+
+    /**
+     * @brief Function to run on timeout
+     */
+    std::function<void()> callback;
+
+    /**
+     * @brief Event source object
+     */
+    std::unique_ptr<Source> source;
+};
+
+} // namespace rbmc

--- a/redundant-bmc/test/meson.build
+++ b/redundant-bmc/test/meson.build
@@ -5,8 +5,10 @@ test(
     executable(
         'rbmc-tests',
         'persistent_data_test.cpp',
+        'redundancy_test.cpp',
         'role_determination_test.cpp',
         '../src/persistent_data.cpp',
+        '../src/redundancy.cpp',
         '../src/role_determination.cpp',
         dependencies: [
             gtest,

--- a/redundant-bmc/test/meson.build
+++ b/redundant-bmc/test/meson.build
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+
+test(
+    'rbmc-tests',
+    executable(
+        'rbmc-tests',
+        'role_determination_test.cpp',
+        '../src/role_determination.cpp',
+        dependencies: [
+            gtest,
+            sdbusplus,
+            phosphordbusinterfaces,
+            phosphorlogging,
+        ],
+        include_directories: '../src',
+    ),
+)

--- a/redundant-bmc/test/meson.build
+++ b/redundant-bmc/test/meson.build
@@ -4,10 +4,13 @@ test(
     'rbmc-tests',
     executable(
         'rbmc-tests',
+        'persistent_data_test.cpp',
         'role_determination_test.cpp',
+        '../src/persistent_data.cpp',
         '../src/role_determination.cpp',
         dependencies: [
             gtest,
+            nlohmann_json_dep,
             sdbusplus,
             phosphordbusinterfaces,
             phosphorlogging,

--- a/redundant-bmc/test/persistent_data_test.cpp
+++ b/redundant-bmc/test/persistent_data_test.cpp
@@ -1,0 +1,90 @@
+#include "persistent_data.hpp"
+#include "role_determination.hpp"
+
+#include <fstream>
+
+#include <gtest/gtest.h>
+
+using namespace rbmc;
+using namespace role_determination;
+
+class PersistentDataTest : public ::testing::Test
+{
+  protected:
+    static void SetUpTestCase()
+    {
+        char d[] = "/tmp/datatestXXXXXX";
+        saveFile = mkdtemp(d);
+        saveFile /= "save.json";
+    }
+
+    static void TearDownTestCase()
+    {
+        std::filesystem::remove_all(saveFile.parent_path());
+    }
+
+    static std::filesystem::path saveFile;
+};
+
+std::filesystem::path PersistentDataTest::saveFile;
+
+TEST_F(PersistentDataTest, WriteAndReadTest)
+{
+    // Write
+    data::write("Role", Role::Active, saveFile);
+    data::write("Bool", true, saveFile);
+    data::write("String", std::string{"String"}, saveFile);
+    data::write("Uint32", uint32_t{0xAABBCCDD}, saveFile);
+
+    // Read back
+    EXPECT_EQ(data::read<Role>("Role", saveFile), Role::Active);
+    EXPECT_EQ(data::read<bool>("Bool", saveFile), true);
+    EXPECT_EQ(data::read<std::string>("String", saveFile),
+              std::string{"String"});
+    EXPECT_EQ(data::read<uint32_t>("Uint32", saveFile), 0xAABBCCDD);
+
+    // Write new values
+    data::write("Role", Role::Passive, saveFile);
+    data::write("Bool", false, saveFile);
+    data::write("String", std::string{"New"}, saveFile);
+    data::write("Uint32", uint32_t{0x12345678}, saveFile);
+
+    // Read back the new values
+    EXPECT_EQ(data::read<Role>("Role", saveFile), Role::Passive);
+    EXPECT_EQ(data::read<bool>("Bool", saveFile), false);
+    EXPECT_EQ(data::read<std::string>("String", saveFile), std::string{"New"});
+    EXPECT_EQ(data::read<uint32_t>("Uint32", saveFile), 0x12345678);
+
+    // Some different types - write
+    data::write("EmptyString", std::string{}, saveFile);
+    data::write("VectorOfStrings", std::vector<std::string>{"a", "b"},
+                saveFile);
+    data::write("EmptyVector", std::vector<std::string>{}, saveFile);
+
+    // Some different types - read back
+    EXPECT_EQ(data::read<std::string>("EmptyString", saveFile), std::string{});
+    EXPECT_EQ(data::read<std::vector<std::string>>("VectorOfStrings", saveFile),
+              (std::vector<std::string>{"a", "b"}));
+    EXPECT_EQ(data::read<std::vector<std::string>>("EmptyVector", saveFile),
+              (std::vector<std::string>{}));
+
+    // Key doesn't exist
+    EXPECT_EQ(data::read<Role>("Blah", saveFile), std::nullopt);
+
+    // File doesn't exist
+    EXPECT_EQ(data::read<Role>("Role", "/blah/blah"), std::nullopt);
+
+    // Invalid JSON
+    std::filesystem::remove(saveFile);
+    std::ofstream file{saveFile};
+    const char* data = R"(
+        {
+            "Role": 1,
+            Bool 0
+        }
+    )";
+    file << data;
+    file.close();
+
+    EXPECT_EQ(data::read<Role>("Role", saveFile), std::nullopt);
+}

--- a/redundant-bmc/test/persistent_data_test.cpp
+++ b/redundant-bmc/test/persistent_data_test.cpp
@@ -60,6 +60,9 @@ TEST_F(PersistentDataTest, WriteAndReadTest)
     data::write("VectorOfStrings", std::vector<std::string>{"a", "b"},
                 saveFile);
     data::write("EmptyVector", std::vector<std::string>{}, saveFile);
+    data::write("Map", std::map<int, std::string>{{1, "one"}, {2, "two"}},
+                saveFile);
+    data::write("EmptyMap", std::map<int, std::string>{}, saveFile);
 
     // Some different types - read back
     EXPECT_EQ(data::read<std::string>("EmptyString", saveFile), std::string{});
@@ -67,6 +70,11 @@ TEST_F(PersistentDataTest, WriteAndReadTest)
               (std::vector<std::string>{"a", "b"}));
     EXPECT_EQ(data::read<std::vector<std::string>>("EmptyVector", saveFile),
               (std::vector<std::string>{}));
+
+    EXPECT_EQ((data::read<std::map<int, std::string>>("Map", saveFile)),
+              (std::map<int, std::string>{{1, "one"}, {2, "two"}}));
+    EXPECT_EQ((data::read<std::map<int, std::string>>("EmptyMap", saveFile)),
+              (std::map<int, std::string>{}));
 
     // Key doesn't exist
     EXPECT_EQ(data::read<Role>("Blah", saveFile), std::nullopt);

--- a/redundant-bmc/test/persistent_data_test.cpp
+++ b/redundant-bmc/test/persistent_data_test.cpp
@@ -88,3 +88,29 @@ TEST_F(PersistentDataTest, WriteAndReadTest)
 
     EXPECT_EQ(data::read<Role>("Role", saveFile), std::nullopt);
 }
+
+TEST_F(PersistentDataTest, RemoveTest)
+{
+    // Write three
+    data::write("Role", Role::Active, saveFile);
+    data::write("Bool", true, saveFile);
+    data::write("String", std::string{"String"}, saveFile);
+
+    // Remove the last one
+    data::remove("String", saveFile);
+    EXPECT_EQ(data::read<std::string>("String", saveFile), std::nullopt);
+
+    // Make sure other ones still there
+    EXPECT_EQ(data::read<Role>("Role", saveFile), Role::Active);
+    EXPECT_EQ(data::read<bool>("Bool", saveFile), true);
+
+    // now remove remaining ones
+    data::remove("Role", saveFile);
+    EXPECT_EQ(data::read<Role>("Role", saveFile), std::nullopt);
+
+    data::remove("Bool", saveFile);
+    EXPECT_EQ(data::read<bool>("Bool", saveFile), std::nullopt);
+
+    // Not found
+    data::remove("Blah");
+}

--- a/redundant-bmc/test/redundancy_test.cpp
+++ b/redundant-bmc/test/redundancy_test.cpp
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "redundancy.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace rbmc::redundancy;
+
+TEST(RedundancyTest, NoRedundancyReasonsTest)
+{
+    using enum NoRedundancyReason;
+
+    // Golden inputs - redundancy can be enabled.
+    const Input golden{
+        .role = rbmc::Role::Active,
+        .siblingPresent = true,
+        .siblingHeartbeat = true,
+        .siblingProvisioned = true,
+        .siblingHasSiblingComm = true,
+        .siblingRole = rbmc::Role::Passive,
+        .siblingState = rbmc::BMCState::Ready,
+        .codeVersionsMatch = true,
+        .manualDisable = false};
+
+    // Nothing stopping redundancy
+    {
+        auto reasons = getNoRedundancyReasons(golden);
+        EXPECT_TRUE(reasons.empty());
+    }
+
+    // Not active
+    {
+        auto input = golden;
+        input.role = rbmc::Role::Unknown;
+
+        auto reasons = getNoRedundancyReasons(input);
+        ASSERT_EQ(reasons.size(), 1);
+        EXPECT_EQ(*reasons.begin(), bmcNotActive);
+    }
+
+    // No sibling
+    {
+        auto input = golden;
+        input.siblingPresent = false;
+
+        auto reasons = getNoRedundancyReasons(input);
+        ASSERT_EQ(reasons.size(), 1);
+        EXPECT_EQ(*reasons.begin(), siblingMissing);
+    }
+
+    // No sibling heartbeat
+    {
+        auto input = golden;
+        input.siblingHeartbeat = false;
+
+        auto reasons = getNoRedundancyReasons(input);
+        ASSERT_EQ(reasons.size(), 1);
+        EXPECT_EQ(*reasons.begin(), noSiblingHeartbeat);
+    }
+
+    // Sibling isn't provisioned
+    {
+        auto input = golden;
+        input.siblingProvisioned = false;
+
+        auto reasons = getNoRedundancyReasons(input);
+        ASSERT_EQ(reasons.size(), 1);
+        EXPECT_EQ(*reasons.begin(), siblingNotProvisioned);
+    }
+
+    // Sibling isn't passive
+    {
+        auto input = golden;
+        input.siblingRole = rbmc::Role::Unknown;
+
+        auto reasons = getNoRedundancyReasons(input);
+        ASSERT_EQ(reasons.size(), 1);
+        EXPECT_EQ(*reasons.begin(), siblingNotPassive);
+    }
+
+    // Sibling can't talk to this BMC
+    {
+        auto input = golden;
+        input.siblingHasSiblingComm = false;
+
+        auto reasons = getNoRedundancyReasons(input);
+        ASSERT_EQ(reasons.size(), 1);
+        EXPECT_EQ(*reasons.begin(), siblingNoCommunication);
+    }
+
+    // FW versions don't match
+    {
+        auto input = golden;
+        input.codeVersionsMatch = false;
+
+        auto reasons = getNoRedundancyReasons(input);
+        ASSERT_EQ(reasons.size(), 1);
+        EXPECT_EQ(*reasons.begin(), codeMismatch);
+    }
+
+    // Sibling is in Quiesce state
+    {
+        auto input = golden;
+        input.siblingState = rbmc::BMCState::Quiesced;
+
+        auto reasons = getNoRedundancyReasons(input);
+        ASSERT_EQ(reasons.size(), 1);
+        EXPECT_EQ(*reasons.begin(), siblingNotAtReady);
+    }
+
+    // Redundancy is manually disabled
+    {
+        auto input = golden;
+        input.manualDisable = true;
+
+        auto reasons = getNoRedundancyReasons(input);
+        ASSERT_EQ(reasons.size(), 1);
+        EXPECT_EQ(*reasons.begin(), manuallyDisabled);
+    }
+
+    // Multiple fails
+    {
+        auto input = golden;
+        input.codeVersionsMatch = false;               // codeMismatch
+        input.siblingState = rbmc::BMCState::Quiesced; // siblingHealth
+        input.siblingHasSiblingComm = false;           // systemHealth
+        input.siblingRole = rbmc::Role::Unknown;       // siblingHealth
+
+        auto reasons = getNoRedundancyReasons(input);
+
+        EXPECT_EQ(reasons.size(), 4);
+        EXPECT_TRUE(std::ranges::contains(reasons, codeMismatch));
+        EXPECT_TRUE(std::ranges::contains(reasons, siblingNotAtReady));
+        EXPECT_TRUE(std::ranges::contains(reasons, siblingNoCommunication));
+        EXPECT_TRUE(std::ranges::contains(reasons, siblingNotPassive));
+    }
+}
+
+TEST(RedundancyTest, GetNoRedundancyDescTest)
+{
+    EXPECT_EQ(getNoRedundancyDescription(NoRedundancyReason::codeMismatch),
+              "Firmware version mismatch");
+}

--- a/redundant-bmc/test/role_determination_test.cpp
+++ b/redundant-bmc/test/role_determination_test.cpp
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "role_determination.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace rbmc;
+using namespace role_determination;
+
+TEST(RoleDeterminationTest, RoleDeterminationTest)
+{
+    {
+        Input input{.bmcPosition = 0};
+        EXPECT_EQ(run(input), Role::Active);
+    }
+
+    {
+        Input input{.bmcPosition = 1};
+        EXPECT_EQ(run(input), Role::Passive);
+    }
+}

--- a/redundant-bmc/test/role_determination_test.cpp
+++ b/redundant-bmc/test/role_determination_test.cpp
@@ -8,13 +8,90 @@ using namespace role_determination;
 
 TEST(RoleDeterminationTest, RoleDeterminationTest)
 {
+    using enum ErrorCase;
+    using enum Role;
+
+    // BMC pos 0 with sibling healthy
     {
-        Input input{.bmcPosition = 0};
-        EXPECT_EQ(run(input), Role::Active);
+        Input input{.bmcPosition = 0,
+                    .siblingPosition = 1,
+                    .siblingRole = Unknown,
+                    .siblingHeartbeat = true,
+                    .siblingProvisioned = true};
+
+        RoleInfo info{Active, noError};
+        EXPECT_EQ(run(input), info);
     }
 
+    // BMC pos 1 with sibling healthy
     {
-        Input input{.bmcPosition = 1};
-        EXPECT_EQ(run(input), Role::Passive);
+        Input input{.bmcPosition = 1,
+                    .siblingPosition = 0,
+                    .siblingRole = Unknown,
+                    .siblingHeartbeat = true,
+                    .siblingProvisioned = true};
+
+        RoleInfo info{Passive, noError};
+        EXPECT_EQ(run(input), info);
+    }
+
+    // No Sibling heartbeat, BMC pos 1
+    {
+        Input input{.bmcPosition = 1,
+                    .siblingPosition = 0,
+                    .siblingRole = Unknown,
+                    .siblingHeartbeat = false,
+                    .siblingProvisioned = true};
+
+        RoleInfo info{Active, noError};
+        EXPECT_EQ(run(input), info);
+    }
+
+    // Both BMCs report the same position
+    {
+        Input input{.bmcPosition = 0,
+                    .siblingPosition = 0,
+                    .siblingRole = Unknown,
+                    .siblingHeartbeat = true,
+                    .siblingProvisioned = true};
+
+        RoleInfo info{Passive, samePositions};
+        EXPECT_EQ(run(input), info);
+    }
+
+    // Sibling not provisioned
+    {
+        Input input{.bmcPosition = 1,
+                    .siblingPosition = 0,
+                    .siblingRole = Unknown,
+                    .siblingHeartbeat = true,
+                    .siblingProvisioned = false};
+
+        RoleInfo info{Active, noError};
+        EXPECT_EQ(run(input), info);
+    }
+
+    // Sibling already active, this pos = 0
+    {
+        Input input{.bmcPosition = 0,
+                    .siblingPosition = 1,
+                    .siblingRole = Active,
+                    .siblingHeartbeat = true,
+                    .siblingProvisioned = true};
+
+        RoleInfo info{Passive, noError};
+        EXPECT_EQ(run(input), info);
+    }
+
+    // Sibling already passive, this pos = 1
+    {
+        Input input{.bmcPosition = 1,
+                    .siblingPosition = 0,
+                    .siblingRole = Passive,
+                    .siblingHeartbeat = true,
+                    .siblingProvisioned = true};
+
+        RoleInfo info{Active, noError};
+        EXPECT_EQ(run(input), info);
     }
 }

--- a/redundant-bmc/test/role_determination_test.cpp
+++ b/redundant-bmc/test/role_determination_test.cpp
@@ -21,7 +21,7 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
                     .siblingProvisioned = true};
 
         RoleInfo info{Active, positionZero};
-        EXPECT_EQ(run(input), info);
+        EXPECT_EQ(determineRole(input), info);
         EXPECT_EQ(getRoleReasonDescription(info.reason), "BMC is position 0");
     }
 
@@ -34,7 +34,7 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
                     .siblingHeartbeat = true,
                     .siblingProvisioned = true};
         RoleInfo info{Passive, positionNonzero};
-        EXPECT_EQ(run(input), info);
+        EXPECT_EQ(determineRole(input), info);
         EXPECT_EQ(getRoleReasonDescription(info.reason),
                   "BMC is not position 0");
     }
@@ -49,7 +49,7 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
                     .siblingProvisioned = true};
 
         RoleInfo info{Active, noSiblingHeartbeat};
-        EXPECT_EQ(run(input), info);
+        EXPECT_EQ(determineRole(input), info);
         EXPECT_EQ(getRoleReasonDescription(info.reason),
                   "No sibling heartbeat");
     }
@@ -64,7 +64,7 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
                     .siblingProvisioned = true};
 
         RoleInfo info{Passive, samePositions};
-        EXPECT_EQ(run(input), info);
+        EXPECT_EQ(determineRole(input), info);
         EXPECT_EQ(getRoleReasonDescription(info.reason),
                   "Both BMCs have the same position");
     }
@@ -79,7 +79,7 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
                     .siblingProvisioned = false};
 
         RoleInfo info{Active, siblingNotProvisioned};
-        EXPECT_EQ(run(input), info);
+        EXPECT_EQ(determineRole(input), info);
         EXPECT_EQ(getRoleReasonDescription(info.reason),
                   "Sibling is not provisioned");
     }
@@ -94,7 +94,7 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
                     .siblingProvisioned = true};
 
         RoleInfo info{Passive, siblingActive};
-        EXPECT_EQ(run(input), info);
+        EXPECT_EQ(determineRole(input), info);
         EXPECT_EQ(getRoleReasonDescription(info.reason),
                   "Sibling is already active");
     }
@@ -109,7 +109,7 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
                     .siblingProvisioned = true};
 
         RoleInfo info{Active, siblingPassive};
-        EXPECT_EQ(run(input), info);
+        EXPECT_EQ(determineRole(input), info);
         EXPECT_EQ(getRoleReasonDescription(info.reason),
                   "Sibling is already passive");
     }
@@ -125,7 +125,7 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
 
         // Preserve passive
         RoleInfo info{Passive, resumePrevious};
-        EXPECT_EQ(run(input), info);
+        EXPECT_EQ(determineRole(input), info);
         EXPECT_EQ(getRoleReasonDescription(info.reason),
                   "Resuming previous role");
     }
@@ -141,7 +141,7 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
 
         // Preserve active
         RoleInfo info{Active, resumePrevious};
-        EXPECT_EQ(run(input), info);
+        EXPECT_EQ(determineRole(input), info);
         EXPECT_EQ(getRoleReasonDescription(info.reason),
                   "Resuming previous role");
     }

--- a/redundant-bmc/test/role_determination_test.cpp
+++ b/redundant-bmc/test/role_determination_test.cpp
@@ -14,6 +14,7 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
     // BMC pos 0 with sibling healthy
     {
         Input input{.bmcPosition = 0,
+                    .previousRole = Unknown,
                     .siblingPosition = 1,
                     .siblingRole = Unknown,
                     .siblingHeartbeat = true,
@@ -26,6 +27,7 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
     // BMC pos 1 with sibling healthy
     {
         Input input{.bmcPosition = 1,
+                    .previousRole = Unknown,
                     .siblingPosition = 0,
                     .siblingRole = Unknown,
                     .siblingHeartbeat = true,
@@ -38,6 +40,7 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
     // No Sibling heartbeat, BMC pos 1
     {
         Input input{.bmcPosition = 1,
+                    .previousRole = Unknown,
                     .siblingPosition = 0,
                     .siblingRole = Unknown,
                     .siblingHeartbeat = false,
@@ -50,6 +53,7 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
     // Both BMCs report the same position
     {
         Input input{.bmcPosition = 0,
+                    .previousRole = Unknown,
                     .siblingPosition = 0,
                     .siblingRole = Unknown,
                     .siblingHeartbeat = true,
@@ -62,6 +66,7 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
     // Sibling not provisioned
     {
         Input input{.bmcPosition = 1,
+                    .previousRole = Unknown,
                     .siblingPosition = 0,
                     .siblingRole = Unknown,
                     .siblingHeartbeat = true,
@@ -74,6 +79,7 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
     // Sibling already active, this pos = 0
     {
         Input input{.bmcPosition = 0,
+                    .previousRole = Unknown,
                     .siblingPosition = 1,
                     .siblingRole = Active,
                     .siblingHeartbeat = true,
@@ -86,11 +92,40 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
     // Sibling already passive, this pos = 1
     {
         Input input{.bmcPosition = 1,
+                    .previousRole = Unknown,
                     .siblingPosition = 0,
                     .siblingRole = Passive,
                     .siblingHeartbeat = true,
                     .siblingProvisioned = true};
 
+        RoleInfo info{Active, noError};
+        EXPECT_EQ(run(input), info);
+    }
+
+    // BMC pos 0 with sibling healthy, previous role = Passive
+    {
+        Input input{.bmcPosition = 0,
+                    .previousRole = Passive,
+                    .siblingPosition = 1,
+                    .siblingRole = Unknown,
+                    .siblingHeartbeat = true,
+                    .siblingProvisioned = true};
+
+        // Preserve passive
+        RoleInfo info{Passive, noError};
+        EXPECT_EQ(run(input), info);
+    }
+
+    // BMC pos 1 with sibling healthy, previous role = Active
+    {
+        Input input{.bmcPosition = 1,
+                    .previousRole = Active,
+                    .siblingPosition = 0,
+                    .siblingRole = Unknown,
+                    .siblingHeartbeat = true,
+                    .siblingProvisioned = true};
+
+        // Preserve active
         RoleInfo info{Active, noError};
         EXPECT_EQ(run(input), info);
     }

--- a/service_files/meson.build
+++ b/service_files/meson.build
@@ -12,6 +12,7 @@ unit_files = [
     'phosphor-reset-host-running@.service',
     'phosphor-reset-sensor-states@.service',
     'xyz.openbmc_project.State.BMC.service',
+    'xyz.openbmc_project.State.BMC.Redundancy.service',
     'xyz.openbmc_project.State.Chassis@.service',
     'xyz.openbmc_project.State.Host@.service',
     'xyz.openbmc_project.State.Hypervisor.service',

--- a/service_files/xyz.openbmc_project.State.BMC.Redundancy.service
+++ b/service_files/xyz.openbmc_project.State.BMC.Redundancy.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Phosphor Redundant BMC State Manager
+Wants=xyz.openbmc_project.State.BMC.service
+After=xyz.openbmc_project.State.BMC.service
+
+[Service]
+ExecStart=/usr/libexec/phosphor-state-manager/phosphor-rbmc-state-manager
+Restart=always
+Type=dbus
+BusName=xyz.openbmc_project.State.BMC.Redundancy
+
+[Install]
+WantedBy=multi-user.target

--- a/service_files/xyz.openbmc_project.State.BMC.Redundancy.service
+++ b/service_files/xyz.openbmc_project.State.BMC.Redundancy.service
@@ -2,6 +2,8 @@
 Description=Phosphor Redundant BMC State Manager
 Wants=xyz.openbmc_project.State.BMC.service
 After=xyz.openbmc_project.State.BMC.service
+Wants=xyz.openbmc_project.State.BMC.Redundancy.Sibling.service
+After=xyz.openbmc_project.State.BMC.Redundancy.Sibling.service
 
 [Service]
 ExecStart=/usr/libexec/phosphor-state-manager/phosphor-rbmc-state-manager

--- a/subprojects/googletest.wrap
+++ b/subprojects/googletest.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url = https://github.com/google/googletest
+revision = HEAD

--- a/target_files/meson.build
+++ b/target_files/meson.build
@@ -1,4 +1,6 @@
 unit_files = [
+    'obmc-bmc-active.target',
+    'obmc-bmc-passive.target',
     'obmc-bmc-service-quiesce@.target',
     'obmc-chassis-blackout@.target',
     'obmc-chassis-hard-poweroff@.target',

--- a/target_files/obmc-bmc-active.target
+++ b/target_files/obmc-bmc-active.target
@@ -1,0 +1,3 @@
+[Unit]
+Description=Active BMC Target
+Conflicts=obmc-bmc-passive.target

--- a/target_files/obmc-bmc-passive.target
+++ b/target_files/obmc-bmc-passive.target
@@ -1,0 +1,3 @@
+[Unit]
+Description=Passive BMC Target
+Conflicts=obmc-bmc-active.target


### PR DESCRIPTION
Cherry picks from 1110, with some format fixing along the way due to new clang-format and meson format changes.