### PR TITLE
RBMC: Call sibling HB change func on iface removed

### DIFF
--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -245,7 +245,17 @@ sdbusplus::async::task<> SiblingImpl::watchInterfaceRemoved()
         {
             lg2::info("Sibling D-Bus interface removed");
             interfacePresent = false;
+
+            auto old = heartbeat;
             heartbeat = false;
+            if (old != heartbeat)
+            {
+                for (const auto& callback :
+                     std::ranges::views::values(heartbeatCBs))
+                {
+                    callback(heartbeat);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
The BMC.Redundancy.Sibling interface will be removed from D-Bus when the sibling can no longer be accessed.  This stops the heartbeat, so any functions registered to be called on sibling heartbeat changes must be called.

Tested:
The loss of that interface on D-Bus is now correctly interpreted as a sibling heartbeat loss.