### PR TITLE
RBMC: Add rbmctool option to reset sibling BMC

### DIFF
--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -3,7 +3,10 @@ execinstalldir = join_paths(get_option('libexecdir'), 'phosphor-state-manager')
 
 ssl_dep = dependency('openssl')
 
+gpiodcxx = dependency('libgpiodcxx', fallback: ['libgpiod', 'gpiodcxx_dep'])
+
 rbmc_deps = [
+    gpiodcxx,
     nlohmann_json_dep,
     phosphordbusinterfaces,
     phosphorlogging,
@@ -24,6 +27,7 @@ executable(
     'role_determination.cpp',
     'services_impl.cpp',
     'sibling_impl.cpp',
+    'sibling_reset_impl.cpp',
     dependencies: rbmc_deps,
     install: true,
     install_dir: execinstalldir,
@@ -34,6 +38,7 @@ executable(
     'persistent_data.cpp',
     'rbmc_tool.cpp',
     'services_impl.cpp',
+    'sibling_reset_impl.cpp',
     dependencies: [rbmc_deps, CLI11],
     install: true,
 )

--- a/redundant-bmc/src/sibling_reset.hpp
+++ b/redundant-bmc/src/sibling_reset.hpp
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+namespace rbmc
+{
+
+/**
+ * @class SiblingReset
+ *
+ * Abstract base class to handling resetting the sibling BMC.
+ */
+class SiblingReset
+{
+  public:
+    SiblingReset() = default;
+    virtual ~SiblingReset() = default;
+    SiblingReset(const SiblingReset&) = delete;
+    SiblingReset& operator=(const SiblingReset&) = delete;
+    SiblingReset(SiblingReset&&) = delete;
+    SiblingReset& operator=(SiblingReset&&) = delete;
+
+    /**
+     * @brief Asserts the reset.
+     *
+     * Releases the GPIO request on completion.
+     */
+    virtual void assertReset() = 0;
+
+    /**
+     * @brief Releases the reset.
+     *
+     * Releases the GPIO request on completion.
+     */
+    virtual void releaseReset() = 0;
+};
+
+} // namespace rbmc

--- a/redundant-bmc/src/sibling_reset_impl.cpp
+++ b/redundant-bmc/src/sibling_reset_impl.cpp
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sibling_reset_impl.hpp"
+
+#include <gpiod.hpp>
+#include <phosphor-logging/lg2.hpp>
+
+#include <cassert>
+
+namespace rbmc
+{
+
+const std::string gpioName = "sibling-bmc-reset";
+
+SiblingResetImpl::SiblingResetImpl()
+{
+    resetLine = gpiod::find_line(gpioName);
+    if (!resetLine)
+    {
+        // Attempt to find the active low version.
+        resetLine = gpiod::find_line(gpioName + "-n");
+        if (resetLine)
+        {
+            activeLow = true;
+        }
+    }
+
+    if (resetLine)
+    {
+        config.consumer = "Sibling BMC Reset";
+        config.request_type = gpiod::line_request::DIRECTION_OUTPUT;
+        config.flags = activeLow ? gpiod::line_request::FLAG_ACTIVE_LOW : 0;
+    }
+    else
+    {
+        // This will cause a fail during the assert/release
+        lg2::error("Could not find BMC reset GPIO {GPIO}", "GPIO", gpioName);
+    }
+}
+
+void SiblingResetImpl::assertReset()
+{
+    if (!resetLine)
+    {
+        throw std::runtime_error("Could not find sibling reset GPIO");
+    }
+
+    lg2::info("Asserting sibling BMC reset GPIO");
+
+    resetLine.request(config, 1);
+    resetLine.release();
+}
+
+void SiblingResetImpl::releaseReset()
+{
+    if (!resetLine)
+    {
+        throw std::runtime_error("Could not find sibling reset GPIO");
+    }
+
+    lg2::info("Releasing sibling BMC reset GPIO");
+
+    resetLine.request(config, 0);
+    resetLine.release();
+}
+
+} // namespace rbmc

--- a/redundant-bmc/src/sibling_reset_impl.hpp
+++ b/redundant-bmc/src/sibling_reset_impl.hpp
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "sibling_reset.hpp"
+
+#include <gpiod.hpp>
+#include <phosphor-logging/lg2.hpp>
+
+namespace rbmc
+{
+
+/**
+ * @class SiblingResetImpl
+ *
+ * Implementation to handle resetting the sibling BMC.
+ */
+class SiblingResetImpl : public SiblingReset
+{
+  public:
+    ~SiblingResetImpl() override = default;
+    SiblingResetImpl(const SiblingResetImpl&) = delete;
+    SiblingResetImpl& operator=(const SiblingResetImpl&) = delete;
+    SiblingResetImpl(SiblingResetImpl&&) = delete;
+    SiblingResetImpl& operator=(SiblingResetImpl&&) = delete;
+
+    /**
+     * @brief Constructor
+     */
+    SiblingResetImpl();
+
+    /**
+     * @brief Asserts the reset.
+     *
+     * Releases the GPIO request on completion.
+     */
+    void assertReset() override;
+
+    /**
+     * @brief Releases the reset.
+     *
+     * Releases the GPIO request on completion.
+     */
+    void releaseReset() override;
+
+  private:
+    /**
+     * @brief The GPIO config for requesting a line.
+     */
+    gpiod::line_request config;
+
+    /**
+     * @brief The reset line
+     */
+    gpiod::line resetLine;
+
+    /**
+     * @brief If the GPIO is active low
+     */
+    bool activeLow{false};
+};
+
+} // namespace rbmc


### PR DESCRIPTION
Add an option to rbmctool to reset the sibling BMC using the reset GPIO.  This reset will also be done during a failover, and the class created to do the reset will also be used in that case.

Note that in the assertReset() and releaseReset() functions the GPIO is not held, so that during real use during a failover if something goes horribly wrong the GPIO won't get stuck being held.

Just a long option was provided to attempt to make it a bit harder to type by accident.

Tested:

New options:

Options:
  -h,--help                   Print this help message and exit
  -d                          Display RBMC Information
  -e Needs: -d                Add extended RBMC details to the display
  --reset-sibling             Reset the sibling BMC

The reset:

$ ./rbmctool --reset-sibling
<6> Asserting sibling BMC reset GPIO
<6> Releasing sibling BMC reset GPIO

Change-Id: I44e61de36e8e83cbba93913ac643261b137345bc