### PR TITLE
RBMC: Move getBMCState call into Services

### DIFF
--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 #pragma once
 #include <sdbusplus/async.hpp>
+#include <xyz/openbmc_project/State/BMC/common.hpp>
 
 namespace rbmc
 {
@@ -82,6 +83,15 @@ class Services
      * @return If power is on
      */
     virtual bool isPoweredOn() const = 0;
+
+    /**
+     * @brief Reads the BMC state
+     *
+     * @return The BMC state
+     */
+    virtual sdbusplus::async::task<
+        sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState>
+        getBMCState() const = 0;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -85,6 +85,15 @@ class ServicesImpl : public Services
      */
     bool isPoweredOn() const override;
 
+    /**
+     * @brief Reads the BMC state
+     *
+     * @return The BMC state
+     */
+    sdbusplus::async::task<
+        sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState>
+        getBMCState() const override;
+
   private:
     /**
      * @brief Returns the D-Bus object path for the unit in the


### PR DESCRIPTION
Move this function from rbmc_tool.cpp into the Services class so that the application code can call it.  It will be used in the future when checking to see if a failover is possible.

Tested:
rbmctool still works