### PR TITLE
Don't enable redundancy at runtime if it wasn't enabled when runtime was first reached.

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -85,6 +85,8 @@ items to see if redundancy can be enabled:
 1. The sibling's 'sibling communication OK' property is true, meaning it is able
    to talk to the active BMC.
 1. The firmware versions are the same on the BMCs.
+1. If attempting to enable any time at runtime, redundancy must have been
+   enabled when runtime was first reached.
 
 ## Scenarios
 

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -41,6 +41,18 @@ sdbusplus::async::task<> PassiveRoleHandler::start()
             "ERROR", e);
     }
 
+    try
+    {
+        // This is only valid on the active BMC
+        data::remove(data::key::redundancyOffAtRuntime);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error(
+            "Failed while removing RedundancyOffAtRuntime saved value: {ERROR}",
+            "ERROR", e);
+    }
+
     co_return;
 }
 

--- a/redundant-bmc/src/persistent_data.hpp
+++ b/redundant-bmc/src/persistent_data.hpp
@@ -19,6 +19,7 @@ constexpr auto passiveError = "PassiveDueToError";
 constexpr auto roleReason = "RoleReason";
 constexpr auto noRedDetails = "NoRedundancyDetails";
 constexpr auto disableRed = "DisableRedundancy";
+constexpr auto redundancyOffAtRuntime = "RedundancyOffAtRuntime";
 } // namespace key
 
 namespace util

--- a/redundant-bmc/src/redundancy.cpp
+++ b/redundant-bmc/src/redundancy.cpp
@@ -62,6 +62,11 @@ NoRedundancyReasons getNoRedundancyReasons(const Input& input)
         }
     }
 
+    if (input.redundancyOffAtRuntimeStart)
+    {
+        reasons.insert(redundancyOffAtRuntimeStart);
+    }
+
     return reasons;
 }
 
@@ -106,6 +111,9 @@ std::string getNoRedundancyDescription(NoRedundancyReason reason)
             break;
         case systemHardwareConfigIssue:
             desc = "System hardware configuration issue"s;
+            break;
+        case redundancyOffAtRuntimeStart:
+            desc = "Redundancy was off upon reaching runtime"s;
             break;
         case other:
             desc = "Other";

--- a/redundant-bmc/src/redundancy.hpp
+++ b/redundant-bmc/src/redundancy.hpp
@@ -29,6 +29,7 @@ struct Input
     BMCState siblingState;
     bool codeVersionsMatch;
     bool manualDisable;
+    bool redundancyOffAtRuntimeStart;
 };
 
 // TODO: Move this to PDI Enums
@@ -48,6 +49,7 @@ enum class NoRedundancyReason
     codeMismatch,
     siblingNotAtReady,
     systemHardwareConfigIssue,
+    redundancyOffAtRuntimeStart,
     other
 };
 

--- a/redundant-bmc/src/redundancy_mgr.hpp
+++ b/redundant-bmc/src/redundancy_mgr.hpp
@@ -17,7 +17,6 @@ namespace rbmc
 class RedundancyMgr
 {
   public:
-    ~RedundancyMgr() = default;
     RedundancyMgr(const RedundancyMgr&) = delete;
     RedundancyMgr& operator=(const RedundancyMgr&) = delete;
     RedundancyMgr(RedundancyMgr&&) = delete;
@@ -33,6 +32,14 @@ class RedundancyMgr
      */
     RedundancyMgr(sdbusplus::async::context& ctx, Services& services,
                   Sibling& sibling, RedundancyInterface& iface);
+
+    /**
+     * @brief Destructor
+     */
+    ~RedundancyMgr()
+    {
+        services.clearSystemStateCallbacks();
+    }
 
     /**
      * @brief Enables or disables redundancy based on the
@@ -71,6 +78,20 @@ class RedundancyMgr
         const redundancy::NoRedundancyReasons& disableReasons);
 
     /**
+     * @brief Called when the system state changes to do
+     *        any necessary work.
+     *
+     * @param[in] newState - the new system state
+     */
+    void systemStateChange(SystemState newState);
+
+    /**
+     * @brief Reads the initial system state value and registers
+     *        for callbacks on changes
+     */
+    void initSystemState();
+
+    /**
      * @brief The async context object
      */
     sdbusplus::async::context& ctx;
@@ -100,6 +121,11 @@ class RedundancyMgr
      *        D-Bus property.
      */
     bool manualDisable = false;
+
+    /**
+     * @brief The current system state value
+     */
+    std::optional<SystemState> systemState;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/redundancy_mgr.hpp
+++ b/redundant-bmc/src/redundancy_mgr.hpp
@@ -92,6 +92,60 @@ class RedundancyMgr
     void initSystemState();
 
     /**
+     * @brief Update the 'redundancy off at runtime' data.
+     *
+     * @param[in] valid - If the value is valid or not.
+     * @param[in] off - The value, if redundancy is off or not.
+     */
+    static void setRedundancyOffAtRuntime(bool valid, bool off);
+
+    /**
+     * @brief Returns the 'redundancy off at runtime' values
+     *
+     * @return If value is valid, and what the value is
+     */
+    static std::tuple<bool, bool> getRedundancyOffAtRuntime();
+
+    /**
+     * @brief Says if Redundancy was off at runtime
+     *
+     * If the value isn't valid, then it won't be off.
+     */
+    static bool isRedundancyOffAtRuntime()
+    {
+        auto [valid, off] = getRedundancyOffAtRuntime();
+        return valid && off;
+    }
+
+    /**
+     * @brief Returns if the 'redundancy off at runtime' value is valid.
+     */
+    static bool isRedundancyOffAtRuntimeValid()
+    {
+        auto [valid, _] = getRedundancyOffAtRuntime();
+        return valid;
+    }
+
+    /**
+     * @brief Clears both the valid and value fields
+     *        of 'redundancy off at runtime'.
+     */
+    static void clearRedundancyOffAtRuntime()
+    {
+        setRedundancyOffAtRuntime(false, false);
+    }
+
+    /**
+     * @brief Sets a valid value for 'redundancy off at runtime'.
+     *
+     * @param[in] off - If off or not
+     */
+    static void setRedundancyOffAtRuntimeValue(bool off)
+    {
+        setRedundancyOffAtRuntime(true, off);
+    }
+
+    /**
      * @brief The async context object
      */
     sdbusplus::async::context& ctx;

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -3,6 +3,9 @@
 
 #include "services.hpp"
 
+#include <xyz/openbmc_project/State/Boot/Progress/common.hpp>
+#include <xyz/openbmc_project/State/Host/common.hpp>
+
 namespace rbmc
 {
 
@@ -79,11 +82,11 @@ class ServicesImpl : public Services
     std::string getFWVersion() const override;
 
     /**
-     * @brief Says if main power is on.
+     * @brief Returns the system state
      *
-     * @return If power is on
+     * @return The system state
      */
-    bool isPoweredOn() const override;
+    SystemState getSystemState() const override;
 
     /**
      * @brief Reads the BMC state
@@ -114,7 +117,7 @@ class ServicesImpl : public Services
     /**
      * @brief Starts the PropertiesChanged watch for the host state
      */
-    sdbusplus::async::task<> watchHostPropertiesChanged();
+    sdbusplus::async::task<> watchHostStatePropertiesChanged();
 
     /**
      * @brief Reads the CurrentHostState property
@@ -122,17 +125,44 @@ class ServicesImpl : public Services
     sdbusplus::async::task<> readHostState();
 
     /**
+     * @brief Reads the BootProgress property
+     */
+    sdbusplus::async::task<> readBootProgress();
+
+    /**
+     * @brief Starts the PropertiesChanged watch for the BootProgress property
+     */
+    sdbusplus::async::task<> watchBootProgressPropertiesChanged();
+
+    /**
+     * @brief Called when either the host state or boot progress property
+     *        changes value to calculate the system state.
+     */
+    void updateSystemState();
+
+    /**
      * @brief The async context object
      */
     sdbusplus::async::context& ctx;
 
     /**
-     * @brief If the host is powered on
-     *
-     * Only valid after the host state service has been started.
-     * Will throw if called before then.
+     * @brief The host state value
      */
-    std::optional<bool> poweredOn;
+    std::optional<
+        sdbusplus::common::xyz::openbmc_project::state::Host::HostState>
+        hostState;
+
+    /**
+     * @brief The boot progress value
+     */
+    std::optional<sdbusplus::common::xyz::openbmc_project::state::boot::
+                      Progress::ProgressStages>
+        bootProgress;
+
+    /**
+     * @brief The current system state value
+     */
+    std::optional<SystemState> systemState;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/test/redundancy_test.cpp
+++ b/redundant-bmc/test/redundancy_test.cpp
@@ -19,7 +19,8 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
         .siblingRole = rbmc::Role::Passive,
         .siblingState = rbmc::BMCState::Ready,
         .codeVersionsMatch = true,
-        .manualDisable = false};
+        .manualDisable = false,
+        .redundancyOffAtRuntimeStart = false};
 
     // Nothing stopping redundancy
     {
@@ -115,6 +116,16 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
         auto reasons = getNoRedundancyReasons(input);
         ASSERT_EQ(reasons.size(), 1);
         EXPECT_EQ(*reasons.begin(), manuallyDisabled);
+    }
+
+    // Redundancy was off at runtime
+    {
+        auto input = golden;
+        input.redundancyOffAtRuntimeStart = true;
+
+        auto reasons = getNoRedundancyReasons(input);
+        ASSERT_EQ(reasons.size(), 1);
+        EXPECT_EQ(*reasons.begin(), redundancyOffAtRuntimeStart);
     }
 
     // Multiple fails


### PR DESCRIPTION
Whenever an attempt to enable redundancy at runtime is made, redundancy can't be enabled if it wasn't already enabled when runtime was first reached.  An example of when the check would be done is after either BMC comes back from a reboot at runtime.   Implement this check by:

1. Start tracking if  the system is at off/booting/runtime/other.  While this commit only cares about off vs runtime, there will be uses for the other states in the future, such as pausing failovers during those periods.
2.  When the state reaches runtime, save if redundancy is off and also save a 'valid' flag with it.  When the system goes to Off, clear the valid flag so that the code knows the redundancy value isn't usable until the next time runtime is reached.
3. When redundancy is being determined, also check these 2 new fields as "valid && redundancy off", and don't enable redundancy if both are true.

