### PR TITLE
RBMC: Create Providers class to hold the various provider helper classes

### DIFF
--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -12,6 +12,9 @@ const std::chrono::minutes siblingHBTimeout{5};
 // NOLINTNEXTLINE
 sdbusplus::async::task<> ActiveRoleHandler::start()
 {
+    auto& services = providers.getServices();
+    auto& sibling = providers.getSibling();
+
     try
     {
         // NOLINTNEXTLINE
@@ -84,6 +87,7 @@ sdbusplus::async::task<> ActiveRoleHandler::siblingHBStarted()
 
     stopSiblingWatches();
 
+    auto& sibling = providers.getSibling();
     co_await sdbusplus::async::execution::when_all(
         sibling.waitForSiblingRole(), sibling.waitForBMCSteadyState());
 

--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -25,14 +25,12 @@ class ActiveRoleHandler : public RoleHandler
      * @brief Constructor
      *
      * @param[in] ctx - The async context object
-     * @param[in] services - The services object
-     * @param[in] sibling - The sibling object
+     * @param[in] providers - The Providers access object
      * @param[in] iface - The redundancy D-Bus interface object
      */
-    ActiveRoleHandler(sdbusplus::async::context& ctx, Services& services,
-                      Sibling& sibling, RedundancyInterface& iface) :
-        RoleHandler(ctx, services, sibling, iface),
-        redMgr(ctx, services, sibling, iface),
+    ActiveRoleHandler(sdbusplus::async::context& ctx, Providers& providers,
+                      RedundancyInterface& iface) :
+        RoleHandler(ctx, providers, iface), redMgr(ctx, providers, iface),
         siblingHBTimer(
             ctx, std::bind_front(&ActiveRoleHandler::siblingHBCritical, this))
     {}
@@ -42,7 +40,7 @@ class ActiveRoleHandler : public RoleHandler
      */
     ~ActiveRoleHandler() override
     {
-        sibling.clearCallbacks(Role::Active);
+        providers.getSibling().clearCallbacks(Role::Active);
     }
 
     /**
@@ -70,6 +68,7 @@ class ActiveRoleHandler : public RoleHandler
      */
     inline void startSiblingWatches()
     {
+        auto& sibling = providers.getSibling();
         sibling.addBMCStateCallback(
             Role::Active,
             std::bind_front(&ActiveRoleHandler::siblingStateChange, this));
@@ -85,6 +84,7 @@ class ActiveRoleHandler : public RoleHandler
     inline void stopSiblingWatches()
     {
         siblingHBTimer.stop();
+        auto& sibling = providers.getSibling();
         sibling.clearBMCStateCallback(Role::Active);
         sibling.clearHeartbeatCallback(Role::Active);
     }

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -89,17 +89,14 @@ sdbusplus::async::task<> Manager::startup()
 
 void Manager::spawnRoleHandler()
 {
-    auto& services = providers->getServices();
-    auto& sibling = providers->getSibling();
-
     if (redundancyInterface.role() == Role::Active)
     {
-        handler = std::make_unique<ActiveRoleHandler>(ctx, services, sibling,
+        handler = std::make_unique<ActiveRoleHandler>(ctx, *providers,
                                                       redundancyInterface);
     }
     else if (redundancyInterface.role() == Role::Passive)
     {
-        handler = std::make_unique<PassiveRoleHandler>(ctx, services, sibling,
+        handler = std::make_unique<PassiveRoleHandler>(ctx, *providers,
                                                        redundancyInterface);
     }
     else

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -1,11 +1,10 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 #pragma once
 
+#include "providers.hpp"
 #include "redundancy_interface.hpp"
 #include "role_determination.hpp"
 #include "role_handler.hpp"
-#include "services.hpp"
-#include "sibling.hpp"
 
 #include <sdbusplus/async.hpp>
 
@@ -32,12 +31,10 @@ class Manager
      * @brief Constructor
      *
      * @param[in] ctx - The async context object
-     * @param[in] services - The services object to interface with system data.
-     * @param[in] sibling - The sibling access object
+     * @param[in] providers - The Providers access object
      */
     Manager(sdbusplus::async::context& ctx,
-            std::unique_ptr<Services>&& services,
-            std::unique_ptr<Sibling>&& sibling);
+            std::unique_ptr<Providers>&& providers);
 
     /**
      * @brief Handler for the DisableRedundancyOverride
@@ -111,21 +108,14 @@ class Manager
     RedundancyInterface redundancyInterface;
 
     /**
-     * @brief The services object
-     *
-     * Wraps system interfaces.
-     */
-    std::unique_ptr<Services> services;
-
-    /**
      * @brief The role handler class
      */
     std::unique_ptr<RoleHandler> handler;
 
     /**
-     * @brief Object to handle sibling BMC access
+     * @brief Contains the various provider helpers
      */
-    std::unique_ptr<Sibling> sibling;
+    std::unique_ptr<Providers> providers;
 
     /**
      * @brief The previously serialized role value.

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -17,7 +17,7 @@ sdbusplus::async::task<> PassiveRoleHandler::start()
     try
     {
         // NOLINTNEXTLINE
-        co_await services.startUnit(bmcPassiveTarget);
+        co_await providers.getServices().startUnit(bmcPassiveTarget);
     }
     catch (const sdbusplus::exception_t& e)
     {
@@ -58,6 +58,8 @@ sdbusplus::async::task<> PassiveRoleHandler::start()
 
 void PassiveRoleHandler::setupSiblingRedEnabledWatch()
 {
+    auto& sibling = providers.getSibling();
+
     // Mirror the active BMC's RedundancyEnabled value
     auto sibRedEnabled = sibling.getRedundancyEnabled();
     if (sibRedEnabled)
@@ -74,7 +76,8 @@ void PassiveRoleHandler::setupSiblingRedEnabledWatch()
 void PassiveRoleHandler::siblingRedEnabledHandler(bool enable)
 {
     // If the sibling is Active, mirror the property on this BMC.
-    if (sibling.getRole().value_or(Role::Unknown) == Role::Active)
+    if (providers.getSibling().getRole().value_or(Role::Unknown) ==
+        Role::Active)
     {
         redundancyInterface.redundancy_enabled(enable);
     }

--- a/redundant-bmc/src/passive_role_handler.hpp
+++ b/redundant-bmc/src/passive_role_handler.hpp
@@ -24,13 +24,12 @@ class PassiveRoleHandler : public RoleHandler
      * @brief Constructor
      *
      * @param[in] ctx - The async context object
-     * @param[in] services - The services object
-     * @param[in] sibling - The sibling object
+     * @param[in] providers - The Providers access object
      * @param[in] iface - The redundancy D-Bus interface object
      */
-    PassiveRoleHandler(sdbusplus::async::context& ctx, Services& services,
-                       Sibling& sibling, RedundancyInterface& iface) :
-        RoleHandler(ctx, services, sibling, iface)
+    PassiveRoleHandler(sdbusplus::async::context& ctx, Providers& providers,
+                       RedundancyInterface& iface) :
+        RoleHandler(ctx, providers, iface)
     {}
 
     /**
@@ -40,7 +39,7 @@ class PassiveRoleHandler : public RoleHandler
      */
     ~PassiveRoleHandler() override
     {
-        sibling.clearCallbacks(Role::Passive);
+        providers.getSibling().clearCallbacks(Role::Passive);
     }
 
     /**

--- a/redundant-bmc/src/providers.hpp
+++ b/redundant-bmc/src/providers.hpp
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "services.hpp"
+#include "sibling.hpp"
+
+namespace rbmc
+{
+
+/**
+ * @class Providers
+ *
+ * Holders the helper classes that provide access
+ * to various pieces of the system.
+ */
+class Providers
+{
+  public:
+    Providers() = default;
+    virtual ~Providers() = default;
+    Providers(const Providers&) = delete;
+    Providers& operator=(const Providers&) = delete;
+    Providers(Providers&&) = delete;
+    Providers& operator=(Providers&&) = delete;
+
+    /**
+     * @brief Returns the Services provider
+     */
+    virtual Services& getServices() = 0;
+
+    /**
+     * @brief Returns the Sibling provider
+     */
+    virtual Sibling& getSibling() = 0;
+};
+
+}; // namespace rbmc

--- a/redundant-bmc/src/providers_impl.hpp
+++ b/redundant-bmc/src/providers_impl.hpp
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "providers.hpp"
+#include "services_impl.hpp"
+#include "sibling_impl.hpp"
+
+namespace rbmc
+{
+
+/**
+ * @class ProvidersImpl
+ *
+ * Holds the real providers classes.
+ *
+ */
+class ProvidersImpl : public Providers
+{
+  public:
+    ~ProvidersImpl() override = default;
+    ProvidersImpl(const ProvidersImpl&) = delete;
+    ProvidersImpl& operator=(const ProvidersImpl&) = delete;
+    ProvidersImpl(ProvidersImpl&&) = delete;
+    ProvidersImpl& operator=(ProvidersImpl&&) = delete;
+
+    /**
+     * @brief Constructor
+     *
+     * @param[in] ctx - The async context object
+     */
+    explicit ProvidersImpl(sdbusplus::async::context& ctx) :
+        services(ctx), sibling(ctx)
+    {}
+
+    /**
+     * @brief Returns the Services provider
+     */
+    Services& getServices() override
+    {
+        return services;
+    }
+
+    /**
+     * @brief Returns the Sibling provider
+     */
+    Sibling& getSibling() override
+    {
+        return sibling;
+    }
+
+  private:
+    /**
+     * @brief The Services implementation
+     */
+    ServicesImpl services;
+
+    /**
+     * @brief The Sibling implementation
+     */
+    SiblingImpl sibling;
+};
+
+}; // namespace rbmc

--- a/redundant-bmc/src/rbmc_manager_main.cpp
+++ b/redundant-bmc/src/rbmc_manager_main.cpp
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include "manager.hpp"
-#include "services_impl.hpp"
-#include "sibling_impl.hpp"
+#include "providers_impl.hpp"
 
 #include <sdbusplus/async/context.hpp>
 #include <sdbusplus/server/manager.hpp>
@@ -16,12 +15,10 @@ int main()
     sdbusplus::async::context ctx;
     sdbusplus::server::manager_t objMgr{ctx, "/xyz/openbmc_project/state"};
 
-    std::unique_ptr<rbmc::Services> services =
-        std::make_unique<rbmc::ServicesImpl>(ctx);
-    std::unique_ptr<rbmc::Sibling> sibling =
-        std::make_unique<rbmc::SiblingImpl>(ctx);
+    std::unique_ptr<rbmc::Providers> providers =
+        std::make_unique<rbmc::ProvidersImpl>(ctx);
 
-    rbmc::Manager manager{ctx, std::move(services), std::move(sibling)};
+    rbmc::Manager manager{ctx, std::move(providers)};
 
     // clang-tidy currently mangles this into something unreadable
     // NOLINTNEXTLINE

--- a/redundant-bmc/src/redundancy_mgr.cpp
+++ b/redundant-bmc/src/redundancy_mgr.cpp
@@ -9,9 +9,9 @@
 namespace rbmc
 {
 
-RedundancyMgr::RedundancyMgr(sdbusplus::async::context& ctx, Services& services,
-                             Sibling& sibling, RedundancyInterface& iface) :
-    ctx(ctx), services(services), sibling(sibling), redundancyInterface(iface),
+RedundancyMgr::RedundancyMgr(sdbusplus::async::context& ctx,
+                             Providers& providers, RedundancyInterface& iface) :
+    ctx(ctx), providers(providers), redundancyInterface(iface),
     manualDisable(iface.disable_redundancy_override())
 {
     try
@@ -38,6 +38,9 @@ void RedundancyMgr::determineAndSetRedundancy()
 
 redundancy::NoRedundancyReasons RedundancyMgr::getNoRedundancyReasons()
 {
+    auto& sibling = providers.getSibling();
+    auto& services = providers.getServices();
+
     redundancy::Input input{
         .role = redundancyInterface.role(),
         .siblingPresent = sibling.isBMCPresent(),
@@ -127,6 +130,8 @@ void RedundancyMgr::disableRedPropChanged(bool disable)
 
 void RedundancyMgr::initSystemState()
 {
+    auto& services = providers.getServices();
+
     services.addSystemStateCallback(
         std::bind_front(&RedundancyMgr::systemStateChange, this));
 

--- a/redundant-bmc/src/redundancy_mgr.hpp
+++ b/redundant-bmc/src/redundancy_mgr.hpp
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "providers.hpp"
 #include "redundancy.hpp"
 #include "redundancy_interface.hpp"
-#include "services.hpp"
-#include "sibling.hpp"
 
 namespace rbmc
 {
@@ -26,19 +25,18 @@ class RedundancyMgr
      * @brief Constructor
      *
      * @param[in] ctx - The async context object
-     * @param[in] services - The services object
-     * @param[in] sibling - The sibling object
+     * @param[in] providers - The Providers access object
      * @param[in] iface - The redundancy D-Bus interface object
      */
-    RedundancyMgr(sdbusplus::async::context& ctx, Services& services,
-                  Sibling& sibling, RedundancyInterface& iface);
+    RedundancyMgr(sdbusplus::async::context& ctx, Providers& providers,
+                  RedundancyInterface& iface);
 
     /**
      * @brief Destructor
      */
     ~RedundancyMgr()
     {
-        services.clearSystemStateCallbacks();
+        providers.getServices().clearSystemStateCallbacks();
     }
 
     /**
@@ -151,14 +149,9 @@ class RedundancyMgr
     sdbusplus::async::context& ctx;
 
     /**
-     * @brief The services object
+     * @brief Provides the various system interfaces
      */
-    Services& services;
-
-    /**
-     * @brief The Sibling object
-     */
-    Sibling& sibling;
+    Providers& providers;
 
     /**
      * @brief The Redundancy D-Bus interface

--- a/redundant-bmc/src/role_handler.hpp
+++ b/redundant-bmc/src/role_handler.hpp
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "providers.hpp"
 #include "redundancy_interface.hpp"
-#include "services.hpp"
-#include "sibling.hpp"
 
 namespace rbmc
 {
@@ -31,14 +30,12 @@ class RoleHandler
      * @brief Constructor
      *
      * @param[in] ctx - The async context object
-     * @param[in] services - The services object
-     * @param[in] sibling - The sibling object
+     * @param[in] providers - The Providers access object
      * @param[in] iface - The redundancy D-Bus interface object
      */
-    RoleHandler(sdbusplus::async::context& ctx, Services& services,
-                Sibling& sibling, RedundancyInterface& iface) :
-        ctx(ctx), services(services), sibling(sibling),
-        redundancyInterface(iface)
+    RoleHandler(sdbusplus::async::context& ctx, Providers& providers,
+                RedundancyInterface& iface) :
+        ctx(ctx), providers(providers), redundancyInterface(iface)
     {}
 
     /**
@@ -68,14 +65,9 @@ class RoleHandler
     sdbusplus::async::context& ctx;
 
     /**
-     * @brief The services object
+     * @brief Provides the various system interfaces
      */
-    Services& services;
-
-    /**
-     * @brief The Sibling object
-     */
-    Sibling& sibling;
+    Providers& providers;
 
     /**
      * @brief The Redundancy D-Bus interface


### PR DESCRIPTION
Add a Providers class to manage the various provider helper classes, as there are more coming.  With this, only it has to be created in main(), and only it has to be passed around.