### PR TITLE
Set FailoversPaused when the system state is not off or runtime

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -120,3 +120,23 @@ wasn't running.
 Note that redundancy cannot be enabled at runtime if the system wasn't booted
 with redundancy enabled. A concurrent maintenance operation would be necessary
 in that case.
+
+## Pausing Failovers
+
+Even when redundancy is enabled, there are periods when failovers will not be
+allowed. This is considered pausing failovers, and there is a boolean
+FailoversPaused D-Bus property to reflect this state.
+
+Failovers will be paused when:
+
+1. The system is at some state other than off or runtime.
+2. More coming.
+
+When failovers are paused, rbmctool can be used to display the reasons why.
+
+Future work to be done:
+
+- Put the reasons on D-Bus and in Redfish so the HMC can get them.
+- Determine if the other BMC needs the reasons, or just if FOs are paused.
+- When writing the failover code, reject the failover if it is paused, though
+  there still needs to be a method to force it for use by field support.

--- a/redundant-bmc/src/persistent_data.hpp
+++ b/redundant-bmc/src/persistent_data.hpp
@@ -20,6 +20,7 @@ constexpr auto roleReason = "RoleReason";
 constexpr auto noRedDetails = "NoRedundancyDetails";
 constexpr auto disableRed = "DisableRedundancy";
 constexpr auto redundancyOffAtRuntime = "RedundancyOffAtRuntime";
+constexpr auto failoversPausedReasons = "FailoversPausedReasons";
 } // namespace key
 
 namespace util

--- a/redundant-bmc/src/redundancy.cpp
+++ b/redundant-bmc/src/redundancy.cpp
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "redundancy.hpp"
 
-namespace rbmc::redundancy
+namespace rbmc
+{
+namespace redundancy
 {
 
 NoRedundancyReasons getNoRedundancyReasons(const Input& input)
@@ -122,4 +124,39 @@ std::string getNoRedundancyDescription(NoRedundancyReason reason)
     return desc;
 }
 
-} // namespace rbmc::redundancy
+} // namespace redundancy
+
+namespace fop
+{
+
+FailoversPausedReasons getFailoversPausedReasons(const Input& input)
+{
+    using enum FailoversPausedReason;
+    FailoversPausedReasons reasons;
+
+    if ((input.systemState != SystemState::off) &&
+        (input.systemState != SystemState::runtime))
+    {
+        reasons.insert(systemState);
+    }
+
+    return reasons;
+}
+
+std::string getFailoversPausedDescription(FailoversPausedReason reason)
+{
+    using enum FailoversPausedReason;
+    using namespace std::string_literals;
+    std::string desc;
+
+    switch (reason)
+    {
+        case systemState:
+            desc = "System state is not off or runtime"s;
+            break;
+    }
+    return desc;
+}
+
+} // namespace fop
+} // namespace rbmc

--- a/redundant-bmc/src/redundancy.hpp
+++ b/redundant-bmc/src/redundancy.hpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "services.hpp"
+
 #include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
 #include <xyz/openbmc_project/State/BMC/common.hpp>
 
@@ -70,4 +72,43 @@ NoRedundancyReasons getNoRedundancyReasons(const Input& input);
 std::string getNoRedundancyDescription(NoRedundancyReason reason);
 
 } // namespace redundancy
+
+// Failovers Paused
+namespace fop
+{
+
+/**
+ * @brief Inputs to the getFailoversPausedReasons function
+ */
+struct Input
+{
+    // TODO: Add more
+    SystemState systemState;
+};
+
+/**
+ * @brief Reasons why failovers have to be paused
+ */
+enum class FailoversPausedReason
+{
+    systemState
+};
+
+using FailoversPausedReasons = std::set<FailoversPausedReason>;
+
+/**
+ * @brief Returns the reasons that failovers must be paused
+ *
+ * @return The reasons.  Empty if there are none.
+ */
+FailoversPausedReasons getFailoversPausedReasons(const Input& input);
+
+/**
+ * @brief Return the string description of the reason
+ *
+ * @return The human readable description.
+ */
+std::string getFailoversPausedDescription(FailoversPausedReason reason);
+
+} // namespace fop
 } // namespace rbmc

--- a/redundant-bmc/src/redundancy_mgr.hpp
+++ b/redundant-bmc/src/redundancy_mgr.hpp
@@ -56,6 +56,12 @@ class RedundancyMgr
      */
     void disableRedPropChanged(bool disable);
 
+    /**
+     * @brief Sets the FailoversPaused property based on the current
+     *        state of the system.
+     */
+    void determineAndSetFailoversPaused();
+
   private:
     /**
      * @brief Returns the reasons that redundancy cannnot be

--- a/redundant-bmc/test/redundancy_test.cpp
+++ b/redundant-bmc/test/redundancy_test.cpp
@@ -151,3 +151,32 @@ TEST(RedundancyTest, GetNoRedundancyDescTest)
     EXPECT_EQ(getNoRedundancyDescription(NoRedundancyReason::codeMismatch),
               "Firmware version mismatch");
 }
+
+TEST(RedundancyTest, FailoversPausedTest)
+{
+    namespace fop = rbmc::fop;
+    using enum fop::FailoversPausedReason;
+
+    std::map<rbmc::SystemState, fop::FailoversPausedReasons> testStates{
+        {rbmc::SystemState::off, {}},
+        {rbmc::SystemState::booting, {systemState}},
+        {rbmc::SystemState::runtime, {}},
+        {rbmc::SystemState::other, {systemState}}};
+
+    for (const auto& [state, expectedReasons] : testStates)
+    {
+        fop::Input input{.systemState = state};
+
+        auto reasons = fop::getFailoversPausedReasons(input);
+        EXPECT_EQ(reasons, expectedReasons);
+    }
+}
+
+TEST(RedundancyTest, GetFailoversPausedDescTest)
+{
+    namespace fop = rbmc::fop;
+
+    EXPECT_EQ(fop::getFailoversPausedDescription(
+                  fop::FailoversPausedReason::systemState),
+              "System state is not off or runtime");
+}


### PR DESCRIPTION
Add support for calculating FailoversPaused based on the system state.  The code is similar to the code that determines if redundancy can be enabled.