### PR TITLE
RBMC: Passive BMC gets FO Paused from Active BMC

### DIFF
--- a/redundant-bmc/src/passive_role_handler.hpp
+++ b/redundant-bmc/src/passive_role_handler.hpp
@@ -64,6 +64,21 @@ class PassiveRoleHandler : public RoleHandler
     void siblingRedEnabledHandler(bool enable) override;
 
     /**
+     * @brief Setup watching the sibling BMC's
+     *        FailoversPaused D-Bus property.
+     */
+    void setupSiblingFailoversPausedWatch();
+
+    /**
+     * @brief Handler for the FailoversPaused property
+     *        on the sibling's D-Bus interface changing.
+     *
+     * Will mirror the value on this BMC's Redundancy
+     * interface if the other BMC is Active.
+     */
+    void siblingFailoversPausedHandler(bool paused);
+
+    /**
      * @brief Handler for the DisableRedundancyOverride
      *        property changing.
      *

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -31,6 +31,7 @@ class Sibling
     using RedundancyEnabledCallback = std::function<void(bool)>;
     using BMCStateCallback = std::function<void(BMCState)>;
     using HeartbeatCallback = std::function<void(bool)>;
+    using FailoversPausedCallback = std::function<void(bool)>;
 
     Sibling() = default;
     virtual ~Sibling() = default;
@@ -133,6 +134,13 @@ class Sibling
     virtual std::optional<bool> getSiblingCommsOK() const = 0;
 
     /**
+     * @brief Returns if the sibling has failovers paused
+     *
+     * @return - If paused, or nullopt if not available
+     */
+    virtual std::optional<bool> getFailoversPaused() const = 0;
+
+    /**
      * @brief Returns if the sibling BMC is plugged in
      *
      * @return bool - if present
@@ -149,6 +157,7 @@ class Sibling
         redEnabledCBs.erase(role);
         clearBMCStateCallback(role);
         clearHeartbeatCallback(role);
+        foPausedCBs.erase(role);
     }
 
     /**
@@ -208,6 +217,18 @@ class Sibling
         heartbeatCBs.emplace(role, std::move(callback));
     }
 
+    /**
+     * @brief Adds a callback function to invoke when the sibling's
+     *        FailoversPaused property changes
+     *
+     * @param[in] role - The role to register with
+     * @param[in] callback - The callback function
+     */
+    void addFailoversPausedCallback(Role role, FailoversPausedCallback callback)
+    {
+        foPausedCBs.emplace(role, std::move(callback));
+    }
+
   protected:
     /**
      * @brief Callbacks for RedundancyEnabled
@@ -223,5 +244,10 @@ class Sibling
      * @brief Callbacks for Heartbeat
      */
     std::map<Role, HeartbeatCallback> heartbeatCBs;
+
+    /**
+     * @brief Callbacks for FailoversPaused
+     */
+    std::map<Role, FailoversPausedCallback> foPausedCBs;
 };
 } // namespace rbmc

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -135,7 +135,15 @@ void SiblingImpl::loadFromPropertyMap(
     it = propertyMap.find("FailoversPaused");
     if (it != propertyMap.end())
     {
+        auto old = failoversPaused;
         failoversPaused = std::get<bool>(it->second);
+        if (failoversPaused != old)
+        {
+            for (const auto& callback : std::ranges::views::values(foPausedCBs))
+            {
+                callback(failoversPaused);
+            }
+        }
     }
 
     it = propertyMap.find("BMCState");

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -189,6 +189,21 @@ class SiblingImpl : public Sibling
     }
 
     /**
+     * @brief Returns if the sibling has failovers paused.
+     *
+     * @return - If paused, or nullopt if not available
+     */
+    std::optional<bool> getFailoversPaused() const override
+    {
+        if (interfacePresent && heartbeat)
+        {
+            return failoversPaused;
+        }
+
+        return std::nullopt;
+    }
+
+    /**
      * @brief Returns if the sibling BMC is plugged in
      *
      * @return bool - if present


### PR DESCRIPTION
The passive BMC will watch the sibling BMC's failovers paused property. If the sibling has the active role, mirror that value out to the FailoversPaused property on the main redundancy D-Bus interface.

This way, when the active BMC pauses failovers, the passive BMC will know that and will be able to reject any failover requests.

Right now, the sibling daemon is just mirroring the Redundancy.FailoversPaused property into the sibling interface, so the flow is:
1. Active BMC determines failovers must be paused.
2. Active BMC writes Redundancy.FailoversPaused.
3. Sibling daemon on active BMC sees that change and sends it to the passive BMC. (Writes to CFAM in IBM's case.)
4. Passive BMC sees sibling interface change and writes it to its Redundancy.FailoversPaused property. (This commit)

In the future, the passive BMC will have its own reasons for pausing failovers, so its Redundancy.FailoversPaused property would be the combination of the failovers paused value from the active BMC and its own calculated value.  And then the active BMC would do the same thing, combining its own calculated value with the one from the passive BMC.

Tested:

Failovers paused on active BMC:
```
Local BMC
-----------------------------
Role:                Active
BMC Position:        0
Redundancy Enabled:  true
BMC State:           Ready
Failovers Paused:    true
FW version hash:     87FC6A7D
Provisioned:         true
Role Reason:         Sibling is already passive
Reasons for failovers paused:
    System state is not off or runtime
```

Failovers paused now set on passive BMC's Redundancy iface:
```
$ busctl get-property xyz.openbmc_project.State.BMC.Redundancy \
/xyz/openbmc_project/state/bmc0 xyz.openbmc_project.State.BMC .Redundancy \
FailoversPaused
b true
```

Unpause failovers on active BMC:
```
Local BMC
-----------------------------
Role:                Active
BMC Position:        0
Redundancy Enabled:  true
BMC State:           Ready
Failovers Paused:    false
FW version hash:     87FC6A7D
Provisioned:         true
Role Reason:         Sibling is already passive
```

The passive BMC now shows FailoversPaused is false:
```
$ busctl get-property xyz.openbmc_project.State.BMC.Redundancy \
/xyz/openbmc_project/state/bmc0 xyz.openbmc_project.State.BMC .Redundancy \
FailoversPaused
b false
```

Change-Id: Ic956e7f52201cfcede0a81fa732cd8023cf4651c