### PR TITLE
Manage RBMC Data Sync on the active BMC

### DIFF
--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -40,7 +40,7 @@ class ActiveRoleHandler : public RoleHandler
      */
     ~ActiveRoleHandler() override
     {
-        providers.getSibling().clearCallbacks(Role::Active);
+        stopSiblingWatches();
     }
 
     /**
@@ -84,9 +84,7 @@ class ActiveRoleHandler : public RoleHandler
     inline void stopSiblingWatches()
     {
         siblingHBTimer.stop();
-        auto& sibling = providers.getSibling();
-        sibling.clearBMCStateCallback(Role::Active);
-        sibling.clearHeartbeatCallback(Role::Active);
+        providers.getSibling().clearCallbacks(Role::Active);
     }
 
     using BMCState =

--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -28,6 +28,7 @@ executable(
     'services_impl.cpp',
     'sibling_impl.cpp',
     'sibling_reset_impl.cpp',
+    'sync_interface_impl.cpp',
     dependencies: rbmc_deps,
     install: true,
     install_dir: execinstalldir,

--- a/redundant-bmc/src/providers.hpp
+++ b/redundant-bmc/src/providers.hpp
@@ -3,6 +3,7 @@
 
 #include "services.hpp"
 #include "sibling.hpp"
+#include "sync_interface.hpp"
 
 namespace rbmc
 {
@@ -32,6 +33,11 @@ class Providers
      * @brief Returns the Sibling provider
      */
     virtual Sibling& getSibling() = 0;
+
+    /**
+     * @brief Returns the SyncInterface provider
+     */
+    virtual SyncInterface& getSyncInterface() = 0;
 };
 
 }; // namespace rbmc

--- a/redundant-bmc/src/providers_impl.hpp
+++ b/redundant-bmc/src/providers_impl.hpp
@@ -4,6 +4,7 @@
 #include "providers.hpp"
 #include "services_impl.hpp"
 #include "sibling_impl.hpp"
+#include "sync_interface_impl.hpp"
 
 namespace rbmc
 {
@@ -29,7 +30,7 @@ class ProvidersImpl : public Providers
      * @param[in] ctx - The async context object
      */
     explicit ProvidersImpl(sdbusplus::async::context& ctx) :
-        services(ctx), sibling(ctx)
+        services(ctx), sibling(ctx), syncInterface(ctx)
     {}
 
     /**
@@ -48,6 +49,14 @@ class ProvidersImpl : public Providers
         return sibling;
     }
 
+    /**
+     * @brief Returns the SyncInterface provider
+     */
+    SyncInterface& getSyncInterface() override
+    {
+        return syncInterface;
+    }
+
   private:
     /**
      * @brief The Services implementation
@@ -58,6 +67,11 @@ class ProvidersImpl : public Providers
      * @brief The Sibling implementation
      */
     SiblingImpl sibling;
+
+    /**
+     * @brief The SyncInterface implementation
+     */
+    SyncInterfaceImpl syncInterface;
 };
 
 }; // namespace rbmc

--- a/redundant-bmc/src/redundancy.cpp
+++ b/redundant-bmc/src/redundancy.cpp
@@ -61,6 +61,11 @@ NoRedundancyReasons getNoRedundancyReasons(const Input& input)
             {
                 reasons.insert(siblingNotAtReady);
             }
+
+            if (input.syncFailed)
+            {
+                reasons.insert(syncFailed);
+            }
         }
     }
 
@@ -116,6 +121,9 @@ std::string getNoRedundancyDescription(NoRedundancyReason reason)
             break;
         case redundancyOffAtRuntimeStart:
             desc = "Redundancy was off upon reaching runtime"s;
+            break;
+        case syncFailed:
+            desc = "Data sync failed"s;
             break;
         case other:
             desc = "Other";

--- a/redundant-bmc/src/redundancy.hpp
+++ b/redundant-bmc/src/redundancy.hpp
@@ -32,6 +32,7 @@ struct Input
     bool codeVersionsMatch;
     bool manualDisable;
     bool redundancyOffAtRuntimeStart;
+    bool syncFailed;
 };
 
 // TODO: Move this to PDI Enums
@@ -52,6 +53,7 @@ enum class NoRedundancyReason
     siblingNotAtReady,
     systemHardwareConfigIssue,
     redundancyOffAtRuntimeStart,
+    syncFailed,
     other
 };
 

--- a/redundant-bmc/src/redundancy_mgr.cpp
+++ b/redundant-bmc/src/redundancy_mgr.cpp
@@ -64,7 +64,8 @@ redundancy::NoRedundancyReasons RedundancyMgr::getNoRedundancyReasons()
         .codeVersionsMatch =
             services.getFWVersion() == sibling.getFWVersion().value_or(""),
         .manualDisable = manualDisable,
-        .redundancyOffAtRuntimeStart = isRedundancyOffAtRuntime()};
+        .redundancyOffAtRuntimeStart = isRedundancyOffAtRuntime(),
+        .syncFailed = syncFailed};
 
     auto reasons = redundancy::getNoRedundancyReasons(input);
 

--- a/redundant-bmc/src/redundancy_mgr.hpp
+++ b/redundant-bmc/src/redundancy_mgr.hpp
@@ -46,6 +46,13 @@ class RedundancyMgr
     void determineAndSetRedundancy();
 
     /**
+     * @brief Determines redundancy, and if enabled does a full sync
+     *
+     * If the full sync fails, redundancy will be disabled.
+     */
+    sdbusplus::async::task<> determineRedundancyAndSync();
+
+    /**
      * @brief Called when the DisableRedundancyOverride D-Bus property
      *        is updated.
      *
@@ -61,6 +68,11 @@ class RedundancyMgr
      *        state of the system.
      */
     void determineAndSetFailoversPaused();
+
+    /**
+     * @brief Disables redundancy due to a failed sync.
+     */
+    void handleBackgroundSyncFailed();
 
   private:
     /**

--- a/redundant-bmc/src/redundancy_mgr.hpp
+++ b/redundant-bmc/src/redundancy_mgr.hpp
@@ -179,6 +179,11 @@ class RedundancyMgr
      * @brief The current system state value
      */
     std::optional<SystemState> systemState;
+
+    /**
+     * @brief If data sync is in a failed state.
+     */
+    bool syncFailed = false;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -148,6 +148,12 @@ class Sibling
     virtual bool isBMCPresent() = 0;
 
     /**
+     * @brief Pause for the amount of time it would take for a heartbeat
+     *        change to be noticed.
+     */
+    virtual sdbusplus::async::task<> pauseForHeartbeatChange() const = 0;
+
+    /**
      * @brief Clears callbacks held based on role
      *
      * @param[in] role - The role to clear

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -155,29 +155,9 @@ class Sibling
     void clearCallbacks(Role role)
     {
         redEnabledCBs.erase(role);
-        clearBMCStateCallback(role);
-        clearHeartbeatCallback(role);
-        foPausedCBs.erase(role);
-    }
-
-    /**
-     * @brief Clears the BMC state callback
-     *
-     * @param[in] role - The role to clear
-     */
-    void clearBMCStateCallback(Role role)
-    {
         bmcStateCBs.erase(role);
-    }
-
-    /**
-     * @brief Clears the heartbeat callback
-     *
-     * @param[in] role - The role to clear
-     */
-    void clearHeartbeatCallback(Role role)
-    {
         heartbeatCBs.erase(role);
+        foPausedCBs.erase(role);
     }
 
     /**

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -421,4 +421,12 @@ sdbusplus::async::task<> SiblingImpl::waitForBMCSteadyState() const
 // NOLINTEND(clang-analyzer-core.uninitialized.Branch,-warnings-as-errors,
 //           readability-static-accessed-through-instance,-warnings-as-errors)
 
+// NOLINTNEXTLINE
+sdbusplus::async::task<> SiblingImpl::pauseForHeartbeatChange() const
+{
+    using namespace std::chrono_literals;
+    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
+    co_return co_await sdbusplus::async::sleep_for(ctx, 5s);
+}
+
 } // namespace rbmc

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -216,6 +216,12 @@ class SiblingImpl : public Sibling
      */
     sdbusplus::async::task<> waitForBMCSteadyState() const override;
 
+    /**
+     * @brief Pause for the amount of time it would take for a heartbeat
+     *        change to be noticed.
+     */
+    sdbusplus::async::task<> pauseForHeartbeatChange() const override;
+
   private:
     /**
      * @brief Starts a Sibling InterfacesAdded watch

--- a/redundant-bmc/src/sync_interface.hpp
+++ b/redundant-bmc/src/sync_interface.hpp
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <sdbusplus/async.hpp>
+#include <xyz/openbmc_project/Control/SyncBMCData/client.hpp>
+#include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
+
+namespace rbmc
+{
+using SyncBMCData =
+    sdbusplus::client::xyz::openbmc_project::control::SyncBMCData<>;
+
+/**
+ * @class SyncInterface
+ *
+ * The interface to the sync daemon to start and stop syncs.
+ */
+class SyncInterface
+{
+  public:
+    SyncInterface() = default;
+    virtual ~SyncInterface() = default;
+    SyncInterface(const SyncInterface&) = delete;
+    SyncInterface& operator=(const SyncInterface&) = delete;
+    SyncInterface(SyncInterface&&) = delete;
+    SyncInterface& operator=(SyncInterface&&) = delete;
+
+    /**
+     * @brief Starts a full sync and waits for it to finish.
+     *
+     * @return true if it completely successfully, else false
+     */
+    virtual sdbusplus::async::task<bool> doFullSync() = 0;
+
+    /**
+     * @brief Turns off background syncing
+     */
+    virtual sdbusplus::async::task<> disableBackgroundSync() = 0;
+
+    /**
+     * @brief Says if a full sync is running inside doFullSync().
+     */
+    inline bool isFullSyncInProgress() const
+    {
+        return fullSyncInProgress;
+    }
+
+    using SyncHealthCallback =
+        std::function<void(SyncBMCData::SyncEventsHealth)>;
+
+    using Role =
+        sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy::Role;
+
+    /**
+     * @brief Adds a function to call when the sync health property
+     *        changes.
+     *
+     * @param[in] role - The role to register with
+     * @param[in] cb - The function object
+     */
+    void watchSyncHealth(Role role, SyncHealthCallback&& cb)
+    {
+        healthCallbacks.emplace(role, std::move(cb));
+    }
+
+    /**
+     * @brief Stops sync health callbacks
+     *
+     * @param[in] role - The role used to add the function.
+     */
+    void stopSyncHealthWatch(Role role)
+    {
+        healthCallbacks.erase(role);
+    }
+
+  protected:
+    /**
+     * @brief If doFullSync is in the middle of doing a sync
+     */
+    bool fullSyncInProgress = false;
+
+    /**
+     * @brief The health status callback functions
+     */
+    std::map<Role, SyncHealthCallback> healthCallbacks;
+};
+
+}; // namespace rbmc

--- a/redundant-bmc/src/sync_interface_impl.cpp
+++ b/redundant-bmc/src/sync_interface_impl.cpp
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <phosphor-logging/lg2.hpp>
+#include <sync_interface_impl.hpp>
+#include <xyz/openbmc_project/ObjectMapper/client.hpp>
+
+#include <ranges>
+
+namespace rbmc
+{
+
+using Mapper = sdbusplus::client::xyz::openbmc_project::ObjectMapper<>;
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<bool> SyncInterfaceImpl::doFullSync()
+{
+    using SyncStatus = SyncBMCData::FullSyncStatus;
+    SyncStatus status = SyncStatus::Unknown;
+
+    try
+    {
+        co_await lookupService();
+
+        auto sync = SyncBMCData(ctx)
+                        .service(syncService)
+                        .path(SyncBMCData::instance_path);
+
+        // Ensure background sync is enabled.
+        co_await sync.disable_sync(false);
+
+        status = co_await sync.full_sync_status();
+
+        fullSyncInProgress = true;
+        if (status != SyncStatus::FullSyncInProgress)
+        {
+            lg2::info("Starting full sync and waiting for completion");
+            co_await sync.start_full_sync();
+        }
+        else
+        {
+            // A full sync is already running, don't need to start one.
+            lg2::info(
+                "A full sync is already in progress, waiting for completion");
+        }
+
+        namespace rules = sdbusplus::bus::match::rules;
+        sdbusplus::async::match match(
+            ctx, rules::propertiesChanged(SyncBMCData::instance_path,
+                                          SyncBMCData::interface));
+
+        status = co_await sync.full_sync_status();
+
+        while ((status == SyncStatus::FullSyncInProgress) &&
+               !ctx.stop_requested())
+        {
+            using PropertyMap =
+                std::unordered_map<std::string, SyncBMCData::PropertiesVariant>;
+            auto [_,
+                  properties] = co_await match.next<std::string, PropertyMap>();
+
+            auto it = properties.find("FullSyncStatus");
+            if (it != properties.end())
+            {
+                status = std::get<SyncStatus>(it->second);
+            }
+        }
+    }
+    catch (const std::exception& e)
+    {
+        fullSyncInProgress = false;
+        throw;
+    }
+
+    lg2::info("Full sync completed with status {STATUS}", "STATUS", status);
+
+    fullSyncInProgress = false;
+    co_return status == SyncStatus::FullSyncCompleted;
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> SyncInterfaceImpl::lookupService()
+{
+    if (!syncService.empty())
+    {
+        co_return;
+    }
+
+    auto object =
+        co_await Mapper(ctx)
+            .service(Mapper::default_service)
+            .path(Mapper::instance_path)
+            .get_object(SyncBMCData::instance_path, {SyncBMCData::interface});
+
+    syncService = object.begin()->first;
+    co_return;
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> SyncInterfaceImpl::disableBackgroundSync()
+{
+    try
+    {
+        co_await lookupService();
+
+        co_await SyncBMCData(ctx)
+            .service(syncService)
+            .path(SyncBMCData::instance_path)
+            .disable_sync(true);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Call to disable sync failed: {ERROR}:", "ERROR", e);
+    }
+
+    co_return;
+}
+
+sdbusplus::async::task<>
+    // NOLINTNEXTLINE
+    SyncInterfaceImpl::watchSyncEventsHealthPropertyChanged()
+{
+    namespace rules = sdbusplus::bus::match::rules;
+    sdbusplus::async::match match(
+        ctx, rules::propertiesChanged(SyncBMCData::instance_path,
+                                      SyncBMCData::interface));
+
+    while (!ctx.stop_requested())
+    {
+        using PropertyMap =
+            std::unordered_map<std::string, SyncBMCData::PropertiesVariant>;
+
+        auto [_, properties] = co_await match.next<std::string, PropertyMap>();
+
+        if (auto it = properties.find("SyncEventsHealth");
+            it != properties.end())
+        {
+            for (const auto& callback :
+                 std::ranges::views::values(healthCallbacks))
+            {
+                callback(std::get<SyncBMCData::SyncEventsHealth>(it->second));
+            }
+        }
+    }
+
+    co_return;
+}
+
+}; // namespace rbmc

--- a/redundant-bmc/src/sync_interface_impl.hpp
+++ b/redundant-bmc/src/sync_interface_impl.hpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "sync_interface.hpp"
+
+namespace rbmc
+{
+
+/**
+ * @class SyncInterfaceImpl
+ *
+ * The interface to the sync daemon to start and stop syncs.
+ */
+class SyncInterfaceImpl : public SyncInterface
+{
+  public:
+    ~SyncInterfaceImpl() override = default;
+    SyncInterfaceImpl(const SyncInterfaceImpl&) = delete;
+    SyncInterfaceImpl& operator=(const SyncInterfaceImpl&) = delete;
+    SyncInterfaceImpl(SyncInterfaceImpl&&) = delete;
+    SyncInterfaceImpl& operator=(SyncInterfaceImpl&&) = delete;
+
+    /**
+     * @brief Constructor
+     *
+     * @param[in] ctx - The async context object
+     */
+    explicit SyncInterfaceImpl(sdbusplus::async::context& ctx) : ctx(ctx)
+    {
+        ctx.spawn(watchSyncEventsHealthPropertyChanged());
+    }
+
+    /**
+     * @brief Starts a full sync and waits for it to finish.
+     *
+     * @return true if it completely successfully, else false
+     */
+    sdbusplus::async::task<bool> doFullSync() override;
+
+    /**
+     * @brief Turns off background syncing
+     */
+    sdbusplus::async::task<> disableBackgroundSync() override;
+
+  private:
+    /**
+     * @brief Looks up the data sync D-Bus service if it hasn't already
+     *        been looked up.
+     */
+    sdbusplus::async::task<> lookupService();
+
+    /**
+     * @brief The properties changed watch for the sync health property
+     */
+    sdbusplus::async::task<> watchSyncEventsHealthPropertyChanged();
+
+    /**
+     * @brief The async context object
+     */
+    sdbusplus::async::context& ctx;
+
+    /**
+     * @brief The name of the sync daemon's D-Bus service.
+     */
+    std::string syncService;
+};
+
+}; // namespace rbmc

--- a/redundant-bmc/test/redundancy_test.cpp
+++ b/redundant-bmc/test/redundancy_test.cpp
@@ -20,7 +20,8 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
         .siblingState = rbmc::BMCState::Ready,
         .codeVersionsMatch = true,
         .manualDisable = false,
-        .redundancyOffAtRuntimeStart = false};
+        .redundancyOffAtRuntimeStart = false,
+        .syncFailed = false};
 
     // Nothing stopping redundancy
     {
@@ -126,6 +127,16 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
         auto reasons = getNoRedundancyReasons(input);
         ASSERT_EQ(reasons.size(), 1);
         EXPECT_EQ(*reasons.begin(), redundancyOffAtRuntimeStart);
+    }
+
+    // Sync failed
+    {
+        auto input = golden;
+        input.syncFailed = true;
+
+        auto reasons = getNoRedundancyReasons(input);
+        ASSERT_EQ(reasons.size(), 1);
+        EXPECT_EQ(*reasons.begin(), syncFailed);
     }
 
     // Multiple fails


### PR DESCRIPTION
Do a full sync when enabling redundancy, including any time the passive BMC's heartbeat starts back up.

Stop background syncing when redundancy is disabled.

Also watch the background sync status.  If it goes to critical, disable redundancy (assuming the heartbeat is still OK).