### PR TITLE
RBMC: Change FailoversPaused to FailoversAllowed

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -169,22 +169,22 @@ just let the sibling heartbeat monitoring code handle the situation.
 However if the sibling still does have a heartbeat, then redundancy will be
 disabled with the reason being a sync failure.
 
-## Pausing Failovers
+## Allowing Failovers
 
 Even when redundancy is enabled, there are periods when failovers will not be
-allowed. This is considered pausing failovers, and there is a boolean
-FailoversPaused D-Bus property to reflect this state.
+allowed. The `FailoversAllowed` D-Bus project reflects this state.
 
-Failovers will be paused when:
+Failovers aren't allowed when:
 
-1. The system is at some state other than off or runtime.
-2. More coming.
+1. Redundancy is disabled.
+2. The system is at some state other than off or runtime.
+3. More coming.
 
-When failovers are paused, rbmctool can be used to display the reasons why.
+When failovers aren't allowed, rbmctool can be used to display the reasons why.
 
 Future work to be done:
 
 - Put the reasons on D-Bus and in Redfish so the HMC can get them.
-- Determine if the other BMC needs the reasons, or just if FOs are paused.
-- When writing the failover code, reject the failover if it is paused, though
-  there still needs to be a method to force it for use by field support.
+- Determine if the other BMC needs the reasons, or just if FOs aren't allowed.
+- When writing the failover code, reject the failover if it isn't allowed,
+  though there still needs to be a method to force it for use by field support.

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -29,7 +29,7 @@ sdbusplus::async::task<> PassiveRoleHandler::start()
     // Setup the mirroring of the active BMC RedundancyEnabled
     setupSiblingRedEnabledWatch();
 
-    setupSiblingFailoversPausedWatch();
+    setupSiblingFailoversAllowedWatch();
 
     try
     {
@@ -75,20 +75,20 @@ void PassiveRoleHandler::setupSiblingRedEnabledWatch()
     });
 }
 
-void PassiveRoleHandler::setupSiblingFailoversPausedWatch()
+void PassiveRoleHandler::setupSiblingFailoversAllowedWatch()
 {
     auto& sibling = providers.getSibling();
 
     // Register for changes
-    sibling.addFailoversPausedCallback(Role::Passive, [this](bool paused) {
-        siblingFailoversPausedHandler(paused);
+    sibling.addFailoversAllowedCallback(Role::Passive, [this](bool allowed) {
+        siblingFailoversAllowedHandler(allowed);
     });
 
     // Handle current value
-    auto sibPaused = sibling.getFailoversPaused();
-    if (sibPaused.has_value())
+    auto sibAllowed = sibling.getFailoversAllowed();
+    if (sibAllowed.has_value())
     {
-        siblingFailoversPausedHandler(sibPaused.value());
+        siblingFailoversAllowedHandler(sibAllowed.value());
     }
 }
 
@@ -102,15 +102,15 @@ void PassiveRoleHandler::siblingRedEnabledHandler(bool enable)
     }
 }
 
-void PassiveRoleHandler::siblingFailoversPausedHandler(bool paused)
+void PassiveRoleHandler::siblingFailoversAllowedHandler(bool allowed)
 {
     // If the sibling is Active, mirror the property on this BMC.
-    // TODO: The passive BMC ill have its own reasons for pausing
+    // TODO: The passive BMC ill have its own reasons for not allowing
     // failovers that also need to be considered.
     if (providers.getSibling().getRole().value_or(Role::Unknown) ==
         Role::Active)
     {
-        redundancyInterface.failovers_paused(paused);
+        redundancyInterface.failovers_allowed(allowed);
     }
 }
 

--- a/redundant-bmc/src/passive_role_handler.hpp
+++ b/redundant-bmc/src/passive_role_handler.hpp
@@ -65,18 +65,18 @@ class PassiveRoleHandler : public RoleHandler
 
     /**
      * @brief Setup watching the sibling BMC's
-     *        FailoversPaused D-Bus property.
+     *        FailoversAllowed D-Bus property.
      */
-    void setupSiblingFailoversPausedWatch();
+    void setupSiblingFailoversAllowedWatch();
 
     /**
-     * @brief Handler for the FailoversPaused property
+     * @brief Handler for the FailoversAllowed property
      *        on the sibling's D-Bus interface changing.
      *
      * Will mirror the value on this BMC's Redundancy
      * interface if the other BMC is Active.
      */
-    void siblingFailoversPausedHandler(bool paused);
+    void siblingFailoversAllowedHandler(bool allowed);
 
     /**
      * @brief Handler for the DisableRedundancyOverride

--- a/redundant-bmc/src/persistent_data.hpp
+++ b/redundant-bmc/src/persistent_data.hpp
@@ -20,7 +20,7 @@ constexpr auto roleReason = "RoleReason";
 constexpr auto noRedDetails = "NoRedundancyDetails";
 constexpr auto disableRed = "DisableRedundancy";
 constexpr auto redundancyOffAtRuntime = "RedundancyOffAtRuntime";
-constexpr auto failoversPausedReasons = "FailoversPausedReasons";
+constexpr auto failoversNotAllowedReasons = "FailoversNotAllowedReasons";
 } // namespace key
 
 namespace util

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -62,11 +62,11 @@ void printNoRedReasons()
     }
 }
 
-void printFOPReasons()
+void printFONotAllowedReasons()
 {
-    std::cout << "Reasons for failovers paused:\n";
+    std::cout << "Reasons failovers are not allowed:\n";
     auto reasons =
-        data::read<std::set<std::string>>(data::key::failoversPausedReasons)
+        data::read<std::set<std::string>>(data::key::failoversNotAllowedReasons)
             .value_or(std::set<std::string>());
     if (!reasons.empty())
     {
@@ -117,8 +117,8 @@ sdbusplus::async::task<> displayLocalBMCInfo(sdbusplus::async::context& ctx,
             auto bmcState = co_await getBMCState(services);
             std::cout << std::format("BMC State:           {}\n", bmcState);
 
-            auto paused = std::get<bool>(props.at("FailoversPaused"));
-            std::cout << std::format("Failovers Paused:    {}\n", paused);
+            auto allowed = std::get<bool>(props.at("FailoversAllowed"));
+            std::cout << std::format("Failovers Allowed:   {}\n", allowed);
 
             std::cout << std::format("FW version hash:     {}\n",
                                      services.getFWVersion());
@@ -137,9 +137,9 @@ sdbusplus::async::task<> displayLocalBMCInfo(sdbusplus::async::context& ctx,
                 printNoRedReasons();
             }
 
-            if ((role == "Active") && enabled && paused)
+            if ((role == "Active") && enabled && !allowed)
             {
-                printFOPReasons();
+                printFONotAllowedReasons();
             }
         }
     }
@@ -197,13 +197,13 @@ sdbusplus::async::task<> displaySiblingBMCInfo(sdbusplus::async::context& ctx,
         auto provisioned = std::get<bool>(props.at("Provisioned"));
         auto commOK = std::get<bool>(props.at("CommunicationOK"));
         auto fwVersion = std::get<std::string>(props.at("FWVersion"));
-        auto paused = std::get<bool>(props.at("FailoversPaused"));
+        auto allowed = std::get<bool>(props.at("FailoversAllowed"));
         auto enabled = std::get<bool>(props.at("RedundancyEnabled"));
 
         std::cout << std::format("BMC Position:        {}\n", pos);
         std::cout << std::format("BMC State:           {}\n", bmcState);
         std::cout << std::format("Redundancy Enabled:  {}\n", enabled);
-        std::cout << std::format("Failovers Paused:    {}\n", paused);
+        std::cout << std::format("Failovers Allowed:   {}\n", allowed);
         std::cout << std::format("Sibling Comm OK:     {}\n", commOK);
         std::cout << std::format("FW version hash:     {}\n", fwVersion);
         std::cout << std::format("Provisioned:         {}\n", provisioned);

--- a/redundant-bmc/src/redundancy.cpp
+++ b/redundant-bmc/src/redundancy.cpp
@@ -134,13 +134,20 @@ std::string getNoRedundancyDescription(NoRedundancyReason reason)
 
 } // namespace redundancy
 
-namespace fop
+namespace fona
 {
 
-FailoversPausedReasons getFailoversPausedReasons(const Input& input)
+FailoversNotAllowedReasons getFailoversNotAllowedReasons(const Input& input)
 {
-    using enum FailoversPausedReason;
-    FailoversPausedReasons reasons;
+    using enum FailoversNotAllowedReason;
+    FailoversNotAllowedReasons reasons;
+
+    if (!input.redundancyEnabled)
+    {
+        reasons.insert(redundancyDisabled);
+        // No need to look for more reasons
+        return reasons;
+    }
 
     if ((input.systemState != SystemState::off) &&
         (input.systemState != SystemState::runtime))
@@ -151,9 +158,9 @@ FailoversPausedReasons getFailoversPausedReasons(const Input& input)
     return reasons;
 }
 
-std::string getFailoversPausedDescription(FailoversPausedReason reason)
+std::string getFailoversNotAllowedDescription(FailoversNotAllowedReason reason)
 {
-    using enum FailoversPausedReason;
+    using enum FailoversNotAllowedReason;
     using namespace std::string_literals;
     std::string desc;
 
@@ -162,9 +169,12 @@ std::string getFailoversPausedDescription(FailoversPausedReason reason)
         case systemState:
             desc = "System state is not off or runtime"s;
             break;
+        case redundancyDisabled:
+            desc = "Redundancy is disabled"s;
+            break;
     }
     return desc;
 }
 
-} // namespace fop
+} // namespace fona
 } // namespace rbmc

--- a/redundant-bmc/src/redundancy.hpp
+++ b/redundant-bmc/src/redundancy.hpp
@@ -75,42 +75,44 @@ std::string getNoRedundancyDescription(NoRedundancyReason reason);
 
 } // namespace redundancy
 
-// Failovers Paused
-namespace fop
+// Failovers not allowed
+namespace fona
 {
 
 /**
- * @brief Inputs to the getFailoversPausedReasons function
+ * @brief Inputs to the getFailoversNotAllowedReasons function
  */
 struct Input
 {
     // TODO: Add more
+    bool redundancyEnabled;
     SystemState systemState;
 };
 
 /**
- * @brief Reasons why failovers have to be paused
+ * @brief Reasons why failovers aren't allowed
  */
-enum class FailoversPausedReason
+enum class FailoversNotAllowedReason
 {
+    redundancyDisabled,
     systemState
 };
 
-using FailoversPausedReasons = std::set<FailoversPausedReason>;
+using FailoversNotAllowedReasons = std::set<FailoversNotAllowedReason>;
 
 /**
- * @brief Returns the reasons that failovers must be paused
+ * @brief Returns the reasons that failovers aren't allowed
  *
  * @return The reasons.  Empty if there are none.
  */
-FailoversPausedReasons getFailoversPausedReasons(const Input& input);
+FailoversNotAllowedReasons getFailoversNotAllowedReasons(const Input& input);
 
 /**
  * @brief Return the string description of the reason
  *
  * @return The human readable description.
  */
-std::string getFailoversPausedDescription(FailoversPausedReason reason);
+std::string getFailoversNotAllowedDescription(FailoversNotAllowedReason reason);
 
-} // namespace fop
+} // namespace fona
 } // namespace rbmc

--- a/redundant-bmc/src/redundancy_mgr.hpp
+++ b/redundant-bmc/src/redundancy_mgr.hpp
@@ -64,10 +64,10 @@ class RedundancyMgr
     void disableRedPropChanged(bool disable);
 
     /**
-     * @brief Sets the FailoversPaused property based on the current
+     * @brief Sets the FailoversAllowed property based on the current
      *        state of the system.
      */
-    void determineAndSetFailoversPaused();
+    void determineAndSetFailoversAllowed();
 
     /**
      * @brief Disables redundancy due to a failed sync.

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -31,7 +31,7 @@ class Sibling
     using RedundancyEnabledCallback = std::function<void(bool)>;
     using BMCStateCallback = std::function<void(BMCState)>;
     using HeartbeatCallback = std::function<void(bool)>;
-    using FailoversPausedCallback = std::function<void(bool)>;
+    using FailoversAllowedCallback = std::function<void(bool)>;
 
     Sibling() = default;
     virtual ~Sibling() = default;
@@ -134,11 +134,11 @@ class Sibling
     virtual std::optional<bool> getSiblingCommsOK() const = 0;
 
     /**
-     * @brief Returns if the sibling has failovers paused
+     * @brief Returns if the sibling has failovers allowed
      *
-     * @return - If paused, or nullopt if not available
+     * @return - If allowed, or nullopt if not available
      */
-    virtual std::optional<bool> getFailoversPaused() const = 0;
+    virtual std::optional<bool> getFailoversAllowed() const = 0;
 
     /**
      * @brief Returns if the sibling BMC is plugged in
@@ -163,7 +163,7 @@ class Sibling
         redEnabledCBs.erase(role);
         bmcStateCBs.erase(role);
         heartbeatCBs.erase(role);
-        foPausedCBs.erase(role);
+        foAllowedCBs.erase(role);
     }
 
     /**
@@ -205,14 +205,15 @@ class Sibling
 
     /**
      * @brief Adds a callback function to invoke when the sibling's
-     *        FailoversPaused property changes
+     *        FailoversAllowed property changes
      *
      * @param[in] role - The role to register with
      * @param[in] callback - The callback function
      */
-    void addFailoversPausedCallback(Role role, FailoversPausedCallback callback)
+    void addFailoversAllowedCallback(Role role,
+                                     FailoversAllowedCallback callback)
     {
-        foPausedCBs.emplace(role, std::move(callback));
+        foAllowedCBs.emplace(role, std::move(callback));
     }
 
   protected:
@@ -232,8 +233,8 @@ class Sibling
     std::map<Role, HeartbeatCallback> heartbeatCBs;
 
     /**
-     * @brief Callbacks for FailoversPaused
+     * @brief Callbacks for FailoversAllowed
      */
-    std::map<Role, FailoversPausedCallback> foPausedCBs;
+    std::map<Role, FailoversAllowedCallback> foAllowedCBs;
 };
 } // namespace rbmc

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -132,16 +132,17 @@ void SiblingImpl::loadFromPropertyMap(
         }
     }
 
-    it = propertyMap.find("FailoversPaused");
+    it = propertyMap.find("FailoversAllowed");
     if (it != propertyMap.end())
     {
-        auto old = failoversPaused;
-        failoversPaused = std::get<bool>(it->second);
-        if (failoversPaused != old)
+        auto old = failoversAllowed;
+        failoversAllowed = std::get<bool>(it->second);
+        if (failoversAllowed != old)
         {
-            for (const auto& callback : std::ranges::views::values(foPausedCBs))
+            for (const auto& callback :
+                 std::ranges::views::values(foAllowedCBs))
             {
-                callback(failoversPaused);
+                callback(failoversAllowed);
             }
         }
     }

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -189,15 +189,15 @@ class SiblingImpl : public Sibling
     }
 
     /**
-     * @brief Returns if the sibling has failovers paused.
+     * @brief Returns if the sibling has failovers allowed.
      *
-     * @return - If paused, or nullopt if not available
+     * @return - If allowed, or nullopt if not available
      */
-    std::optional<bool> getFailoversPaused() const override
+    std::optional<bool> getFailoversAllowed() const override
     {
         if (interfacePresent && heartbeat)
         {
-            return failoversPaused;
+            return failoversAllowed;
         }
 
         return std::nullopt;
@@ -298,9 +298,9 @@ class SiblingImpl : public Sibling
     bool redEnabled = false;
 
     /**
-     * @brief If sibling failovers are paused
+     * @brief If sibling failovers are allowed
      */
-    bool failoversPaused = false;
+    bool failoversAllowed = false;
 
     /**
      * @brief The sibling's BMC state


### PR DESCRIPTION
Rename the FailoversPaused property to FailoversAllowed to more accurately reflect what it's used for.

Also, a failover is not allowed when redundancy is disabled, so also included a check for that when calculated the property value.

Tested:
Manually disable redundancy:
```
$ rbmctool -de

Local BMC
-----------------------------
Role:                Active
BMC Position:        0
Redundancy Enabled:  false
BMC State:           Ready
Failovers Allowed:   false <-----------
FW version hash:     7969307F
Provisioned:         true
Role Reason:         Sibling is already passive
Reasons for no BMC redundancy:
    Manually disabled

$ grep -A 1 FailoversNotAllowed /var/lib/phosphor-state-manager/redundant-bmc/data.json
    "FailoversNotAllowedReasons": [
        "Redundancy is disabled"
```

Wrong system state:
```
$ rbmctool -de

Local BMC
-----------------------------
Role:                Active
BMC Position:        0
Redundancy Enabled:  true
BMC State:           Ready
Failovers Allowed:   false <------------
FW version hash:     7969307F
Provisioned:         true
Role Reason:         Sibling is already passive
Reasons failovers are not allowed:
    System state is not off or runtime
```

Change-Id: Icdde7b8acf76220d1c311068b4f8223e33c5023f