### PR TITLE
bmc-state: ensure bmc remains in quiesced

### DIFF
--- a/bmc_state_manager.hpp
+++ b/bmc_state_manager.hpp
@@ -97,6 +97,11 @@ class BMC : public BMCInherit
 
   private:
     /**
+     * @brief Put BMC into quiesced state and disable all state monitoring
+     **/
+    void bmcIsQuiesced();
+
+    /**
      * @brief Retrieve input systemd unit state
      **/
     std::string getUnitState(const std::string& unitToCheck);


### PR DESCRIPTION
Recently found a bug where if a critical application fails early in the BMC boot, the BMC state will start at Quiesced but go to Ready. This is a bug in that once the BMC goes to Quiesced, it must remain there until the BMC is rebooted.

The bug is that the discoverInitialState() function initially moves to Quiesced on startup but it does not unsubscribe from systemd events so if the failing service was not a "Requires" for multi-user.target, the BMC state management application will get the "done" dbus event and move from Quiesced to Ready.

Tested:
- Confirmed that BMC now remains in Quiesced when early services fail

Change-Id: Ied1a25939b324c04ae850894584daabe6f02c190