### PR TITLE
RBMC: Stop using 2 sibling BMC properties

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -27,8 +27,6 @@ The current rules for role determination are:
 
 1. If the sibling BMC doesn't have a heartbeat, choose active. It could be the
    sibling isn't even present.
-1. If the sibling BMC's position matches this BMC's position, choose passive.
-   This is an error case.
 1. If the sibling isn't provisioned, choose active.
 1. If the sibling is already passive, choose active.
 1. If the sibling is already active, choose passive.

--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -80,8 +80,6 @@ items to see if redundancy can be enabled:
 1. Redundancy hasn't been manually disabled with the D-bus property that does
    so.
 1. The sibling BMC has been provisioned.
-1. The sibling's 'sibling communication OK' property is true, meaning it is able
-   to talk to the active BMC.
 1. The firmware versions are the same on the BMCs.
 1. If attempting to enable any time at runtime, redundancy must have been
    enabled when runtime was first reached.

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -149,12 +149,10 @@ role_determination::RoleInfo Manager::determineRole()
         //        them anyway because there would be no heartbeat.
         auto siblingRole = sibling.getRole().value_or(Role::Unknown);
         auto siblingProvisioned = sibling.getProvisioned().value_or(false);
-        auto siblingPosition = sibling.getPosition().value_or(0xFF);
 
         role_determination::Input input{
             .bmcPosition = services.getBMCPosition(),
             .previousRole = previousRole,
-            .siblingPosition = siblingPosition,
             .siblingRole = siblingRole,
             .siblingHeartbeat = sibling.hasHeartbeat(),
             .siblingProvisioned = siblingProvisioned};

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -193,14 +193,12 @@ sdbusplus::async::task<> displaySiblingBMCInfo(sdbusplus::async::context& ctx,
         auto bmcState = BMCState::convertBMCStateToString(
             std::get<BMCState::BMCState>(props.at("BMCState")));
         bmcState = bmcState.substr(bmcState.find_last_of('.') + 1);
-        auto pos = std::get<size_t>(props.at("BMCPosition"));
         auto provisioned = std::get<bool>(props.at("Provisioned"));
         auto commOK = std::get<bool>(props.at("CommunicationOK"));
         auto fwVersion = std::get<std::string>(props.at("FWVersion"));
         auto allowed = std::get<bool>(props.at("FailoversAllowed"));
         auto enabled = std::get<bool>(props.at("RedundancyEnabled"));
 
-        std::cout << std::format("BMC Position:        {}\n", pos);
         std::cout << std::format("BMC State:           {}\n", bmcState);
         std::cout << std::format("Redundancy Enabled:  {}\n", enabled);
         std::cout << std::format("Failovers Allowed:   {}\n", allowed);

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -194,7 +194,6 @@ sdbusplus::async::task<> displaySiblingBMCInfo(sdbusplus::async::context& ctx,
             std::get<BMCState::BMCState>(props.at("BMCState")));
         bmcState = bmcState.substr(bmcState.find_last_of('.') + 1);
         auto provisioned = std::get<bool>(props.at("Provisioned"));
-        auto commOK = std::get<bool>(props.at("CommunicationOK"));
         auto fwVersion = std::get<std::string>(props.at("FWVersion"));
         auto allowed = std::get<bool>(props.at("FailoversAllowed"));
         auto enabled = std::get<bool>(props.at("RedundancyEnabled"));
@@ -202,7 +201,6 @@ sdbusplus::async::task<> displaySiblingBMCInfo(sdbusplus::async::context& ctx,
         std::cout << std::format("BMC State:           {}\n", bmcState);
         std::cout << std::format("Redundancy Enabled:  {}\n", enabled);
         std::cout << std::format("Failovers Allowed:   {}\n", allowed);
-        std::cout << std::format("Sibling Comm OK:     {}\n", commOK);
         std::cout << std::format("FW version hash:     {}\n", fwVersion);
         std::cout << std::format("Provisioned:         {}\n", provisioned);
     }

--- a/redundant-bmc/src/redundancy.cpp
+++ b/redundant-bmc/src/redundancy.cpp
@@ -47,11 +47,6 @@ NoRedundancyReasons getNoRedundancyReasons(const Input& input)
                 reasons.insert(siblingNotPassive);
             }
 
-            if (!input.siblingHasSiblingComm)
-            {
-                reasons.insert(siblingNoCommunication);
-            }
-
             if (!input.codeVersionsMatch)
             {
                 reasons.insert(codeMismatch);
@@ -106,9 +101,6 @@ std::string getNoRedundancyDescription(NoRedundancyReason reason)
             break;
         case siblingNotPassive:
             desc = "Sibling is not passive"s;
-            break;
-        case siblingNoCommunication:
-            desc = "Sibling has no communication with this BMC"s;
             break;
         case codeMismatch:
             desc = "Firmware version mismatch"s;

--- a/redundant-bmc/src/redundancy.hpp
+++ b/redundant-bmc/src/redundancy.hpp
@@ -26,7 +26,6 @@ struct Input
     bool siblingPresent;
     bool siblingHeartbeat;
     bool siblingProvisioned;
-    bool siblingHasSiblingComm;
     Role siblingRole;
     BMCState siblingState;
     bool codeVersionsMatch;
@@ -48,7 +47,6 @@ enum class NoRedundancyReason
     noSiblingHeartbeat,
     siblingNotProvisioned,
     siblingNotPassive,
-    siblingNoCommunication,
     codeMismatch,
     siblingNotAtReady,
     systemHardwareConfigIssue,

--- a/redundant-bmc/src/redundancy_mgr.cpp
+++ b/redundant-bmc/src/redundancy_mgr.cpp
@@ -102,7 +102,6 @@ redundancy::NoRedundancyReasons RedundancyMgr::getNoRedundancyReasons()
         .siblingPresent = sibling.isBMCPresent(),
         .siblingHeartbeat = sibling.hasHeartbeat(),
         .siblingProvisioned = sibling.getProvisioned().value_or(false),
-        .siblingHasSiblingComm = sibling.getSiblingCommsOK().value_or(false),
         .siblingRole = sibling.getRole().value_or(Role::Unknown),
         .siblingState = sibling.getBMCState().value_or(BMCState::NotReady),
         .codeVersionsMatch =

--- a/redundant-bmc/src/role_determination.cpp
+++ b/redundant-bmc/src/role_determination.cpp
@@ -15,11 +15,6 @@ RoleInfo determineRole(const Input& input)
         result = {Role::Active, RoleReason::noSiblingHeartbeat};
     }
 
-    else if (input.bmcPosition == input.siblingPosition)
-    {
-        result = {Role::Passive, RoleReason::samePositions};
-    }
-
     else if (!input.siblingProvisioned)
     {
         result = {Role::Active, RoleReason::siblingNotProvisioned};
@@ -71,9 +66,6 @@ std::string getRoleReasonDescription(RoleReason reason)
         case RoleReason::noSiblingHeartbeat:
             desc = "No sibling heartbeat"s;
             break;
-        case RoleReason::samePositions:
-            desc = "Both BMCs have the same position"s;
-            break;
         case RoleReason::siblingNotProvisioned:
             desc = "Sibling is not provisioned"s;
             break;
@@ -109,8 +101,8 @@ std::string getRoleReasonDescription(RoleReason reason)
 bool isErrorReason(RoleReason reason)
 {
     using enum RoleReason;
-    return (reason == samePositions) || (reason == notProvisioned) ||
-           (reason == siblingServiceNotRunning) || (reason == exception);
+    return (reason == notProvisioned) || (reason == siblingServiceNotRunning) ||
+           (reason == exception);
 }
 
 } // namespace rbmc::role_determination

--- a/redundant-bmc/src/role_determination.hpp
+++ b/redundant-bmc/src/role_determination.hpp
@@ -19,7 +19,6 @@ struct Input
 {
     size_t bmcPosition;
     Role previousRole;
-    size_t siblingPosition;
     Role siblingRole;
     bool siblingHeartbeat;
     bool siblingProvisioned;
@@ -32,7 +31,6 @@ enum class RoleReason
 {
     unknown,
     noSiblingHeartbeat,
-    samePositions,
     siblingNotProvisioned,
     siblingPassive,
     siblingActive,

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -120,13 +120,6 @@ class Sibling
     virtual std::optional<std::string> getFWVersion() const = 0;
 
     /**
-     * @brief Returns the sibling BMC's commsOK value
-     *
-     * @return - The value, or nullopt if not available
-     */
-    virtual std::optional<bool> getSiblingCommsOK() const = 0;
-
-    /**
      * @brief Returns if the sibling has failovers allowed
      *
      * @return - If allowed, or nullopt if not available

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -85,13 +85,6 @@ class Sibling
     virtual sdbusplus::async::task<> waitForBMCSteadyState() const = 0;
 
     /**
-     * @brief Returns the sibling BMC's position
-     *
-     * @return - The position or nullopt if not available
-     */
-    virtual std::optional<size_t> getPosition() const = 0;
-
-    /**
      * @brief Returns the sibling BMC's state
      *
      * @return - The state or nullopt if not available

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -161,12 +161,6 @@ void SiblingImpl::loadFromPropertyMap(
         role = std::get<Role>(it->second);
     }
 
-    it = propertyMap.find("CommunicationOK");
-    if (it != propertyMap.end())
-    {
-        commsOK = std::get<bool>(it->second);
-    }
-
     it = propertyMap.find("Heartbeat");
     if (it != propertyMap.end())
     {

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -99,13 +99,7 @@ sdbusplus::async::task<std::string> SiblingImpl::getServiceName()
 void SiblingImpl::loadFromPropertyMap(
     const SiblingImpl::PropertyMap& propertyMap)
 {
-    auto it = propertyMap.find("BMCPosition");
-    if (it != propertyMap.end())
-    {
-        bmcPosition = std::get<size_t>(it->second);
-    }
-
-    it = propertyMap.find("FWVersion");
+    auto it = propertyMap.find("FWVersion");
     if (it != propertyMap.end())
     {
         fwVersion = std::get<std::string>(it->second);

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -159,21 +159,6 @@ class SiblingImpl : public Sibling
     }
 
     /**
-     * @brief Returns the sibling BMC's commsOK value
-     *
-     * @return - The value, or nullopt if not available
-     */
-    std::optional<bool> getSiblingCommsOK() const override
-    {
-        if (interfacePresent && heartbeat)
-        {
-            return commsOK;
-        }
-
-        return std::nullopt;
-    }
-
-    /**
      * @brief Returns if the sibling has failovers allowed.
      *
      * @return - If allowed, or nullopt if not available
@@ -291,11 +276,6 @@ class SiblingImpl : public Sibling
      * @brief The sibling's role
      */
     Role role = Role::Unknown;
-
-    /**
-     * @brief If the sibling can talk to this BMC
-     */
-    bool commsOK = false;
 
     /**
      * @brief If the sibling heartbeat is active.

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -84,21 +84,6 @@ class SiblingImpl : public Sibling
     sdbusplus::async::task<> waitForSiblingRole() override;
 
     /**
-     * @brief Returns the sibling BMC's position
-     *
-     * @return - The position or nullopt if not available
-     */
-    std::optional<size_t> getPosition() const override
-    {
-        if (interfacePresent && heartbeat)
-        {
-            return bmcPosition;
-        }
-
-        return std::nullopt;
-    }
-
-    /**
      * @brief Returns the sibling BMC's state
      *
      * @return - The state or nullopt if not available
@@ -276,11 +261,6 @@ class SiblingImpl : public Sibling
      * @brief If init() has been called
      */
     bool initialized = false;
-
-    /**
-     * @brief The sibling's BMC position
-     */
-    size_t bmcPosition = 0;
 
     /**
      * @brief The sibling's FW version string

--- a/redundant-bmc/test/redundancy_test.cpp
+++ b/redundant-bmc/test/redundancy_test.cpp
@@ -15,7 +15,6 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
         .siblingPresent = true,
         .siblingHeartbeat = true,
         .siblingProvisioned = true,
-        .siblingHasSiblingComm = true,
         .siblingRole = rbmc::Role::Passive,
         .siblingState = rbmc::BMCState::Ready,
         .codeVersionsMatch = true,
@@ -79,16 +78,6 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
         EXPECT_EQ(*reasons.begin(), siblingNotPassive);
     }
 
-    // Sibling can't talk to this BMC
-    {
-        auto input = golden;
-        input.siblingHasSiblingComm = false;
-
-        auto reasons = getNoRedundancyReasons(input);
-        ASSERT_EQ(reasons.size(), 1);
-        EXPECT_EQ(*reasons.begin(), siblingNoCommunication);
-    }
-
     // FW versions don't match
     {
         auto input = golden;
@@ -142,17 +131,15 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
     // Multiple fails
     {
         auto input = golden;
-        input.codeVersionsMatch = false;               // codeMismatch
-        input.siblingState = rbmc::BMCState::Quiesced; // siblingHealth
-        input.siblingHasSiblingComm = false;           // systemHealth
-        input.siblingRole = rbmc::Role::Unknown;       // siblingHealth
+        input.codeVersionsMatch = false;
+        input.siblingState = rbmc::BMCState::Quiesced;
+        input.siblingRole = rbmc::Role::Unknown;
 
         auto reasons = getNoRedundancyReasons(input);
 
-        EXPECT_EQ(reasons.size(), 4);
+        EXPECT_EQ(reasons.size(), 3);
         EXPECT_TRUE(std::ranges::contains(reasons, codeMismatch));
         EXPECT_TRUE(std::ranges::contains(reasons, siblingNotAtReady));
-        EXPECT_TRUE(std::ranges::contains(reasons, siblingNoCommunication));
         EXPECT_TRUE(std::ranges::contains(reasons, siblingNotPassive));
     }
 }

--- a/redundant-bmc/test/role_determination_test.cpp
+++ b/redundant-bmc/test/role_determination_test.cpp
@@ -15,7 +15,6 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
     {
         Input input{.bmcPosition = 0,
                     .previousRole = Unknown,
-                    .siblingPosition = 1,
                     .siblingRole = Unknown,
                     .siblingHeartbeat = true,
                     .siblingProvisioned = true};
@@ -29,7 +28,6 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
     {
         Input input{.bmcPosition = 1,
                     .previousRole = Unknown,
-                    .siblingPosition = 0,
                     .siblingRole = Unknown,
                     .siblingHeartbeat = true,
                     .siblingProvisioned = true};
@@ -43,7 +41,6 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
     {
         Input input{.bmcPosition = 1,
                     .previousRole = Unknown,
-                    .siblingPosition = 0,
                     .siblingRole = Unknown,
                     .siblingHeartbeat = false,
                     .siblingProvisioned = true};
@@ -54,26 +51,10 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
                   "No sibling heartbeat");
     }
 
-    // Both BMCs report the same position
-    {
-        Input input{.bmcPosition = 0,
-                    .previousRole = Unknown,
-                    .siblingPosition = 0,
-                    .siblingRole = Unknown,
-                    .siblingHeartbeat = true,
-                    .siblingProvisioned = true};
-
-        RoleInfo info{Passive, samePositions};
-        EXPECT_EQ(determineRole(input), info);
-        EXPECT_EQ(getRoleReasonDescription(info.reason),
-                  "Both BMCs have the same position");
-    }
-
     // Sibling not provisioned
     {
         Input input{.bmcPosition = 1,
                     .previousRole = Unknown,
-                    .siblingPosition = 0,
                     .siblingRole = Unknown,
                     .siblingHeartbeat = true,
                     .siblingProvisioned = false};
@@ -88,7 +69,6 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
     {
         Input input{.bmcPosition = 0,
                     .previousRole = Unknown,
-                    .siblingPosition = 1,
                     .siblingRole = Active,
                     .siblingHeartbeat = true,
                     .siblingProvisioned = true};
@@ -103,7 +83,6 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
     {
         Input input{.bmcPosition = 1,
                     .previousRole = Unknown,
-                    .siblingPosition = 0,
                     .siblingRole = Passive,
                     .siblingHeartbeat = true,
                     .siblingProvisioned = true};
@@ -118,7 +97,6 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
     {
         Input input{.bmcPosition = 0,
                     .previousRole = Passive,
-                    .siblingPosition = 1,
                     .siblingRole = Unknown,
                     .siblingHeartbeat = true,
                     .siblingProvisioned = true};
@@ -134,7 +112,6 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
     {
         Input input{.bmcPosition = 1,
                     .previousRole = Active,
-                    .siblingPosition = 0,
                     .siblingRole = Unknown,
                     .siblingHeartbeat = true,
                     .siblingProvisioned = true};


### PR DESCRIPTION
Stop using the sibling BMC position and the sibling 'sibling Communication OK' properties.
This is to prepare for moving away from the 'xyz.openbmc_project.State.BMC.Redundancy.Sibling' interface.

These properties don't have a good new home, and turned out not to be that necessary anyway.  Details are in the commit messages.