### PR TITLE
RBMC: Hardcode timeout in waitForSiblingUp()

### DIFF
--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -11,8 +11,6 @@
 namespace rbmc
 {
 
-const std::chrono::minutes siblingTimeout{6};
-
 Manager::Manager(sdbusplus::async::context& ctx,
                  std::unique_ptr<Providers>&& providers) :
     ctx(ctx), redundancyInterface(ctx, *this), providers(std::move(providers))
@@ -71,7 +69,7 @@ sdbusplus::async::task<> Manager::startup()
     {
         if (sibling.isBMCPresent())
         {
-            co_await sibling.waitForSiblingUp(siblingTimeout);
+            co_await sibling.waitForSiblingUp();
 
             if (previousRole == Role::Passive)
             {

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -64,13 +64,12 @@ class Sibling
     virtual bool hasHeartbeat() const = 0;
 
     /**
-     * @brief Waits up to 'timeout' for the sibling interface to
+     * @brief Waits up to 6 minutes for the sibling interface to
      *        be on D-Bus and have the heartbeat property active.
      *
      * @return - The task object
      */
-    virtual sdbusplus::async::task<> waitForSiblingUp(
-        const std::chrono::seconds& timeout) = 0;
+    virtual sdbusplus::async::task<> waitForSiblingUp() = 0;
 
     /**
      * @brief Waits for the sibling role to change, assuming that the

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -316,13 +316,12 @@ sdbusplus::async::task<> SiblingImpl::watchNameOwnerChanged()
     co_return;
 }
 
-// NOLINTBEGIN
-sdbusplus::async::task<> SiblingImpl::waitForSiblingUp(
-    const std::chrono::seconds& timeout)
-// NOLINTEND
+// NOLINTNEXTLINE
+sdbusplus::async::task<> SiblingImpl::waitForSiblingUp()
 {
     using namespace std::chrono_literals;
     auto start = std::chrono::steady_clock::now();
+    std::chrono::minutes timeout{6};
     auto waiting = false;
 
     while ((!interfacePresent || !heartbeat) &&
@@ -331,7 +330,7 @@ sdbusplus::async::task<> SiblingImpl::waitForSiblingUp(
         if (!waiting)
         {
             lg2::info(
-                "Waiting up to {TIME}s for sibling interface and/or heartbeat: "
+                "Waiting up to {TIME} minutes for sibling interface and/or heartbeat: "
                 "Present = {PRES}, Heartbeat = {HB}",
                 "TIME", timeout.count(), "PRES", interfacePresent, "HB",
                 heartbeat);

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -65,13 +65,12 @@ class SiblingImpl : public Sibling
     sdbusplus::async::task<> init() override;
 
     /**
-     * @brief Waits up to 'timeout' for the sibling interface to
+     * @brief Waits up to 6 minutes for the sibling interface to
      *        be on D-Bus and have the heartbeat property active.
      *
      * @return - The task object
      */
-    sdbusplus::async::task<> waitForSiblingUp(
-        const std::chrono::seconds& timeout) override;
+    sdbusplus::async::task<> waitForSiblingUp() override;
 
     /**
      * @brief Waits for the sibling role to change, assuming that the


### PR DESCRIPTION
This function was only ever called with 1 timeout value, so just hardcode it in the function, which also makes it consistent with other similar functions.

Change-Id: I0755460976c3edbb4e786cbc7e931d9dd19c436a