### PR TITLE
RBMC: Make siblingRedEnabledHandler not virtual

### DIFF
--- a/redundant-bmc/src/passive_role_handler.hpp
+++ b/redundant-bmc/src/passive_role_handler.hpp
@@ -61,7 +61,7 @@ class PassiveRoleHandler : public RoleHandler
      * Will mirror the value on this BMC's Redundancy
      * interface if the other BMC is Active.
      */
-    void siblingRedEnabledHandler(bool enable) override;
+    void siblingRedEnabledHandler(bool enable);
 
     /**
      * @brief Setup watching the sibling BMC's

--- a/redundant-bmc/src/role_handler.hpp
+++ b/redundant-bmc/src/role_handler.hpp
@@ -45,12 +45,6 @@ class RoleHandler
     virtual sdbusplus::async::task<> start() = 0;
 
     /**
-     * @brief Handler for the RedundancyEnabled property
-     *        on the sibling's D-Bus interface changing.
-     */
-    virtual void siblingRedEnabledHandler(bool /*enable*/) {};
-
-    /**
      * @brief Handler for the DisableRedundancyOverride
      *        property changing.
      *


### PR DESCRIPTION
This doesn't need to be a virtual function.

Change-Id: Ib07bf8d7a1b6f747e158605531b0069936125ce6