### PR TITLE
RBMC: Start using the 4 new Sibling D-bus interfaces

### DIFF
--- a/redundant-bmc/src/rbmc_manager_main.cpp
+++ b/redundant-bmc/src/rbmc_manager_main.cpp
@@ -5,25 +5,21 @@
 
 #include <sdbusplus/async/context.hpp>
 #include <sdbusplus/server/manager.hpp>
-#include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
-
-using Redundancy =
-    sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy;
 
 int main()
 {
     sdbusplus::async::context ctx;
-    sdbusplus::server::manager_t objMgr{ctx, "/xyz/openbmc_project/state"};
+    sdbusplus::server::manager_t objMgr{
+        ctx, rbmc::RedundancyInterface::namespace_path::value};
 
     std::unique_ptr<rbmc::Providers> providers =
         std::make_unique<rbmc::ProvidersImpl>(ctx);
 
     rbmc::Manager manager{ctx, std::move(providers)};
 
-    // clang-tidy currently mangles this into something unreadable
     // NOLINTNEXTLINE
     ctx.spawn([](sdbusplus::async::context& ctx) -> sdbusplus::async::task<> {
-        ctx.request_name(Redundancy::interface);
+        ctx.request_name(rbmc::RedundancyInterface::interface);
         co_return;
     }(ctx));
 

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -85,9 +85,13 @@ sdbusplus::async::task<> displayLocalBMCInfo(sdbusplus::async::context& ctx,
                                              bool extended)
 // NOLINTEND
 {
+    auto path =
+        sdbusplus::message::object_path{Redundancy::namespace_path::value} /
+        Redundancy::namespace_path::bmc;
+
     auto redundancy = sdbusplus::async::proxy()
                           .service("xyz.openbmc_project.State.BMC.Redundancy")
-                          .path(Redundancy::instance_path)
+                          .path(path.str)
                           .interface(Redundancy::interface);
 
     std::cout << "Local BMC\n";

--- a/redundant-bmc/src/redundancy_interface.cpp
+++ b/redundant-bmc/src/redundancy_interface.cpp
@@ -8,11 +8,14 @@
 namespace rbmc
 {
 
+const std::string objectPath =
+    std::string{RedundancyInterface::namespace_path::value} + '/' +
+    RedundancyInterface::namespace_path::bmc;
+
 RedundancyInterface::RedundancyInterface(sdbusplus::async::context& ctx,
                                          Manager& manager) :
     sdbusplus::aserver::xyz::openbmc_project::state::bmc::Redundancy<
-        RedundancyInterface>(ctx,
-                             RedundancyInterface::Redundancy::instance_path),
+        RedundancyInterface>(ctx, objectPath.c_str()),
     manager(manager)
 {
     try

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -1,7 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 #pragma once
 #include <sdbusplus/async.hpp>
-#include <xyz/openbmc_project/State/BMC/Redundancy/Sibling/client.hpp>
 #include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
 #include <xyz/openbmc_project/State/BMC/common.hpp>
 
@@ -11,8 +10,7 @@ namespace rbmc
 /**
  * @class Sibling
  *
- * Provides information about the Sibling BMC, getting it from
- * xyz.openbmc_project.State.BMC.Redundancy.Sibling.
+ * Provides information about the Sibling BMC.
  *
  * Will only provide data value when that Sibling interface is
  * present with the heartbeat property true, meaning the code


### PR DESCRIPTION
The rbmc-cfamd daemon now uses the 4 different D-Bus interfaces to hold the sibling BMC's information instead of just 1.  Move over the phosphor-rbmc-state-manager daemon to start using them.