### PR TITLE
RBMC: Control data syncing on the passive BMC

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -165,6 +165,29 @@ just let the sibling heartbeat monitoring code handle the situation.
 However if the sibling still does have a heartbeat, then redundancy will be
 disabled with the reason being a sync failure.
 
+## Interacting with the sync daemon on the Passive BMC
+
+Similar to the active BMC, the passive BMC also has to issue a full sync.
+
+It will start the full sync, which also starts the background sync, using the
+same sequence as the active BMC when:
+
+- The `RedundancyEnabled` property from the active BMC changes to true
+- The active BMC heartbeat starts:
+  - If redundancy is not enabled at this point, nothing will happen.
+
+Background sync will be stopped when:
+
+- The `RedundancyEnabled` property changes to false
+- The active BMC heartbeat stops.
+- The `SyncEventsHealth` property changes to critical.
+
+If background sync hits a failure and the health changes to critical, redundancy
+will not be disabled. The sync will explicitly stopped and then it would just be
+restarted next time a full sync is done. It will do the same 5 second wait the
+active BMC does to see if the heartbeat has stopped, meaning most likely the
+active BMC either died or was rebooted.
+
 ## Allowing Failovers
 
 Even when redundancy is enabled, there are periods when failovers will not be

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -31,6 +31,8 @@ sdbusplus::async::task<> PassiveRoleHandler::start()
 
     setupSiblingFailoversAllowedWatch();
 
+    setupSiblingHBWatch();
+
     try
     {
         // Only the active needs NoRedundancyDetails persisted.
@@ -62,17 +64,22 @@ void PassiveRoleHandler::setupSiblingRedEnabledWatch()
 {
     auto& sibling = providers.getSibling();
 
-    // Mirror the active BMC's RedundancyEnabled value
-    auto sibRedEnabled = sibling.getRedundancyEnabled();
-    if (sibRedEnabled)
-    {
-        siblingRedEnabledHandler(sibRedEnabled.value());
-    }
-
-    // Also register for changes
+    // Register for changes
     sibling.addRedundancyEnabledCallback(Role::Passive, [this](bool enabled) {
         siblingRedEnabledHandler(enabled);
     });
+
+    // Handle current value
+    auto sibRedEnabled = sibling.getRedundancyEnabled();
+    if (sibRedEnabled.has_value())
+    {
+        siblingRedEnabledHandler(sibRedEnabled.value());
+    }
+    else
+    {
+        // No sibling right now, make sure sync is off
+        ctx.spawn(stopSync());
+    }
 }
 
 void PassiveRoleHandler::setupSiblingFailoversAllowedWatch()
@@ -100,6 +107,9 @@ void PassiveRoleHandler::siblingRedEnabledHandler(bool enable)
     {
         redundancyInterface.redundancy_enabled(enable);
     }
+
+    // Kick off a full sync if possible
+    ctx.spawn(tryFullSync());
 }
 
 void PassiveRoleHandler::siblingFailoversAllowedHandler(bool allowed)
@@ -118,6 +128,115 @@ void PassiveRoleHandler::disableRedPropChanged(bool /*disable*/)
 {
     lg2::error("Cannot modify DisableRedundancy property on passive BMC");
     throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> PassiveRoleHandler::tryFullSync()
+{
+    if (providers.getSibling().hasHeartbeat() &&
+        providers.getSibling().getRedundancyEnabled().value_or(false) &&
+        (providers.getSibling().getRole().value_or(Role::Unknown) ==
+         Role::Active))
+    {
+        co_await startSync();
+    }
+    else
+    {
+        co_await stopSync();
+    }
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> PassiveRoleHandler::startSync()
+{
+    if (fullSyncDone)
+    {
+        co_return;
+    }
+
+    if (co_await providers.getSyncInterface().doFullSync())
+    {
+        fullSyncDone = true;
+
+        providers.getSyncInterface().watchSyncHealth(
+            Role::Passive,
+            [this](auto health) { syncHealthPropertyChanged(health); });
+    }
+    else
+    {
+        lg2::error("Full sync on passive BMC failed");
+        co_await stopSync();
+        // TODO: create error log
+    }
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> PassiveRoleHandler::stopSync()
+{
+    fullSyncDone = false;
+    providers.getSyncInterface().stopSyncHealthWatch(Role::Passive);
+    co_await providers.getSyncInterface().disableBackgroundSync();
+}
+
+void PassiveRoleHandler::syncHealthPropertyChanged(
+    SyncBMCData::SyncEventsHealth health)
+{
+    lg2::info("Passive BMC sync health property changed to {HEALTH}", "HEALTH",
+              health);
+
+    if (health == SyncBMCData::SyncEventsHealth::Critical)
+    {
+        // Don't care about fails if no redundancy.
+        if (!redundancyInterface.redundancy_enabled())
+        {
+            lg2::info("Redundancy isn't enabled so don't care about sync fail");
+            return;
+        }
+
+        ctx.spawn(syncHealthCritical());
+    }
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> PassiveRoleHandler::syncHealthCritical()
+{
+    lg2::info("Disabling sync because it is failing");
+    co_await stopSync();
+
+    // Redundancy doesn't need to be disabled if a background sync fails on a
+    // passive BMC. Still wait to see if it was caused by loss of the active
+    // BMC via a heartbeat check, so we know what happened.
+    // TODO: Also do network failure detection.
+
+    lg2::info("Waiting to see if sibling heartbeat stops");
+    co_await providers.getSibling().pauseForHeartbeatChange();
+
+    if (providers.getSibling().hasHeartbeat())
+    {
+        lg2::error("Sync fail was not caused by a sibling BMC problem");
+        // TODO: Create error log
+    }
+    else
+    {
+        lg2::info(
+            "Sync health is critical, but there is also a sibling heartbeat loss");
+    }
+}
+
+void PassiveRoleHandler::siblingHBChange(bool hb)
+{
+    lg2::info("Sibling heartbeat changed to {HB}", "HB", hb);
+
+    if (hb)
+    {
+        // Probably redundancy would be disabled here,
+        // but try anyway just in case.
+        ctx.spawn(tryFullSync());
+    }
+    else
+    {
+        ctx.spawn(stopSync());
+    }
 }
 
 } // namespace rbmc


### PR DESCRIPTION
The passive BMC will attempt to do a full sync in the following cases:
1. The RedundancyEnabled property changes to true
2. The active BMC's heartbeat starts and redundancy is already enabled.

Most likely in the latter case redundancy won't have been enabled yet, but it will still check there just in case it is.

It will also watch for background sync failures.  If there is a failure, it won't disable redundancy but it will create an error log (eventually) if it detects the sibling is still alive.

Tested:

On POR, full sync occurs after redundancy is enabled by active:

```
Jun 13 16:17:46 huygens phosphor-rbmc-state-manager[694]: Finished waiting for obmc-bmc-passive.target to start (result = active)
Jun 13 16:19:03 huygens phosphor-rbmc-state-manager[694]: Sibling property RedundancyEnabled changed
Jun 13 16:19:03 huygens phosphor-rbmc-state-manager[694]: Starting full sync and waiting for completion
Jun 13 16:19:03 huygens phosphor-rbmc-state-manager[694]: Full sync completed with status xyz.openbmc_project.Control.SyncBMCData.FullSyncStatus.FullSyncCompleted
```

Active BMC heartbeat stops:
```
Jun 13 03:33:56 huygens phosphor-rbmc-state-manager[1183]: Sibling property Active changed
Jun 13 03:33:56 huygens phosphor-rbmc-state-manager[1183]: Sibling heartbeat changed to False
Jun 13 03:33:56 huygens phosphor-rbmc-data-sync-mgr[711]: Sync is Disabled, Stopping events
```

RBMC manager on active BMC restarts:
```
Jun 13 03:35:40 huygens phosphor-rbmc-state-manager[1183]: Sibling property RedundancyEnabled changed
...
Jun 13 03:35:40 huygens phosphor-rbmc-data-sync-mgr[711]: Sync is Disabled, Stopping events
...
Jun 13 03:35:42 huygens phosphor-rbmc-state-manager[1183]: Sibling property RedundancyEnabled changed
Jun 13 03:35:42 huygens phosphor-rbmc-state-manager[1183]: Starting full sync and waiting for completion
Jun 13 03:35:42 huygens phosphor-rbmc-state-manager[1183]: Full sync completed with status xyz.openbmc_project.Control.SyncBMCData.FullSyncStatus.FullSyncCompleted
```

Background sync failure (special sync daemon code to cause a failure):
```
Jun 13 03:37:40 huygens phosphor-rbmc-state-manager[1183]: Passive BMC sync health property changed to xyz.openbmc_project.Control.SyncBMCData.SyncEventsHealth.Critical
Jun 13 03:37:40 huygens phosphor-rbmc-state-manager[1183]: Disabling sync because it is failing
Jun 13 03:37:40 huygens phosphor-rbmc-state-manager[1183]: Waiting to see if sibling heartbeat stops
Jun 13 03:37:45 huygens phosphor-rbmc-state-manager[1183]: Sync fail was not caused by a sibling BMC problem
```

Change-Id: I6769beab4695908335c33acd538935f153e44af9