### PR TITLE
RBMC: Only allow failovers after full sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ state to/by the end user.
 
 ## State Tracking and Control
 
-phosphor-state-manager makes extensive use of systemd. There is a writeup
-[here][1] with an overview of systemd and its use by OpenBMC.
+phosphor-state-manager makes extensive use of systemd. There is a [writeup][1]
+with an overview of systemd and its use by OpenBMC.
 
 phosphor-state-manager monitors for systemd targets to complete as a trigger to
 updating the its corresponding D-Bus property. When using PSM, a user must

--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -174,7 +174,9 @@ Failovers aren't allowed when:
 
 1. Redundancy is disabled.
 2. The system is at some state other than off or runtime.
-3. More coming.
+3. `RedundancyEnabled` has changed to true but a full sync hasn't been
+   completed.
+4. More coming.
 
 When failovers aren't allowed, rbmctool can be used to display the reasons why.
 

--- a/redundant-bmc/src/redundancy.cpp
+++ b/redundant-bmc/src/redundancy.cpp
@@ -141,6 +141,11 @@ FailoversNotAllowedReasons getFailoversNotAllowedReasons(const Input& input)
         return reasons;
     }
 
+    if (!input.fullSyncComplete)
+    {
+        reasons.insert(fullSyncNotComplete);
+    }
+
     if ((input.systemState != SystemState::off) &&
         (input.systemState != SystemState::runtime))
     {
@@ -160,6 +165,9 @@ std::string getFailoversNotAllowedDescription(FailoversNotAllowedReason reason)
     {
         case systemState:
             desc = "System state is not off or runtime"s;
+            break;
+        case fullSyncNotComplete:
+            desc = "A full sync hasn't been completed"s;
             break;
         case redundancyDisabled:
             desc = "Redundancy is disabled"s;

--- a/redundant-bmc/src/redundancy.hpp
+++ b/redundant-bmc/src/redundancy.hpp
@@ -84,6 +84,7 @@ struct Input
 {
     // TODO: Add more
     bool redundancyEnabled;
+    bool fullSyncComplete;
     SystemState systemState;
 };
 
@@ -93,6 +94,7 @@ struct Input
 enum class FailoversNotAllowedReason
 {
     redundancyDisabled,
+    fullSyncNotComplete,
     systemState
 };
 

--- a/redundant-bmc/src/redundancy_mgr.cpp
+++ b/redundant-bmc/src/redundancy_mgr.cpp
@@ -51,6 +51,8 @@ void RedundancyMgr::determineAndSetRedundancy()
     {
         // Make sure syncs are disabled if redundancy is disabled.
         ctx.spawn(providers.getSyncInterface().disableBackgroundSync());
+
+        providers.getSyncInterface().clearFullSyncComplete();
     }
 }
 
@@ -81,6 +83,11 @@ sdbusplus::async::task<> RedundancyMgr::determineRedundancyAndSync()
             // This will disable redundancy as syncFailed = true
             determineAndSetRedundancy();
             syncFailed = false;
+        }
+        else
+        {
+            // Full sync is done so recalculate FailoversAllowed
+            determineAndSetFailoversAllowed();
         }
     }
 }
@@ -283,6 +290,7 @@ void RedundancyMgr::determineAndSetFailoversAllowed()
 {
     fona::Input input{
         .redundancyEnabled = redundancyInterface.redundancy_enabled(),
+        .fullSyncComplete = providers.getSyncInterface().isFullSyncComplete(),
         .systemState = systemState.value_or(SystemState::other)};
 
     auto notAllowedReasons = fona::getFailoversNotAllowedReasons(input);

--- a/redundant-bmc/src/sync_interface.hpp
+++ b/redundant-bmc/src/sync_interface.hpp
@@ -45,6 +45,23 @@ class SyncInterface
         return fullSyncInProgress;
     }
 
+    /**
+     * @brief Says if a full sync has been completed since
+     *        redundancy was most recently enabled.
+     */
+    inline bool isFullSyncComplete() const
+    {
+        return fullSyncComplete;
+    }
+
+    /**
+     * @brief Clears the full sync complete indication
+     */
+    inline void clearFullSyncComplete()
+    {
+        fullSyncComplete = false;
+    }
+
     using SyncHealthCallback =
         std::function<void(SyncBMCData::SyncEventsHealth)>;
 
@@ -78,6 +95,12 @@ class SyncInterface
      * @brief If doFullSync is in the middle of doing a sync
      */
     bool fullSyncInProgress = false;
+
+    /**
+     * @brief If a full sync has successfully been completed
+     *        this go around of redundancy being enabled.
+     */
+    bool fullSyncComplete = false;
 
     /**
      * @brief The health status callback functions

--- a/redundant-bmc/src/sync_interface_impl.cpp
+++ b/redundant-bmc/src/sync_interface_impl.cpp
@@ -19,6 +19,8 @@ sdbusplus::async::task<bool> SyncInterfaceImpl::doFullSync()
 
     try
     {
+        fullSyncComplete = false;
+
         co_await lookupService();
 
         auto sync = SyncBMCData(ctx)
@@ -74,7 +76,8 @@ sdbusplus::async::task<bool> SyncInterfaceImpl::doFullSync()
     lg2::info("Full sync completed with status {STATUS}", "STATUS", status);
 
     fullSyncInProgress = false;
-    co_return status == SyncStatus::FullSyncCompleted;
+    fullSyncComplete = status == SyncStatus::FullSyncCompleted;
+    co_return fullSyncComplete;
 }
 
 // NOLINTNEXTLINE

--- a/redundant-bmc/test/redundancy_test.cpp
+++ b/redundant-bmc/test/redundancy_test.cpp
@@ -163,7 +163,9 @@ TEST(RedundancyTest, FailoversNotAllowedTest)
 
     for (const auto& [state, expectedReasons] : testStates)
     {
-        fona::Input input{.redundancyEnabled = true, .systemState = state};
+        fona::Input input{.redundancyEnabled = true,
+                          .fullSyncComplete = true,
+                          .systemState = state};
 
         auto reasons = fona::getFailoversNotAllowedReasons(input);
         EXPECT_EQ(reasons, expectedReasons);
@@ -172,11 +174,23 @@ TEST(RedundancyTest, FailoversNotAllowedTest)
     // Redundancy disabled
     {
         fona::Input input{.redundancyEnabled = false,
+                          .fullSyncComplete = true,
                           .systemState = rbmc::SystemState::off};
         auto reasons = fona::getFailoversNotAllowedReasons(input);
         ASSERT_EQ(reasons.size(), 1);
         EXPECT_EQ(*reasons.begin(),
                   fona::FailoversNotAllowedReason::redundancyDisabled);
+    }
+
+    // Full sync not complete
+    {
+        fona::Input input{.redundancyEnabled = true,
+                          .fullSyncComplete = false,
+                          .systemState = rbmc::SystemState::off};
+        auto reasons = fona::getFailoversNotAllowedReasons(input);
+        ASSERT_EQ(reasons.size(), 1);
+        EXPECT_EQ(*reasons.begin(),
+                  fona::FailoversNotAllowedReason::fullSyncNotComplete);
     }
 }
 


### PR DESCRIPTION
After the active BMC determined redundancy could be enabled, it was setting the 'RedundancyEnabled' and 'FailoversAllowed' properties to true and then starting a full sync.

However, it is not desired to actually allow a failover to occur until the full sync is complete.  So, add a new check into the code that calculates failovers allowed to also check for the full sync being complete.

The flag that tracks if the full sync is complete lasts until redundancy is disabled.

Tested:
Traces during initial full sync that show failovers not being allowed:
```
phosphor-rbmc-state-manager[1516]: Finished waiting for obmc-bmc-active.target to start (result = active)
phosphor-rbmc-state-manager[1516]: Done waiting for sibling steady state. State = xyz.openbmc_project.State.BMC.BMCState.Ready
phosphor-rbmc-state-manager[1516]: Enabling redundancy
phosphor-rbmc-state-manager[1516]: Failovers not allowed because A full sync hasn't been completed
phosphor-rbmc-state-manager[1516]: Starting full sync and waiting for completion
phosphor-rbmc-state-manager[1516]: Full sync completed with status xyz.openbmc_project.Control.SyncBMCData.FullSyncStatus.FullSyncCompleted
phosphor-rbmc-state-manager[1516]: Changing failovers to allowed
```

rbmctool output during that time:
```
Local BMC
-----------------------------
Role:                Active
BMC Position:        0
Redundancy Enabled:  true
BMC State:           Ready
Failovers Allowed:   false
FW version hash:     7969307F
Provisioned:         true
Role Reason:         Sibling is already passive
Reasons failovers are not allowed:
    A full sync hasn't been completed
```

Change-Id: I14dedd43619fffdeea11449319b681f8b95a1698