### PR TITLE
Put failover interface on D-Bus

### DIFF
--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -11,8 +11,14 @@
 namespace rbmc
 {
 
+const std::string failoverPath =
+    std::string{RedundancyInterface::namespace_path::value} + '/' +
+    RedundancyInterface::namespace_path::bmc;
+
 Manager::Manager(sdbusplus::async::context& ctx,
                  std::unique_ptr<Providers>&& providers) :
+    sdbusplus::aserver::xyz::openbmc_project::control::Failover<Manager>(
+        ctx, failoverPath.c_str()),
     ctx(ctx), redundancyInterface(ctx, *this), providers(std::move(providers))
 {
     try
@@ -41,6 +47,9 @@ Manager::Manager(sdbusplus::async::context& ctx,
         lg2::error("Failed trying to obtain previous role error: {ERROR}",
                    "ERROR", e);
     }
+
+    // emit the Failover interfaces added signal
+    emit_added();
 
     ctx.spawn(startup());
 }
@@ -265,6 +274,15 @@ void Manager::disableRedPropChanged(bool disable)
     }
 
     handler->disableRedPropChanged(disable);
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> Manager::method_call(
+    start_failover_t /* unused */, const FailoverOptions& /* options */)
+{
+    // TODO: Implement the failover
+    lg2::error("Failovers are not implemented yet");
+    throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -7,9 +7,12 @@
 #include "role_handler.hpp"
 
 #include <sdbusplus/async.hpp>
+#include <xyz/openbmc_project/Control/Failover/aserver.hpp>
 
 namespace rbmc
 {
+
+using FailoverOptions = std::map<std::string, std::variant<bool>>;
 
 /**
  * @class Manager
@@ -17,10 +20,10 @@ namespace rbmc
  * Manages the high level operations of the redundant
  * BMC functionality.
  */
-class Manager
+class Manager :
+    public sdbusplus::aserver::xyz::openbmc_project::control::Failover<Manager>
 {
   public:
-    Manager() = delete;
     ~Manager() = default;
     Manager(const Manager&) = delete;
     Manager& operator=(const Manager&) = delete;
@@ -45,6 +48,14 @@ class Manager
      * @param[in] disable - The property value
      */
     void disableRedPropChanged(bool disable);
+
+    /**
+     * @brief Implements the StartFailover D-Bus method.
+     *
+     * @param[in] options - The failover options
+     */
+    sdbusplus::async::task<> method_call(start_failover_t /* unused */,
+                                         const FailoverOptions& options);
 
   private:
     /**


### PR DESCRIPTION
Put the failover interface on D-Bus and add rbmctool options to call it.   The call doesn't do anything yet and just returns an 'Unavailable' error.