### PR TITLE
Check if a failover request can proceed

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -224,6 +224,7 @@ Future work to be done:
 When the call is made to start the failover on the passive BMC, it will reject
 the request if any of the following are true.
 
+1. A failover is imminent or already in progress.
 1. Redundancy isn't enabled.
 1. FailoversAllowed is false. Exceptions are:
    - The `force` option was passed into the `StartFailover` method.

--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -154,4 +154,15 @@ sdbusplus::async::task<> ActiveRoleHandler::syncHealthCritical()
     co_return;
 }
 
+// NOLINTNEXTLINE
+auto ActiveRoleHandler::getFailoverBlockedReason(
+    [[maybe_unused]] const FailoverOptions& options)
+    -> sdbusplus::async::task<fo_blocked::Reason>
+{
+    // At some point in the future we may allow triggering
+    // a failover from the active BMC, but not at the moment.
+    lg2::error("Active BMC cannot trigger a failover now");
+    co_return fo_blocked::Reason::bmcNotPassive;
+}
+
 } // namespace rbmc

--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -63,6 +63,19 @@ class ActiveRoleHandler : public RoleHandler
         redMgr.disableRedPropChanged(disable);
     }
 
+    /**
+     * @brief Called when a failover is requested, this will return
+     *        Reason::none if a failover is allowed right now, or the
+     *        reason that it isn't.
+     *
+     * @param[in] options - The options passed into the StartFailover
+     *                      D-Bus method.
+     *
+     * @return Reason::none if failover is OK, else the reason it isn't.
+     */
+    sdbusplus::async::task<fo_blocked::Reason> getFailoverBlockedReason(
+        const FailoverOptions& options) override;
+
   private:
     /**
      * @brief Starts the Sibling property watches/callbacks

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -12,8 +12,6 @@
 namespace rbmc
 {
 
-using FailoverOptions = std::map<std::string, std::variant<bool>>;
-
 /**
  * @class Manager
  *

--- a/redundant-bmc/src/passive_role_handler.hpp
+++ b/redundant-bmc/src/passive_role_handler.hpp
@@ -48,6 +48,19 @@ class PassiveRoleHandler : public RoleHandler
      */
     sdbusplus::async::task<> start() override;
 
+    /**
+     * @brief Called when a failover is requested, this will return
+     *        Reason::none if a failover is allowed right now, or the
+     *        reason that it isn't.
+     *
+     * @param[in] options - The options passed into the StartFailover
+     *                      D-Bus method.
+     *
+     * @return Reason::none if failover is OK, else the reason it isn't.
+     */
+    sdbusplus::async::task<fo_blocked::Reason> getFailoverBlockedReason(
+        const FailoverOptions& options) override;
+
   private:
     /**
      * @brief Setup mirroring the active BMC's

--- a/redundant-bmc/src/redundancy.cpp
+++ b/redundant-bmc/src/redundancy.cpp
@@ -278,6 +278,9 @@ std::string getFailoverBlockedDescription(Reason reason)
         case Reason::notAtReady:
             desc = "This BMC is not at Ready state"s;
             break;
+        case Reason::bmcNotPassive:
+            desc = "This BMC is not passive"s;
+            break;
     }
     return desc;
 }

--- a/redundant-bmc/src/redundancy.hpp
+++ b/redundant-bmc/src/redundancy.hpp
@@ -115,4 +115,54 @@ FailoversNotAllowedReasons getFailoversNotAllowedReasons(const Input& input);
 std::string getFailoversNotAllowedDescription(FailoversNotAllowedReason reason);
 
 } // namespace fona
+
+namespace fo_blocked
+{
+
+/**
+ * @brief Inputs to the is failover blocked  function
+ */
+struct Input
+{
+    bool siblingHeartbeat;
+    BMCState siblingState;
+    bool redundancyEnabled;
+    bool syncInProgress;
+    BMCState state;
+    bool failoversNotAllowed;
+    bool forceOption;
+    bool lastKnownRedundancyEnabled;
+};
+
+/**
+ * @brief Reasons why a failover is blocked
+ */
+enum class Reason
+{
+    none,
+    redundancyNotEnabled,
+    fullSyncInProgress,
+    failoversNotAllowed,
+    siblingDeadButRedundancyNotEnabled,
+    notAtReady
+};
+
+/**
+ * @brief Returns the reason a failover is blocked by the passive BMC
+ *
+ * @param[in] input - The current system states that will be checked.
+ *
+ * @return Reason::none if blocked, else the reason it is.
+ */
+Reason getFailoverBlockedReason(const Input& input);
+
+/**
+ * @brief Return the string description of the reason
+ *
+ * @return The human readable description.
+ */
+std::string getFailoverBlockedDescription(Reason reason);
+
+} // namespace fo_blocked
+
 } // namespace rbmc

--- a/redundant-bmc/src/redundancy.hpp
+++ b/redundant-bmc/src/redundancy.hpp
@@ -144,7 +144,8 @@ enum class Reason
     fullSyncInProgress,
     failoversNotAllowed,
     siblingDeadButRedundancyNotEnabled,
-    notAtReady
+    notAtReady,
+    bmcNotPassive
 };
 
 /**

--- a/redundant-bmc/src/role_handler.hpp
+++ b/redundant-bmc/src/role_handler.hpp
@@ -2,7 +2,10 @@
 #pragma once
 
 #include "providers.hpp"
+#include "redundancy.hpp"
 #include "redundancy_interface.hpp"
+
+using FailoverOptions = std::map<std::string, std::variant<bool>>;
 
 namespace rbmc
 {
@@ -51,6 +54,19 @@ class RoleHandler
      * @param[in] disable - The new disable value.
      */
     virtual void disableRedPropChanged(bool disable) = 0;
+
+    /**
+     * @brief Called when a failover is requested, this will return
+     *        Reason::none if a failover is allowed right now, or the
+     *        reason that it isn't.
+     *
+     * @param[in] options - The options passed into the StartFailover
+     *                      D-Bus method.
+     *
+     * @return Reason::none if failover is OK, else the reason it isn't.
+     */
+    virtual sdbusplus::async::task<fo_blocked::Reason> getFailoverBlockedReason(
+        const FailoverOptions& options) = 0;
 
   protected:
     /**

--- a/redundant-bmc/test/redundancy_test.cpp
+++ b/redundant-bmc/test/redundancy_test.cpp
@@ -202,3 +202,103 @@ TEST(RedundancyTest, GetFailoversNotAllowedDescTest)
                   fona::FailoversNotAllowedReason::systemState),
               "System state is not off or runtime");
 }
+
+TEST(RedundancyTest, FailoverBlockedTest)
+{
+    rbmc::fo_blocked::Input golden{
+        .siblingHeartbeat = true,
+        .siblingState = rbmc::BMCState::Ready,
+        .redundancyEnabled = true,
+        .syncInProgress = false,
+        .state = rbmc::BMCState::Ready,
+        .failoversNotAllowed = false,
+        .forceOption = false,
+        .lastKnownRedundancyEnabled = true};
+
+    EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(golden),
+              rbmc::fo_blocked::Reason::none);
+
+    // Redundancy not enabled
+    {
+        auto input = golden;
+        input.redundancyEnabled = false;
+        EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
+                  rbmc::fo_blocked::Reason::redundancyNotEnabled);
+    }
+
+    // Failovers not allowed
+    {
+        auto input = golden;
+        input.failoversNotAllowed = true;
+        EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
+                  rbmc::fo_blocked::Reason::failoversNotAllowed);
+    }
+
+    // Failovers not allowed, but forced
+    {
+        auto input = golden;
+        input.failoversNotAllowed = true;
+        input.forceOption = true;
+        EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
+                  rbmc::fo_blocked::Reason::none);
+    }
+
+    // Failovers not allowed, but sibling is Quiesced
+    {
+        auto input = golden;
+        input.failoversNotAllowed = true;
+        input.siblingState = rbmc::BMCState::Quiesced;
+        EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
+                  rbmc::fo_blocked::Reason::none);
+    }
+
+    // Sync in progress
+    {
+        auto input = golden;
+        input.syncInProgress = true;
+        EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
+                  rbmc::fo_blocked::Reason::fullSyncInProgress);
+    }
+
+    // Sibling not responding, but redundancy was enabled
+    {
+        auto input = golden;
+        input.siblingHeartbeat = false;
+        EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
+                  rbmc::fo_blocked::Reason::none);
+    }
+
+    // Sibling not responding, redundancy was enabled and failovers not allowed
+    {
+        auto input = golden;
+        input.siblingHeartbeat = false;
+        input.failoversNotAllowed = true;
+        EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
+                  rbmc::fo_blocked::Reason::none);
+    }
+
+    // Sibling not responding, redundancy was enabled, but this BMC in Quiesced.
+    {
+        auto input = golden;
+        input.siblingHeartbeat = false;
+        input.state = rbmc::BMCState::Quiesced;
+        EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
+                  rbmc::fo_blocked::Reason::notAtReady);
+    }
+
+    // Sibling not responding, but redundancy wasn't enabled
+    {
+        auto input = golden;
+        input.siblingHeartbeat = false;
+        input.lastKnownRedundancyEnabled = false;
+        EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
+                  rbmc::fo_blocked::Reason::siblingDeadButRedundancyNotEnabled);
+    }
+}
+
+TEST(RedundancyTest, GetNoFailoverDescTest)
+{
+    EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedDescription(
+                  rbmc::fo_blocked::Reason::redundancyNotEnabled),
+              "Redundancy is not enabled");
+}


### PR DESCRIPTION
In the StartFailover method, add in the code to check if it should be allowed to proceed.