### PR TITLE
RBMC: Allow 'activating' as a sibling unit state

### DIFF
--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -206,7 +206,7 @@ sdbusplus::async::task<std::optional<role_determination::RoleInfo>>
     {
         auto state =
             co_await providers->getServices().getUnitState(Sibling::unitName);
-        if (state != "active")
+        if ((state != "active") && (state != "activating"))
         {
             lg2::info("Sibling service state is {STATE}", "STATE", state);
             co_return RoleInfo{Role::Passive,


### PR DESCRIPTION
Before the role determination code even checks to see what the other BMC is doing, it checks if there are any error conditions that require the local BMC to become passive right away.

One of those checks is if the service that communicates with the sibling BMC is dead or not.  It was just checking if the service's unit state wasn't "active", but if that service was in the middle of a restart, it might also be "activating", so allow that as well.

Tested:
On good path role is still determined as usual.

Change-Id: I75c0058bd0b0f8a7fdfd894c5e4712d863ba1378