### PR TITLE
RBMC: Add service to wait for role target

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -21,6 +21,13 @@ anymore and so would default to active based on its position, and BMC 1 was
 active last time and would default to just restoring its role. Letting BMC 1 go
 first in this case would ensure BMC 0 remains passive.
 
+### Holding off BMC Ready
+
+A service file linked into multi-user.target that polls for the active and
+passive systemd targets to complete will prevent the system from reaching the
+BMC ready state before the role has been determined. On the active BMC this
+would also wait for all of the active applications to be started.
+
 ## Role Determination Rules
 
 The current rules for role determination are:

--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -43,3 +43,6 @@ executable(
     dependencies: [rbmc_deps, CLI11],
     install: true,
 )
+
+scripts = ['scripts/wait-for-active-passive-target.sh']
+install_data(scripts, install_mode: 'rwxr-xr-x', install_dir: execinstalldir)

--- a/redundant-bmc/src/scripts/wait-for-active-passive-target.sh
+++ b/redundant-bmc/src/scripts/wait-for-active-passive-target.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Wait for the Role property to get set to Active or Passive and
+# then wait for the corresponding obmc-bmc-<role>.target to start.
+
+retries=600 # Wait max 20 minutes for role to be set
+passive=0
+while [ "$retries" -ne 0 ]
+do
+    role=$(busctl get-property xyz.openbmc_project.State.BMC.Redundancy /xyz/openbmc_project/state/bmc0 xyz.openbmc_project.State.BMC.Redundancy Role)
+
+    if  echo "$role" | grep -q "Active" ; then
+        break;
+    elif  echo "$role" | grep -q "Passive" ; then
+        passive=1
+        break;
+    fi
+    retries="$((retries - 1))"
+    sleep 2
+done
+
+if [ "$retries" -eq 0 ];
+then
+    echo "Timed out waiting for BMC role"
+    exit 1
+fi
+
+target="obmc-bmc-active.target"
+if [ "$passive" -eq 1 ];
+then
+    target="obmc-bmc-passive.target"
+fi
+
+echo "BMC role determined, now waiting for $target to start"
+
+unit=$(busctl call org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager GetUnit s $target)
+# returns: 'o "<unit>"'
+unit=${unit//o /} # remove the 'o '
+unit=${unit//\"/} # remove the "
+
+retries=1800 # Wait max 60 minutes for target to start
+while [ "$retries" -ne 0 ]
+do
+    state=$(busctl get-property org.freedesktop.systemd1 "$unit" org.freedesktop.systemd1.Unit ActiveState)
+
+    if echo "$state" | grep -q -e '\"active\"' -e '\"failed\"' ;
+    then
+        echo "Done waiting for $target"
+        exit 0
+    fi
+    retries="$((retries - 1))"
+    sleep 2
+done
+
+echo "Timed out waiting for $target to start"
+exit 1

--- a/service_files/meson.build
+++ b/service_files/meson.build
@@ -26,6 +26,7 @@ unit_files = [
     'phosphor-create-chassis-poweron-log@.service',
     'phosphor-set-chassis-transition-to-on@.service',
     'phosphor-set-chassis-transition-to-off@.service',
+    'phosphor-wait-for-active-passive-target.service',
 ]
 
 fs = import('fs')

--- a/service_files/phosphor-wait-for-active-passive-target.service
+++ b/service_files/phosphor-wait-for-active-passive-target.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Wait for obmc-bmc-active or obmc-bmc-passive target to be started
+After=xyz.openbmc_project.State.BMC.Redundancy.service
+
+[Service]
+ExecStart=/usr/libexec/phosphor-state-manager/wait-for-active-passive-target.sh
+Type=oneshot
+Restart=no
+
+[Install]
+RequiredBy=multi-user.target


### PR DESCRIPTION
Add a new script wait-for-active-passive-target.sh that will wait for the role to be determined on D-Bus and then wait for either the obmc-bmc-active.target or obmc-bmc-passive.target to be started.

Also add a new service phosphor-wait-for-active-passive-target.service to call it.

This service will be linked to multi-user.target, so it can keep it from completing until the script is done.  This way, the BMC ready state can be held off until that is done.  This avoids the case where the BMC state says ready but it actually isn't ready because either the role is still unknown or all of the active services haven't been started yet.

Tested:

Waits for almost 2 minutes:
```
20:07:38 p11bmc systemd[1]: Starting Wait for obmc-bmc-active or obmc-bmc-passive target to be started
20:09:33 p11bmc wait-for-active-passive-target.sh[858]: BMC role determined, now waiting for obmc-bmc-passive.target to start
20:09:33 p11bmc wait-for-active-passive-target.sh[858]: Done waiting for obmc-bmc-passive.target
20:09:33 p11bmc systemd[1]: phosphor-wait-for-active-passive-target.service: Deactivated successfully.
20:09:33 p11bmc systemd[1]: Finished Wait for obmc-bmc-active or obmc-bmc-passive target to be started.
```

Change-Id: I4804b9a375b6267fca8a9f3f80a19bb44fbc313f