### PR TITLE
RBMC: Add toggleReset function to SiblingReset

### DIFF
--- a/redundant-bmc/src/providers.hpp
+++ b/redundant-bmc/src/providers.hpp
@@ -3,6 +3,7 @@
 
 #include "services.hpp"
 #include "sibling.hpp"
+#include "sibling_reset.hpp"
 #include "sync_interface.hpp"
 
 namespace rbmc
@@ -38,6 +39,11 @@ class Providers
      * @brief Returns the SyncInterface provider
      */
     virtual SyncInterface& getSyncInterface() = 0;
+
+    /**
+     * @brief Returns the SiblingReset provider
+     */
+    virtual SiblingReset& getSiblingReset() = 0;
 };
 
 }; // namespace rbmc

--- a/redundant-bmc/src/providers_impl.hpp
+++ b/redundant-bmc/src/providers_impl.hpp
@@ -4,6 +4,7 @@
 #include "providers.hpp"
 #include "services_impl.hpp"
 #include "sibling_impl.hpp"
+#include "sibling_reset_impl.hpp"
 #include "sync_interface_impl.hpp"
 
 namespace rbmc
@@ -30,7 +31,7 @@ class ProvidersImpl : public Providers
      * @param[in] ctx - The async context object
      */
     explicit ProvidersImpl(sdbusplus::async::context& ctx) :
-        services(ctx), sibling(ctx), syncInterface(ctx)
+        services(ctx), sibling(ctx), syncInterface(ctx), siblingReset(ctx)
     {}
 
     /**
@@ -57,6 +58,14 @@ class ProvidersImpl : public Providers
         return syncInterface;
     }
 
+    /**
+     * @brief Returns the SiblingReset provider
+     */
+    SiblingReset& getSiblingReset() override
+    {
+        return siblingReset;
+    }
+
   private:
     /**
      * @brief The Services implementation
@@ -72,6 +81,11 @@ class ProvidersImpl : public Providers
      * @brief The SyncInterface implementation
      */
     SyncInterfaceImpl syncInterface;
+
+    /**
+     * @brief The SiblingReset implementation
+     */
+    SiblingResetImpl siblingReset;
 };
 
 }; // namespace rbmc

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -232,30 +232,18 @@ sdbusplus::async::task<> displayInfo(sdbusplus::async::context& ctx,
     std::cout << "\n";
 }
 
-void resetSiblingBMC()
+// NOLINTNEXTLINE
+sdbusplus::async::task<> resetSiblingBMC(sdbusplus::async::context& ctx)
 {
-    rbmc::SiblingResetImpl reset;
+    rbmc::SiblingResetImpl reset{ctx};
 
     try
     {
-        reset.assertReset();
+        co_await reset.toggleReset();
     }
     catch (const std::exception& e)
     {
         lg2::error("Failed asserting sibling reset: {ERROR}", "ERROR", e);
-        exit(EXIT_FAILURE);
-    }
-
-    using namespace std::chrono_literals;
-    std::this_thread::sleep_for(50ms);
-
-    try
-    {
-        reset.releaseReset();
-    }
-    catch (const std::exception& e)
-    {
-        lg2::error("Failed releasing sibling reset: {ERROR}", "ERROR", e);
         exit(EXIT_FAILURE);
     }
 }
@@ -394,7 +382,7 @@ int main(int argc, char** argv)
     }
     else if (resetSibling)
     {
-        resetSiblingBMC();
+        ctx.spawn(resetSiblingBMC(ctx));
     }
     else if (disableRedundancy)
     {

--- a/redundant-bmc/src/sibling_reset.hpp
+++ b/redundant-bmc/src/sibling_reset.hpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <sdbusplus/async.hpp>
+
 namespace rbmc
 {
 
@@ -32,6 +34,11 @@ class SiblingReset
      * Releases the GPIO request on completion.
      */
     virtual void releaseReset() = 0;
+
+    /**
+     * @brief Toggles the GPIO to do the full reset
+     */
+    virtual sdbusplus::async::task<> toggleReset() = 0;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/sibling_reset_impl.cpp
+++ b/redundant-bmc/src/sibling_reset_impl.cpp
@@ -12,7 +12,7 @@ namespace rbmc
 
 const std::string gpioName = "sibling-bmc-reset";
 
-SiblingResetImpl::SiblingResetImpl()
+SiblingResetImpl::SiblingResetImpl(sdbusplus::async::context& ctx) : ctx(ctx)
 {
     resetLine = gpiod::find_line(gpioName);
     if (!resetLine)
@@ -63,5 +63,28 @@ void SiblingResetImpl::releaseReset()
     resetLine.request(config, 0);
     resetLine.release();
 }
+
+// NOLINTBEGIN(clang-analyzer-core.uninitialized.Branch)
+// NOLINTNEXTLINE(readability-static-accessed-through-instance)
+sdbusplus::async::task<> SiblingResetImpl::toggleReset()
+{
+    if (!resetLine)
+    {
+        throw std::runtime_error("Could not find sibling reset GPIO");
+    }
+
+    lg2::info("Toggling sibling reset GPIO");
+
+    resetLine.request(config, 1);
+
+    using namespace std::chrono_literals;
+
+    co_await sdbusplus::async::sleep_for(ctx, 1ms);
+
+    resetLine.set_value(0);
+
+    resetLine.release();
+}
+// NOLINTEND(clang-analyzer-core.uninitialized.Branch)
 
 } // namespace rbmc

--- a/redundant-bmc/src/sibling_reset_impl.hpp
+++ b/redundant-bmc/src/sibling_reset_impl.hpp
@@ -26,7 +26,7 @@ class SiblingResetImpl : public SiblingReset
     /**
      * @brief Constructor
      */
-    SiblingResetImpl();
+    SiblingResetImpl(sdbusplus::async::context& ctx);
 
     /**
      * @brief Asserts the reset.
@@ -42,7 +42,17 @@ class SiblingResetImpl : public SiblingReset
      */
     void releaseReset() override;
 
+    /**
+     * @brief Toggles the GPIO to do the full reset
+     */
+    sdbusplus::async::task<> toggleReset() override;
+
   private:
+    /**
+     * @brief The async context object
+     */
+    sdbusplus::async::context& ctx;
+
     /**
      * @brief The GPIO config for requesting a line.
      */


### PR DESCRIPTION
Put the calls to set the reset GPIO both to a 1 and a 0 into the same function, toggleReset, so the GPIO only has to be requested and released once.

The standalone assert and release reset functions are being kept for use in BMC card concurrent maintenance functionality.

Also add the SiblingReset class to the Providers class so code will have access to it.  It will be used during a failover to reset the original passive BMC so it can reboot and become passive.

Tested:
rbmctool --reset-sibling still works:

```
$ rbmctool --reset-sibling
<6> Toggling sibling reset GPIO

// journal:
rbmctool[1262]: Toggling sibling reset GPIO
phosphor-rbmc-state-manager[1143]: Sibling property Active changed
phosphor-rbmc-state-manager[1143]: Sibling BMC heartbeat lost
```

Change-Id: I0c15712c1720a06e6f72a08bdbfd8e3e937b4eff