### PR TITLE
RBMC: Add FO-in-progress as no redundancy reason

### DIFF
--- a/redundant-bmc/src/redundancy.cpp
+++ b/redundant-bmc/src/redundancy.cpp
@@ -15,7 +15,13 @@ NoRedundancyReasons getNoRedundancyReasons(const Input& input)
 
     // TODO:
     // - Network and/or sync health
-    // - Can't enable redundancy if system wasn't booted with it enabled
+
+    if (input.failoverInProgress)
+    {
+        reasons.insert(failoverInProgress);
+        // Don't bother checking other reasons
+        return reasons;
+    }
 
     if (input.role != Role::Active)
     {
@@ -118,6 +124,9 @@ std::string getNoRedundancyDescription(NoRedundancyReason reason)
             break;
         case syncFailed:
             desc = "Data sync failed"s;
+            break;
+        case failoverInProgress:
+            desc = "Failover in progress"s;
             break;
         case other:
             desc = "Other";

--- a/redundant-bmc/src/redundancy.hpp
+++ b/redundant-bmc/src/redundancy.hpp
@@ -32,6 +32,7 @@ struct Input
     bool manualDisable;
     bool redundancyOffAtRuntimeStart;
     bool syncFailed;
+    bool failoverInProgress;
 };
 
 // TODO: Move this to PDI Enums
@@ -52,6 +53,7 @@ enum class NoRedundancyReason
     systemHardwareConfigIssue,
     redundancyOffAtRuntimeStart,
     syncFailed,
+    failoverInProgress,
     other
 };
 

--- a/redundant-bmc/src/redundancy_mgr.cpp
+++ b/redundant-bmc/src/redundancy_mgr.cpp
@@ -115,7 +115,8 @@ redundancy::NoRedundancyReasons RedundancyMgr::getNoRedundancyReasons()
             services.getFWVersion() == sibling.getFWVersion().value_or(""),
         .manualDisable = manualDisable,
         .redundancyOffAtRuntimeStart = isRedundancyOffAtRuntime(),
-        .syncFailed = syncFailed};
+        .syncFailed = syncFailed,
+        .failoverInProgress = failoverInProgress};
 
     auto reasons = redundancy::getNoRedundancyReasons(input);
 
@@ -329,6 +330,12 @@ void RedundancyMgr::determineAndSetFailoversAllowed()
         // Already traced above.
         redundancyInterface.failovers_allowed(false);
     }
+}
+
+void RedundancyMgr::disableRedundancyDueToFailover()
+{
+    failoverInProgress = true;
+    determineAndSetRedundancy();
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/redundancy_mgr.hpp
+++ b/redundant-bmc/src/redundancy_mgr.hpp
@@ -74,6 +74,19 @@ class RedundancyMgr
      */
     void handleBackgroundSyncFailed();
 
+    /**
+     * @brief Called to disable redundancy when a failover is in progress
+     */
+    void disableRedundancyDueToFailover();
+
+    /**
+     * @brief Clears the failover in progress indication
+     */
+    void clearFailoverInProgress()
+    {
+        failoverInProgress = false;
+    }
+
   private:
     /**
      * @brief Returns the reasons that redundancy cannnot be
@@ -196,6 +209,13 @@ class RedundancyMgr
      * @brief If data sync is in a failed state.
      */
     bool syncFailed = false;
+
+    /**
+     * @brief Status on if a failover is in progress
+     *
+     * If true, redundancy can't be enabled.
+     */
+    bool failoverInProgress = false;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/test/redundancy_test.cpp
+++ b/redundant-bmc/test/redundancy_test.cpp
@@ -20,7 +20,8 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
         .codeVersionsMatch = true,
         .manualDisable = false,
         .redundancyOffAtRuntimeStart = false,
-        .syncFailed = false};
+        .syncFailed = false,
+        .failoverInProgress = false};
 
     // Nothing stopping redundancy
     {
@@ -126,6 +127,17 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
         auto reasons = getNoRedundancyReasons(input);
         ASSERT_EQ(reasons.size(), 1);
         EXPECT_EQ(*reasons.begin(), syncFailed);
+    }
+
+    // Failover in progress.
+    {
+        auto input = golden;
+        input.failoverInProgress = true;
+
+        // It is always reported by itself
+        auto reasons = getNoRedundancyReasons(input);
+        ASSERT_EQ(reasons.size(), 1);
+        EXPECT_EQ(*reasons.begin(), failoverInProgress);
     }
 
     // Multiple fails


### PR DESCRIPTION
In a failover, the passive BMC will reset the original active BMC and then claim the active role itself and wait for the other BMC to come back as passive.

During that time, redundancy won't be enabled as the sibling BMC is in the middle of rebooting.  A new no redundancy reason of 'failover in progress' is being added that will be used during this time to make it obvious what is going on.

In addition, a new function 'disableRedundancyDueToFailover' is being added to RedundancyMgr that can be called to disable redundancy with this reason.  The reason would then persist on future calls to determine redundancy until the other new function, clearFailoverInProgress, is called.

Tested:
The new unit test that checks this reason passes.

Change-Id: Ia481ad1a74616625735c2a31f8efc737c58b1681