### PR TITLE
RBMC: Add FO-in-progress check for FO not allowed

### DIFF
--- a/redundant-bmc/src/redundancy.cpp
+++ b/redundant-bmc/src/redundancy.cpp
@@ -143,6 +143,13 @@ FailoversNotAllowedReasons getFailoversNotAllowedReasons(const Input& input)
         return reasons;
     }
 
+    if (input.failoverInProgress)
+    {
+        reasons.insert(failoverInProgress);
+        // No need to look for more reasons
+        return reasons;
+    }
+
     if (!input.fullSyncComplete)
     {
         reasons.insert(fullSyncNotComplete);
@@ -170,6 +177,9 @@ std::string getFailoversNotAllowedDescription(FailoversNotAllowedReason reason)
             break;
         case fullSyncNotComplete:
             desc = "A full sync hasn't been completed"s;
+            break;
+        case failoverInProgress:
+            desc = "A failover is in progress"s;
             break;
         case redundancyDisabled:
             desc = "Redundancy is disabled"s;

--- a/redundant-bmc/src/redundancy.hpp
+++ b/redundant-bmc/src/redundancy.hpp
@@ -85,6 +85,7 @@ struct Input
     // TODO: Add more
     bool redundancyEnabled;
     bool fullSyncComplete;
+    bool failoverInProgress;
     SystemState systemState;
 };
 
@@ -95,6 +96,7 @@ enum class FailoversNotAllowedReason
 {
     redundancyDisabled,
     fullSyncNotComplete,
+    failoverInProgress,
     systemState
 };
 

--- a/redundant-bmc/src/redundancy_mgr.cpp
+++ b/redundant-bmc/src/redundancy_mgr.cpp
@@ -291,6 +291,7 @@ void RedundancyMgr::determineAndSetFailoversAllowed()
     fona::Input input{
         .redundancyEnabled = redundancyInterface.redundancy_enabled(),
         .fullSyncComplete = providers.getSyncInterface().isFullSyncComplete(),
+        .failoverInProgress = failoverInProgress,
         .systemState = systemState.value_or(SystemState::other)};
 
     auto notAllowedReasons = fona::getFailoversNotAllowedReasons(input);
@@ -329,6 +330,12 @@ void RedundancyMgr::determineAndSetFailoversAllowed()
         // Already traced above.
         redundancyInterface.failovers_allowed(false);
     }
+}
+
+void RedundancyMgr::clearFailoversAllowedDuringFailover()
+{
+    failoverInProgress = true;
+    determineAndSetFailoversAllowed();
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/redundancy_mgr.hpp
+++ b/redundant-bmc/src/redundancy_mgr.hpp
@@ -74,6 +74,22 @@ class RedundancyMgr
      */
     void handleBackgroundSyncFailed();
 
+    /**
+     * @brief Sets failoverInProgress and then calls
+     *        determineAndSetFailoversAllowed to disallow
+     *        failovers.
+     */
+    void clearFailoversAllowedDuringFailover();
+
+    /**
+     * @brief Clears the failover in progress indication which
+     *        is used in calculating FailoversAllowed
+     */
+    inline void clearFailoverInProgress()
+    {
+        failoverInProgress = false;
+    }
+
   private:
     /**
      * @brief Returns the reasons that redundancy cannnot be
@@ -196,6 +212,13 @@ class RedundancyMgr
      * @brief If data sync is in a failed state.
      */
     bool syncFailed = false;
+
+    /**
+     * @brief If a failover is currently in progress.
+     *
+     * Used in the FailoversAllowed determination.
+     */
+    bool failoverInProgress = false;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/test/redundancy_test.cpp
+++ b/redundant-bmc/test/redundancy_test.cpp
@@ -165,6 +165,7 @@ TEST(RedundancyTest, FailoversNotAllowedTest)
     {
         fona::Input input{.redundancyEnabled = true,
                           .fullSyncComplete = true,
+                          .failoverInProgress = false,
                           .systemState = state};
 
         auto reasons = fona::getFailoversNotAllowedReasons(input);
@@ -175,6 +176,7 @@ TEST(RedundancyTest, FailoversNotAllowedTest)
     {
         fona::Input input{.redundancyEnabled = false,
                           .fullSyncComplete = true,
+                          .failoverInProgress = false,
                           .systemState = rbmc::SystemState::off};
         auto reasons = fona::getFailoversNotAllowedReasons(input);
         ASSERT_EQ(reasons.size(), 1);
@@ -186,11 +188,24 @@ TEST(RedundancyTest, FailoversNotAllowedTest)
     {
         fona::Input input{.redundancyEnabled = true,
                           .fullSyncComplete = false,
+                          .failoverInProgress = false,
                           .systemState = rbmc::SystemState::off};
         auto reasons = fona::getFailoversNotAllowedReasons(input);
         ASSERT_EQ(reasons.size(), 1);
         EXPECT_EQ(*reasons.begin(),
                   fona::FailoversNotAllowedReason::fullSyncNotComplete);
+    }
+
+    // Failover in progress
+    {
+        fona::Input input{.redundancyEnabled = true,
+                          .fullSyncComplete = true,
+                          .failoverInProgress = true,
+                          .systemState = rbmc::SystemState::off};
+        auto reasons = fona::getFailoversNotAllowedReasons(input);
+        ASSERT_EQ(reasons.size(), 1);
+        EXPECT_EQ(*reasons.begin(),
+                  fona::FailoversNotAllowedReason::failoverInProgress);
     }
 }
 


### PR DESCRIPTION
In a failover, the passive BMC will reset the original active BMC and then claim the active role itself and wait for the other BMC to come back as passive.

During that time, the FailoversAllowed D-Bus property will be set to false to make it obvious to users that a failover isn't available then. When the passive BMC makes it back to ready state and the active BMC checks if redundancy can still be enabled, FailoversAllowed can be set back to true assuming nothing else is blocking it.

To handle this, this commit adds support for a 'failover-in-progress' reason for failovers to be disallowed.

It also adds a clearFailoversAllowedDuringFailover function on RedundancyMgr that will be called during the failover to call determineAndSetFailoversAllowed with failoverInProgress = true.

Later, RedundancyMgr::clearFailoverInProgress can be called to clear the failover in progress indication.

Tested:
New testcases pass.

Change-Id: I1107d1a67dba1c7ea003758d95055d2affcae4e7