### PR TITLE
RBMC: Clear sync complete flag when passive back

### DIFF
--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -94,6 +94,7 @@ sdbusplus::async::task<> ActiveRoleHandler::siblingHBStarted()
         sibling.waitForSiblingRole(), sibling.waitForBMCSteadyState());
 
     lg2::info("Attempting to enable redundancy now that sibling is back");
+    providers.getSyncInterface().clearFullSyncComplete();
     co_await redMgr.determineRedundancyAndSync();
 
     // TODO: full sync, etc


### PR DESCRIPTION
When the passive BMC reboots, the active BMC notices that its heartbeat stops but it leaves RedundancyEnabled and FailoversAllowed at true assuming it comes back in time.

When it does come back, it will go down the same full sync path as when enabling redundancy.  However, there is a policy that a failover should not be allowed until the full is complete.

To keep to that policy even when redundancy wasn't officially disabled, clear the sync complete flag when the sibling heartbeat comes back so that the next time a full sync is done FailoversAllowed will briefly turn off while the sync is in progress.

Tested:
FailoversAllowed turns off during sync:  (some traces emitted for clarity)
```
phosphor-rbmc-state-manager[1179]: Sibling BMC heartbeat lost
phosphor-rbmc-state-manager[1179]: Disabling redundancy in 5 minutes if sibling heartbeat doesn't recover
phosphor-rbmc-state-manager[1179]: Passive BMC heartbeat started

// Run though determineRedundancyAndSync()
phosphor-rbmc-state-manager[1179]: Attempting to enable redundancy now that sibling is back
phosphor-rbmc-state-manager[1179]: Enabling redundancy

// Turn off FailoversAllowed while the full sync is running:
phosphor-rbmc-state-manager[1179]: Failovers not allowed because A full sync hasn't been completed
phosphor-rbmc-state-manager[1179]: Starting full sync and waiting for completion
phosphor-rbmc-state-manager[1179]: Full sync completed with status xyz.openbmc_project.Control.SyncBMCData.FullSyncStatus.FullSyncCompleted
phosphor-rbmc-state-manager[1179]: Changing failovers to allowed
```

Change-Id: I035340df4df0a3ac91939153b4353efa01ddcd46