### PR TITLE
RBMC:  Implement the full failover

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -208,7 +208,8 @@ Failovers aren't allowed when:
 2. The system is at some state other than off or runtime.
 3. `RedundancyEnabled` has changed to true but a full sync hasn't been
    completed.
-4. More coming.
+4. A failover is in progress.
+5. More coming.
 
 When failovers aren't allowed, rbmctool can be used to display the reasons why.
 
@@ -234,3 +235,21 @@ the request if any of the following are true.
    enabled. If it was last known to be enabled, a failover is allowed so that
    the remaining BMC can become active.
 1. The passive BMC is not in the `Ready` state.
+
+### Failover Sequence
+
+The failover sequence is:
+
+1. The `StartFailover` D-Bus method is called on the passive BMC daemon.
+1. The passive BMC checks to make sure
+   [it doesn't need to reject the request](#rejecting-a-failover-request). If it
+   does an error is returned via D-Bus.
+1. The passive BMC disables background syncs.
+1. The passive BMC sets its `FailoverImminent` property to true, and then waits
+   for 10 seconds to allow the other BMC to prepare for the failover assuming it
+   is alive.
+1. The passive BMC clears `FailoverImment` and sets `FailoverInProgress`.
+1. The passive BMC toggles the reset on the sibling BMC to reboot it.
+1. The passive BMC now switches its role to Active.
+1. The new active BMC sets `FailoversAllowed` to false.
+1. TODO: Remaining steps

--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -252,4 +252,13 @@ The failover sequence is:
 1. The passive BMC toggles the reset on the sibling BMC to reboot it.
 1. The passive BMC now switches its role to Active.
 1. The new active BMC sets `FailoversAllowed` to false.
-1. TODO: Remaining steps
+1. The new active BMC takes over the hardware access bus. (TODO in code still)
+1. The new active BMC starts obmc-bmc-active.target. This starts all of the
+   active only services. It will not proceed until all active services have been
+   started which may take some time.
+1. The new active BMC waits for the sibling BMC to restart its heartbeat and get
+   to the BMC ready (or quiesced) state.
+1. The new active BMC clears `FailoverInProgress`.
+1. The new active BMC evaluates if redundancy can still be enabled, and if so it
+   issues a full sync. Otherwise it sets `RedundancyEnabled` to false.
+1. When the full sync is complete, `FailoversAllowed` is now set to true.

--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -165,4 +165,55 @@ auto ActiveRoleHandler::getFailoverBlockedReason(
     co_return fo_blocked::Reason::bmcNotPassive;
 }
 
+// NOLINTNEXTLINE
+sdbusplus::async::task<> ActiveRoleHandler::failoverStartActiveTarget()
+{
+    try
+    {
+        co_await providers.getServices().startUnit(bmcActiveTarget);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        // TODO: error log
+        lg2::error(
+            "Failed while starting BMC active target during failover: {ERROR}",
+            "ERROR", e);
+    }
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> ActiveRoleHandler::failoverWaitForSibling()
+{
+    // Wait a bit to ensure the sibling reset is detected before we
+    // start waiting for it to come back. After the active target
+    // has real code in it that runs longer than a few seconds,
+    // this could be removed.
+    co_await providers.getSibling().pauseForHeartbeatChange();
+
+    // Wait for the sibling heartbeat to come back
+    co_await providers.getSibling().waitForSiblingUp();
+
+    // Wait for the sibling to get to a steady state so redundancy can
+    // be determined.
+    co_await providers.getSibling().waitForBMCSteadyState();
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> ActiveRoleHandler::failoverDetermineRedundancy()
+{
+    // Reset full sync complete so failovers allowed will
+    // stay off until the full sync is done.
+    providers.getSyncInterface().clearFullSyncComplete();
+
+    // Tell redMgr failover is complete so it won't block
+    // failovers allowed.
+    redMgr.clearFailoverInProgress();
+
+    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
+    co_await redMgr.determineRedundancyAndSync();
+
+    startSiblingWatches();
+    startSyncHealthWatch();
+}
+
 } // namespace rbmc

--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -76,6 +76,15 @@ class ActiveRoleHandler : public RoleHandler
     sdbusplus::async::task<fo_blocked::Reason> getFailoverBlockedReason(
         const FailoverOptions& options) override;
 
+    /**
+     * @brief Sets FailoversAllowed to false with the reason set to
+     *        'failover in progress'.
+     */
+    inline void clearFailoversAllowedDuringFailover()
+    {
+        redMgr.clearFailoversAllowedDuringFailover();
+    }
+
   private:
     /**
      * @brief Starts the Sibling property watches/callbacks

--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -85,6 +85,29 @@ class ActiveRoleHandler : public RoleHandler
         redMgr.clearFailoversAllowedDuringFailover();
     }
 
+    /**
+     * @brief Start the obmc-bmc-active systemd target and wait
+     *        for it to complete.
+     *
+     * All active services will have been started when this returns.
+     */
+    sdbusplus::async::task<> failoverStartActiveTarget();
+
+    /**
+     * @brief Waits for the sibling to come back online after it was
+     *        reset during a failover.
+     */
+    sdbusplus::async::task<> failoverWaitForSibling();
+
+    /**
+     * @brief Determines redundancy and failovers allowed after the
+     *        new passive BMC has come back up (or timed out)
+     *        during the failover.
+     *
+     * If redundancy is enabled, will issue a full sync.
+     */
+    sdbusplus::async::task<> failoverDetermineRedundancy();
+
   private:
     /**
      * @brief Starts the Sibling property watches/callbacks

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -303,9 +303,65 @@ sdbusplus::async::task<> Manager::method_call(start_failover_t /* unused */,
         throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
     }
 
-    // TODO: Implement the failover
-    lg2::error("Failovers are not implemented yet");
-    throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
+    if (redundancyInterface.role() == Role::Passive)
+    {
+        // TODO: Uncomment: ctx.spawn(doFailoverFromPassive());
+        // And delete these 2 lines
+        lg2::error("Failovers are not implemented yet");
+        throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
+    }
+    else
+    {
+        // Shouldn't get here, would have failed in getFailoverBlockedReason
+        lg2::info("StartFailover on active BMC not supported yet");
+        throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
+    }
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> Manager::doFailoverFromPassive()
+{
+    lg2::info("Starting failover");
+
+    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
+    co_await providers->getSyncInterface().disableBackgroundSync();
+
+    // Stop handling as a passive BMC. This BMC no longer needs to
+    // watch for any changes from the one we're about to reset.
+    handler.reset();
+
+    redundancyInterface.failover_imminent(true);
+
+    // Wait to give the sibling a chance to react to seeing
+    // failover imminent before continuing.
+    co_await providers->getServices().doFailoverImminentDelay();
+
+    redundancyInterface.failover_imminent(false);
+
+    lg2::info("Setting failover in progress");
+    redundancyInterface.failover_in_progress(true);
+
+    // TODO: Save failover in progress indication in filesystem
+    // so we'll know to be active if rebooted in the middle of this.
+
+    // Reset the active so it can come back as passive.
+    // If this were to throw, let it restart the app.
+    co_await providers->getSiblingReset().toggleReset();
+
+    lg2::info("Claiming active role");
+    updateRole(role_determination::RoleInfo{
+        Role::Active, role_determination::RoleReason::failover});
+
+    auto* active = new ActiveRoleHandler(ctx, *providers, redundancyInterface);
+    handler.reset(active);
+
+    active->clearFailoversAllowedDuringFailover();
+    // At this point:
+    // - RedundancyEnabled = true
+    // - FailoverInProgress = true
+    // - FailoversAllowed = false
+
+    // TODO: Finish failover
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -286,7 +286,8 @@ sdbusplus::async::task<> Manager::method_call(start_failover_t /* unused */,
         throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
     }
 
-    if (redundancyInterface.failover_imminent() || failover_in_progress())
+    if (redundancyInterface.failover_imminent() ||
+        redundancyInterface.failover_in_progress())
     {
         lg2::error(
             "Failover not allowed because a failover is already imminent or in progress ");

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -280,17 +280,17 @@ void Manager::disableRedPropChanged(bool disable)
 sdbusplus::async::task<> Manager::method_call(start_failover_t /* unused */,
                                               const FailoverOptions& options)
 {
-    if (!handler)
-    {
-        lg2::error("Failover not allowed because it is too early");
-        throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
-    }
-
     if (redundancyInterface.failover_imminent() ||
         redundancyInterface.failover_in_progress())
     {
         lg2::error(
             "Failover not allowed because a failover is already imminent or in progress ");
+        throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
+    }
+
+    if (!handler)
+    {
+        lg2::error("Failover not allowed because it is too early");
         throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
     }
 
@@ -305,10 +305,7 @@ sdbusplus::async::task<> Manager::method_call(start_failover_t /* unused */,
 
     if (redundancyInterface.role() == Role::Passive)
     {
-        // TODO: Uncomment: ctx.spawn(doFailoverFromPassive());
-        // And delete these 2 lines
-        lg2::error("Failovers are not implemented yet");
-        throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
+        ctx.spawn(doFailoverFromPassive());
     }
     else
     {
@@ -342,7 +339,8 @@ sdbusplus::async::task<> Manager::doFailoverFromPassive()
     redundancyInterface.failover_in_progress(true);
 
     // TODO: Save failover in progress indication in filesystem
-    // so we'll know to be active if rebooted in the middle of this.
+    // so it can be used to know that this BMC should be active
+    // if rebooted in the middle of this.
 
     // Reset the active so it can come back as passive.
     // If this were to throw, let it restart the app.
@@ -356,12 +354,20 @@ sdbusplus::async::task<> Manager::doFailoverFromPassive()
     handler.reset(active);
 
     active->clearFailoversAllowedDuringFailover();
-    // At this point:
-    // - RedundancyEnabled = true
-    // - FailoverInProgress = true
-    // - FailoversAllowed = false
 
-    // TODO: Finish failover
+    // TODO: Grab local bus.  Not needed if it would be linked
+    // into the active target instead.
+
+    co_await active->failoverStartActiveTarget();
+
+    co_await active->failoverWaitForSibling();
+
+    lg2::info("Clearing failover in progress");
+    redundancyInterface.failover_in_progress(false);
+
+    // TODO, remove failover-in-progress indication in filesystem
+
+    co_await active->failoverDetermineRedundancy();
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -107,6 +107,12 @@ class Manager :
     void spawnRoleHandler();
 
     /**
+     * @brief Drives the failover from passive to active when
+     *        this BMC is the starting passive one.
+     */
+    sdbusplus::async::task<> doFailoverFromPassive();
+
+    /**
      * @brief The async context object
      */
     sdbusplus::async::context& ctx;

--- a/redundant-bmc/src/role_determination.cpp
+++ b/redundant-bmc/src/role_determination.cpp
@@ -93,6 +93,9 @@ std::string getRoleReasonDescription(RoleReason reason)
         case RoleReason::exception:
             desc = "Exception thrown while determining role"s;
             break;
+        case RoleReason::failover:
+            desc = "Failover"s;
+            break;
     }
 
     return desc;

--- a/redundant-bmc/src/role_determination.hpp
+++ b/redundant-bmc/src/role_determination.hpp
@@ -39,7 +39,8 @@ enum class RoleReason
     positionNonzero,
     notProvisioned,
     siblingServiceNotRunning,
-    exception
+    exception,
+    failover
 };
 
 /**

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -104,6 +104,13 @@ class Services
     virtual SystemState getSystemState() const = 0;
 
     /**
+     * @brief Execute the 'failover imminent' delay to the other BMC
+     *        has a warning that a failover is imminent and that it will
+     *        be reset.
+     */
+    virtual sdbusplus::async::task<> doFailoverImminentDelay() const = 0;
+
+    /**
      * @brief Returns the string name for the system state enum
      *
      * @param[in] state - The state enum

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -475,4 +475,12 @@ auto ServicesImpl::getBMCState() const -> sdbusplus::async::task<
     co_return co_await stateMgr.current_bmc_state();
 }
 
+// NOLINTNEXTLINE
+sdbusplus::async::task<> ServicesImpl::doFailoverImminentDelay() const
+{
+    lg2::info("Delaying for 10s for failover imminent notification");
+    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
+    co_await sdbusplus::async::sleep_for(ctx, std::chrono::seconds{10});
+}
+
 } // namespace rbmc

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -97,6 +97,13 @@ class ServicesImpl : public Services
         sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState>
         getBMCState() const override;
 
+    /**
+     * @brief Execute the 'failover imminent' delay to the other BMC
+     *        has a warning that a failover is imminent and that it will
+     *        be reset.
+     */
+    sdbusplus::async::task<> doFailoverImminentDelay() const override;
+
   private:
     /**
      * @brief Returns the D-Bus object path for the unit in the


### PR DESCRIPTION
Implement the fail over, broken up into a commit for the first part and a commit for the second.

