### PR TITLE
RBMC: Preserve roles after failover reboot

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -37,6 +37,9 @@ The current rules for role determination are:
 1. If the sibling isn't provisioned, choose active.
 1. If the sibling is already passive, choose active.
 1. If the sibling is already active, choose passive.
+1. If there was previously a failover in progress, choose active. See
+   [below for more details](#reboots-in-the-middle-of-a-failover).
+1. If the sibling has a failover in progress, choose passive.
 1. If the previous role isn't unknown, choose that assuming it wasn't passive
    just due to an error.
 1. Finally, if this BMC's position is zero choose active, otherwise passive.
@@ -269,3 +272,22 @@ The failover sequence is:
 1. The new active BMC evaluates if redundancy can still be enabled, and if so it
    issues a full sync. Otherwise it sets `RedundancyEnabled` to false.
 1. When the full sync is complete, `FailoversAllowed` is now set to true.
+
+### Reboots in the middle of a failover
+
+If the new active BMC is rebooted in the middle of a failover while the other
+BMC is somewhere in its reboot, the roles should be preserved with the new
+active BMC staying active.
+
+Preserving the roles is accomplished by:
+
+- On the new active BMC at the start of the failover save the failover in
+  progress indication in the filesystem. On every startup, look for that
+  indication and use it in the
+  [role determination calculation](#role-determination-rules). It will be
+  cleared from the filesystem after a successful failover or after it was used
+  in role determination.
+
+- On the new passive BMC during role determination obtain the failover in
+  progress value from the other BMC. If it is true, then choose the passive
+  role.

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -48,6 +48,24 @@ Manager::Manager(sdbusplus::async::context& ctx,
                    "ERROR", e);
     }
 
+    try
+    {
+        // Restore FailoverInProgress on D-Bus
+        auto failoverInProgress =
+            data::read<bool>(data::key::failoverInProgress).value_or(false);
+        if (failoverInProgress)
+        {
+            lg2::info("Failover was previously in progress");
+        }
+
+        redundancyInterface.failover_in_progress(failoverInProgress);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed trying to obtain failover-in-progress: {ERROR}",
+                   "ERROR", e);
+    }
+
     // emit the Failover interfaces added signal
     emit_added();
 
@@ -89,9 +107,38 @@ sdbusplus::async::task<> Manager::startup()
         updateRole(determineRole());
     }
 
-    spawnRoleHandler();
+    co_await postStartupClearFOInProgress();
 
-    co_return;
+    spawnRoleHandler();
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> Manager::postStartupClearFOInProgress()
+{
+    if (!redundancyInterface.failover_in_progress())
+    {
+        co_return;
+    }
+
+    // If true, this property is used by both BMCs to determine their roles.
+    // This BMC will have already used it.  Check the other BMC already has
+    // as well and then it can be set to false and removed from the persistent
+    // data.
+
+    lg2::info(
+        "Waiting for sibling to get role and then clearing failover in progress");
+
+    co_await providers->getSibling().waitForSiblingRole();
+
+    redundancyInterface.failover_in_progress(false);
+    try
+    {
+        data::remove(data::key::failoverInProgress);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed removing failover-in-progress: {ERROR}", "ERROR", e);
+    }
 }
 
 void Manager::spawnRoleHandler()
@@ -156,13 +203,17 @@ role_determination::RoleInfo Manager::determineRole()
         //        them anyway because there would be no heartbeat.
         auto siblingRole = sibling.getRole().value_or(Role::Unknown);
         auto siblingProvisioned = sibling.getProvisioned().value_or(false);
+        auto siblingFailoverInProgress =
+            sibling.getFailoverInProgress().value_or(false);
 
         role_determination::Input input{
             .bmcPosition = services.getBMCPosition(),
             .previousRole = previousRole,
             .siblingRole = siblingRole,
             .siblingHeartbeat = sibling.hasHeartbeat(),
-            .siblingProvisioned = siblingProvisioned};
+            .siblingProvisioned = siblingProvisioned,
+            .failoverInProgress = redundancyInterface.failover_in_progress(),
+            .siblingFailoverInProgress = siblingFailoverInProgress};
 
         // If an error case forced it to passive last time, don't use
         // the previous role in the determination so that we don't try
@@ -338,13 +389,22 @@ sdbusplus::async::task<> Manager::doFailoverFromPassive()
     lg2::info("Setting failover in progress");
     redundancyInterface.failover_in_progress(true);
 
-    // TODO: Save failover in progress indication in filesystem
-    // so it can be used to know that this BMC should be active
-    // if rebooted in the middle of this.
-
     // Reset the active so it can come back as passive.
     // If this were to throw, let it restart the app.
     co_await providers->getSiblingReset().toggleReset();
+
+    try
+    {
+        // Now that its past the reset, save the failover in progress
+        // indication in case this BMC is rebooted before the failover
+        // is done.
+        data::write(data::key::failoverInProgress, true);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed serializing failover-in-progress: {ERROR}", "ERROR",
+                   e);
+    }
 
     lg2::info("Claiming active role");
     updateRole(role_determination::RoleInfo{
@@ -365,7 +425,14 @@ sdbusplus::async::task<> Manager::doFailoverFromPassive()
     lg2::info("Clearing failover in progress");
     redundancyInterface.failover_in_progress(false);
 
-    // TODO, remove failover-in-progress indication in filesystem
+    try
+    {
+        data::remove(data::key::failoverInProgress);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed removing failover-in-progress: {ERROR}", "ERROR", e);
+    }
 
     co_await active->failoverDetermineRedundancy();
 }

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -113,6 +113,12 @@ class Manager :
     sdbusplus::async::task<> doFailoverFromPassive();
 
     /**
+     * @brief Clears 'failover in progress' if it is on and
+     *        removes the persisted value.
+     */
+    sdbusplus::async::task<> postStartupClearFOInProgress();
+
+    /**
      * @brief The async context object
      */
     sdbusplus::async::context& ctx;

--- a/redundant-bmc/src/persistent_data.hpp
+++ b/redundant-bmc/src/persistent_data.hpp
@@ -21,6 +21,7 @@ constexpr auto noRedDetails = "NoRedundancyDetails";
 constexpr auto disableRed = "DisableRedundancy";
 constexpr auto redundancyOffAtRuntime = "RedundancyOffAtRuntime";
 constexpr auto failoversNotAllowedReasons = "FailoversNotAllowedReasons";
+constexpr auto failoverInProgress = "FailoverInProgress";
 } // namespace key
 
 namespace util

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -30,7 +30,7 @@ constexpr auto siblingService =
 template <typename T>
 void printParam(std::string_view key, const T& value)
 {
-    std::println("{:21}{}", key, value);
+    std::println("{:22}{}", key, value);
 }
 
 void printReason(std::string_view reason)
@@ -131,6 +131,7 @@ sdbusplus::async::task<> displayLocalBMCInfo(sdbusplus::async::context& ctx,
             auto bmcState = co_await getBMCState(services);
             printParam("BMC State:", bmcState);
             printParam("Failovers Allowed:", props.failovers_allowed);
+            printParam("Failover In Progress:", props.failover_in_progress);
             printParam("FW Version Hash:", services.getFWVersion());
             printParam("Provisioned:", services.getProvisioned());
 

--- a/redundant-bmc/src/role_determination.cpp
+++ b/redundant-bmc/src/role_determination.cpp
@@ -30,6 +30,16 @@ RoleInfo determineRole(const Input& input)
         result = {Role::Passive, RoleReason::siblingActive};
     }
 
+    else if (input.failoverInProgress)
+    {
+        result = {Role::Active, RoleReason::failoverInProgress};
+    }
+
+    else if (input.siblingFailoverInProgress)
+    {
+        result = {Role::Passive, RoleReason::siblingFailoverInProgress};
+    }
+
     else if (input.previousRole == Role::Active)
     {
         result = {Role::Active, RoleReason::resumePrevious};
@@ -89,6 +99,12 @@ std::string getRoleReasonDescription(RoleReason reason)
             break;
         case RoleReason::siblingServiceNotRunning:
             desc = "Sibling BMC service is not running"s;
+            break;
+        case RoleReason::failoverInProgress:
+            desc = "Newly active from failover";
+            break;
+        case RoleReason::siblingFailoverInProgress:
+            desc = "Sibling was driving a failover";
             break;
         case RoleReason::exception:
             desc = "Exception thrown while determining role"s;

--- a/redundant-bmc/src/role_determination.hpp
+++ b/redundant-bmc/src/role_determination.hpp
@@ -22,6 +22,8 @@ struct Input
     Role siblingRole;
     bool siblingHeartbeat;
     bool siblingProvisioned;
+    bool failoverInProgress;
+    bool siblingFailoverInProgress;
 };
 
 /**
@@ -40,7 +42,9 @@ enum class RoleReason
     notProvisioned,
     siblingServiceNotRunning,
     exception,
-    failover
+    failover,
+    failoverInProgress,
+    siblingFailoverInProgress
 };
 
 /**

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -124,6 +124,13 @@ class Sibling
     virtual std::optional<bool> getFailoversAllowed() const = 0;
 
     /**
+     * @brief Returns if the sibling has a failover in progress
+     *
+     * @return - If allowed, or nullopt if not available
+     */
+    virtual std::optional<bool> getFailoverInProgress() const = 0;
+
+    /**
      * @brief Returns if the sibling BMC is plugged in
      *
      * @return bool - if present

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -120,6 +120,12 @@ void SiblingImpl::loadRedundancyProps(
         }
     }
 
+    it = propertyMap.find("FailoverInProgress");
+    if (it != propertyMap.end())
+    {
+        redundancy.failoverInProgress = std::get<bool>(it->second);
+    }
+
     it = propertyMap.find("Role");
     if (it != propertyMap.end())
     {

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -169,6 +169,21 @@ class SiblingImpl : public Sibling
     }
 
     /**
+     * @brief Returns if the sibling has a failover in progress
+     *
+     * @return - If in progress, or nullopt if not available
+     */
+    std::optional<bool> getFailoverInProgress() const override
+    {
+        if (getInterfacePresent() && hasHeartbeat())
+        {
+            return redundancy.failoverInProgress;
+        }
+
+        return std::nullopt;
+    }
+
+    /**
      * @brief Returns if the sibling BMC is plugged in
      *
      * @return bool - if present
@@ -301,6 +316,7 @@ class SiblingImpl : public Sibling
         Role role = Role::Unknown;
         bool redundancyEnabled = false;
         bool failoversAllowed = false;
+        bool failoverInProgress = false;
     };
 
     /**

--- a/redundant-bmc/test/role_determination_test.cpp
+++ b/redundant-bmc/test/role_determination_test.cpp
@@ -17,7 +17,9 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
                     .previousRole = Unknown,
                     .siblingRole = Unknown,
                     .siblingHeartbeat = true,
-                    .siblingProvisioned = true};
+                    .siblingProvisioned = true,
+                    .failoverInProgress = false,
+                    .siblingFailoverInProgress = false};
 
         RoleInfo info{Active, positionZero};
         EXPECT_EQ(determineRole(input), info);
@@ -30,7 +32,9 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
                     .previousRole = Unknown,
                     .siblingRole = Unknown,
                     .siblingHeartbeat = true,
-                    .siblingProvisioned = true};
+                    .siblingProvisioned = true,
+                    .failoverInProgress = false,
+                    .siblingFailoverInProgress = false};
         RoleInfo info{Passive, positionNonzero};
         EXPECT_EQ(determineRole(input), info);
         EXPECT_EQ(getRoleReasonDescription(info.reason),
@@ -43,7 +47,9 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
                     .previousRole = Unknown,
                     .siblingRole = Unknown,
                     .siblingHeartbeat = false,
-                    .siblingProvisioned = true};
+                    .siblingProvisioned = true,
+                    .failoverInProgress = false,
+                    .siblingFailoverInProgress = false};
 
         RoleInfo info{Active, noSiblingHeartbeat};
         EXPECT_EQ(determineRole(input), info);
@@ -57,7 +63,9 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
                     .previousRole = Unknown,
                     .siblingRole = Unknown,
                     .siblingHeartbeat = true,
-                    .siblingProvisioned = false};
+                    .siblingProvisioned = false,
+                    .failoverInProgress = false,
+                    .siblingFailoverInProgress = false};
 
         RoleInfo info{Active, siblingNotProvisioned};
         EXPECT_EQ(determineRole(input), info);
@@ -71,7 +79,9 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
                     .previousRole = Unknown,
                     .siblingRole = Active,
                     .siblingHeartbeat = true,
-                    .siblingProvisioned = true};
+                    .siblingProvisioned = true,
+                    .failoverInProgress = false,
+                    .siblingFailoverInProgress = false};
 
         RoleInfo info{Passive, siblingActive};
         EXPECT_EQ(determineRole(input), info);
@@ -85,7 +95,9 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
                     .previousRole = Unknown,
                     .siblingRole = Passive,
                     .siblingHeartbeat = true,
-                    .siblingProvisioned = true};
+                    .siblingProvisioned = true,
+                    .failoverInProgress = false,
+                    .siblingFailoverInProgress = false};
 
         RoleInfo info{Active, siblingPassive};
         EXPECT_EQ(determineRole(input), info);
@@ -99,7 +111,9 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
                     .previousRole = Passive,
                     .siblingRole = Unknown,
                     .siblingHeartbeat = true,
-                    .siblingProvisioned = true};
+                    .siblingProvisioned = true,
+                    .failoverInProgress = false,
+                    .siblingFailoverInProgress = false};
 
         // Preserve passive
         RoleInfo info{Passive, resumePrevious};
@@ -114,13 +128,51 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
                     .previousRole = Active,
                     .siblingRole = Unknown,
                     .siblingHeartbeat = true,
-                    .siblingProvisioned = true};
+                    .siblingProvisioned = true,
+                    .failoverInProgress = false,
+                    .siblingFailoverInProgress = false};
 
         // Preserve active
         RoleInfo info{Active, resumePrevious};
         EXPECT_EQ(determineRole(input), info);
         EXPECT_EQ(getRoleReasonDescription(info.reason),
                   "Resuming previous role");
+    }
+
+    // Simulate a reboot in the middle of a failover on
+    // the active BMC - failover in progress = true.
+    {
+        Input input{.bmcPosition = 1,
+                    .previousRole = Active,
+                    .siblingRole = Unknown,
+                    .siblingHeartbeat = true,
+                    .siblingProvisioned = true,
+                    .failoverInProgress = true,
+                    .siblingFailoverInProgress = false};
+
+        RoleInfo info{Active, failoverInProgress};
+        EXPECT_EQ(determineRole(input), info);
+        EXPECT_EQ(getRoleReasonDescription(info.reason),
+                  "Newly active from failover");
+    }
+
+    // Simulate a passive BMC coming back from a failover
+    // when the new active BMC was rebooted and just came back.
+    // With siblingFailoverInProgress set it won't resume
+    // previous role of active.
+    {
+        Input input{.bmcPosition = 0,
+                    .previousRole = Active,
+                    .siblingRole = Unknown,
+                    .siblingHeartbeat = true,
+                    .siblingProvisioned = true,
+                    .failoverInProgress = false,
+                    .siblingFailoverInProgress = true};
+
+        RoleInfo info{Passive, siblingFailoverInProgress};
+        EXPECT_EQ(determineRole(input), info);
+        EXPECT_EQ(getRoleReasonDescription(info.reason),
+                  "Sibling was driving a failover");
     }
 }
 


### PR DESCRIPTION
Consider the case where BMC 1 is far enough along in driving a failover that it has taken the active role, reset the other BMC, and is now waiting for it to come back as the passive BMC.

Normally when BMC 0 comes back it would just see the other BMC is already active and become passive.  However, if BMC 1 was rebooted sometime during its wait, then BMC 0 would come back first and wait for BMC 1 to catch up so they could determine their roles at roughly the same time.

At that point, there is nothing that directs BMC 0 to become passive as would be expected so it would just become active since it was previously active.

As for BMC 1, in the best case it would come up slightly behind BMC 0 enough to be able to claim its opposite role, but it may not so then it would end up also choosing the active role as it was previously active before the reboot.

To fix this so the roles are definitely preserved after the failover, do the following.
1. When FailoverInProgress is set to true on the new active BMC, also save it in the filesystem and then when its set back to false on D-Bus at the end of the failover remove it.
2. On the role determination that happens during startup, check if there is a persisted true value of FailoverInProgress.  If there is, that means this was a newly active BMC that was rebooted during the failover, so claim the active role.  After role determination is done, that persisted value can be removed.
3. Add support so the sibling BMC can obtain the FailoverInProgress value.
4. During role determination, if 'sibling failover in progress' is true, then claim the passive role as this BMC must be the newly passive one.

Tested:
Reboot the new active BMC in the middle of a failover, and get.

Passive BMC:
```
Local BMC
-----------------------------
Role:                 Passive <--------
BMC Position:         0
Redundancy Enabled:   true
BMC State:            Ready
Failovers Allowed:    true
Failover In Progress: false
FW Version Hash:      7D719923
Provisioned:          true
Role Reason:          Sibling was driving a failover <------
```

Active BMC:
```
Local BMC
-----------------------------
Role:                 Active <--------------------
BMC Position:         1
Redundancy Enabled:   true
BMC State:            NotReady
Failovers Allowed:    true
Failover In Progress: false
FW Version Hash:      7D719923
Provisioned:          true
Role Reason:          Newly active from failover <-------------
```

If it's is running behind, it can also show:

```
Local BMC
-----------------------------
Role:                 Active
BMC Position:         1
Redundancy Enabled:   true
BMC State:            Ready
Failovers Allowed:    true
Failover In Progress: false
FW Version Hash:      7D719923
Provisioned:          true
Role Reason:          Sibling is already passive
```

Change-Id: I634932451fb737fde1e2efedb44bbcb27a148a1c