### PR TITLE
Flush journal and stop background sync before failover reset

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -291,3 +291,11 @@ Preserving the roles is accomplished by:
 - On the new passive BMC during role determination obtain the failover in
   progress value from the other BMC. If it is true, then choose the passive
   role.
+
+### Active BMC handling of an imminent failover
+
+When the current active BMC sees the failover imminent indication, it will do
+the following to prepare to be reset and come back as the passive BMC:
+
+1. Stop background syncing.
+2. Flush any unwritten journal messages to disk.

--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -224,6 +224,7 @@ void ActiveRoleHandler::siblingFailoverImminent(bool imminent)
         lg2::info("A failover is imminent");
 
         ctx.spawn(providers.getSyncInterface().disableBackgroundSync());
+        ctx.spawn(providers.getServices().flushJournal());
     }
 }
 

--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -217,4 +217,14 @@ sdbusplus::async::task<> ActiveRoleHandler::failoverDetermineRedundancy()
     startSyncHealthWatch();
 }
 
+void ActiveRoleHandler::siblingFailoverImminent(bool imminent)
+{
+    if (imminent)
+    {
+        lg2::info("A failover is imminent");
+
+        ctx.spawn(providers.getSyncInterface().disableBackgroundSync());
+    }
+}
+
 } // namespace rbmc

--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -122,6 +122,10 @@ class ActiveRoleHandler : public RoleHandler
         sibling.addHeartbeatCallback(
             Role::Active,
             std::bind_front(&ActiveRoleHandler::siblingHBChange, this));
+
+        sibling.addFailoverImminentCallback(
+            Role::Active,
+            std::bind_front(&ActiveRoleHandler::siblingFailoverImminent, this));
     }
 
     /**
@@ -196,6 +200,15 @@ class ActiveRoleHandler : public RoleHandler
      * Redundancy will be disabled if it's a true sync failure.
      */
     sdbusplus::async::task<> syncHealthCritical();
+
+    /**
+     * @brief Called when the passive BMC is about to start a failover
+     *        so that any preparation can be done.
+     *
+     * @param[in] imminent - The new FailoverImminent value.
+     *
+     */
+    void siblingFailoverImminent(bool imminent);
 
     /**
      * @brief Redundancy manager object

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -111,6 +111,11 @@ class Services
     virtual sdbusplus::async::task<> doFailoverImminentDelay() const = 0;
 
     /**
+     * @brief Flush the journal to the filesystem.
+     */
+    virtual sdbusplus::async::task<> flushJournal() const = 0;
+
+    /**
      * @brief Returns the string name for the system state enum
      *
      * @param[in] state - The state enum

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -65,6 +65,88 @@ sdbusplus::async::task<std::string> getService(sdbusplus::async::context& ctx,
     co_return object.begin()->first;
 }
 
+/**
+ * @brief Run a shell command asynchronously
+ *
+ * Use the pipe()/fork() paradigm to fork off a child process to run
+ * the command. The child will write the command RC to its FD obtained
+ * from pipe() and exit. Meanwhile the parent will use async::fdio to
+ * asynchronously wait for that rc to show up in its read FD it had
+ * obtained from pipe().
+ */
+// NOLINTNEXTLINE
+sdbusplus::async::task<int> runAsyncCmd(sdbusplus::async::context& ctx,
+                                        const std::string& cmd)
+{
+    int pipeFDs[2];
+
+    // Open the read and write pipes
+    if (pipe(pipeFDs) == -1)
+    {
+        auto e = errno;
+        lg2::error("runAsyncCmd: pipe() failed with errno: {ERRNO}", "ERRNO",
+                   e);
+        co_return -1;
+    }
+
+    pid_t pid = fork();
+    if (pid == -1)
+    {
+        auto e = errno;
+        close(pipeFDs[0]);
+        close(pipeFDs[1]);
+        lg2::error("runAsyncCmd: fork failed with errno {ERRNO}", "ERRNO", e);
+        co_return -1;
+    }
+    else if (pid == 0)
+    {
+        // Child
+
+        // Close the read pipe
+        close(pipeFDs[0]);
+
+        // NOLINTNEXTLINE(cert-env33-c)
+        int rc = std::system(cmd.c_str());
+
+        int exitCode = (rc == -1) ? -1 : (WIFEXITED(rc) ? WEXITSTATUS(rc) : -1);
+
+        // Write the exit code to the write pipe
+        ssize_t s = write(pipeFDs[1], &exitCode, sizeof(exitCode));
+
+        _exit((s == sizeof(rc)) ? 0 : 1);
+    }
+
+    // In the parent here.
+
+    // close the write pipe
+    close(pipeFDs[1]);
+
+    // Async wait for the child to write the command's rc to the read pipe
+    sdbusplus::async::fdio fdio(ctx, pipeFDs[0]);
+    co_await fdio.next();
+
+    int cmdRC = -1;
+    ssize_t bytesRead = read(pipeFDs[0], &cmdRC, sizeof(cmdRC));
+    close(pipeFDs[0]);
+
+    if (bytesRead != sizeof(cmdRC))
+    {
+        lg2::error("runAsyncCmd: Failed to read return code from command {CMD}",
+                   "CMD", cmd);
+        co_return -1;
+    }
+
+    // Wait for child to exit
+    int status;
+    if (waitpid(pid, &status, 0) == -1)
+    {
+        lg2::error("runAsyncCmd: waitpid failed for command {CMD}", "CMD", cmd);
+        co_return -1;
+    }
+
+    co_return cmdRC;
+}
+
 } // namespace util
 
 // NOLINTNEXTLINE
@@ -481,6 +563,21 @@ sdbusplus::async::task<> ServicesImpl::doFailoverImminentDelay() const
     lg2::info("Delaying for 10s for failover imminent notification");
     // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
     co_await sdbusplus::async::sleep_for(ctx, std::chrono::seconds{10});
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> ServicesImpl::flushJournal() const
+{
+    try
+    {
+        lg2::info("Starting journal flush");
+        auto rc = co_await util::runAsyncCmd(ctx, "/usr/bin/journalctl --sync");
+        lg2::info("Completed journal flush with rc {RC}", "RC", rc);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Exception while syncing journal: {ERROR}", "ERROR", e);
+    }
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -104,6 +104,12 @@ class ServicesImpl : public Services
      */
     sdbusplus::async::task<> doFailoverImminentDelay() const override;
 
+    /**
+     * @brief Flush the journal to the filesystem with
+     *        "journalctl --sync"
+     */
+    sdbusplus::async::task<> flushJournal() const override;
+
   private:
     /**
      * @brief Returns the D-Bus object path for the unit in the

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -30,6 +30,7 @@ class Sibling
     using BMCStateCallback = std::function<void(BMCState)>;
     using HeartbeatCallback = std::function<void(bool)>;
     using FailoversAllowedCallback = std::function<void(bool)>;
+    using FailoverImminentCallback = std::function<void(bool)>;
 
     Sibling() = default;
     virtual ~Sibling() = default;
@@ -126,9 +127,16 @@ class Sibling
     /**
      * @brief Returns if the sibling has a failover in progress
      *
-     * @return - If allowed, or nullopt if not available
+     * @return - If in progress, or nullopt if not available
      */
     virtual std::optional<bool> getFailoverInProgress() const = 0;
+
+    /**
+     * @brief Returns if the sibling has a failover imminent
+     *
+     * @return - If imminent, or nullopt if not available
+     */
+    virtual std::optional<bool> getFailoverImminent() const = 0;
 
     /**
      * @brief Returns if the sibling BMC is plugged in
@@ -154,6 +162,7 @@ class Sibling
         bmcStateCBs.erase(role);
         heartbeatCBs.erase(role);
         foAllowedCBs.erase(role);
+        foImminentCBs.erase(role);
     }
 
     /**
@@ -206,6 +215,19 @@ class Sibling
         foAllowedCBs.emplace(role, std::move(callback));
     }
 
+    /**
+     * @brief Adds a callback function to invoke when the sibling's
+     *        FailoverImminent property changes
+     *
+     * @param[in] role - The role to register with
+     * @param[in] callback - The callback function
+     */
+    void addFailoverImminentCallback(Role role,
+                                     FailoverImminentCallback callback)
+    {
+        foImminentCBs.emplace(role, std::move(callback));
+    }
+
   protected:
     /**
      * @brief Callbacks for RedundancyEnabled
@@ -226,5 +248,10 @@ class Sibling
      * @brief Callbacks for FailoversAllowed
      */
     std::map<Role, FailoversAllowedCallback> foAllowedCBs;
+
+    /**
+     * @brief Callbacks for FailoverImminent
+     */
+    std::map<Role, FailoverImminentCallback> foImminentCBs;
 };
 } // namespace rbmc

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -120,6 +120,21 @@ void SiblingImpl::loadRedundancyProps(
         }
     }
 
+    it = propertyMap.find("FailoverImminent");
+    if (it != propertyMap.end())
+    {
+        auto old = redundancy.failoverImminent;
+        redundancy.failoverImminent = std::get<bool>(it->second);
+        if (redundancy.failoverImminent != old)
+        {
+            for (const auto& callback :
+                 std::ranges::views::values(foImminentCBs))
+            {
+                callback(redundancy.failoverImminent);
+            }
+        }
+    }
+
     it = propertyMap.find("FailoverInProgress");
     if (it != propertyMap.end())
     {

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -184,6 +184,21 @@ class SiblingImpl : public Sibling
     }
 
     /**
+     * @brief Returns if the sibling has a failover imminent
+     *
+     * @return - If imminent, or nullopt if not available
+     */
+    std::optional<bool> getFailoverImminent() const override
+    {
+        if (getInterfacePresent() && hasHeartbeat())
+        {
+            return redundancy.failoverImminent;
+        }
+
+        return std::nullopt;
+    }
+
+    /**
      * @brief Returns if the sibling BMC is plugged in
      *
      * @return bool - if present
@@ -317,6 +332,7 @@ class SiblingImpl : public Sibling
         bool redundancyEnabled = false;
         bool failoversAllowed = false;
         bool failoverInProgress = false;
+        bool failoverImminent = false;
     };
 
     /**


### PR DESCRIPTION
On the existing active BMC, watch for the failover imminent indication and stop background sync and flush the journal to disk.