### PR TITLE
RBMC: Use presence of sibling BMC's redundancy interface to know if that BMC is healthy

### DIFF
--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -7,7 +7,7 @@ namespace rbmc
 {
 
 constexpr auto bmcActiveTarget = "obmc-bmc-active.target";
-const std::chrono::minutes siblingHBTimeout{5};
+const std::chrono::minutes siblingHealthTimeout{5};
 
 // NOLINTNEXTLINE
 sdbusplus::async::task<> ActiveRoleHandler::start()
@@ -27,7 +27,7 @@ sdbusplus::async::task<> ActiveRoleHandler::start()
                    e);
     }
 
-    if (sibling.hasHeartbeat())
+    if (sibling.alive())
     {
         // Make sure the sibling had time to get its role assigned, and
         // also wait for it to hit steady state as redundancy can only
@@ -56,36 +56,36 @@ void ActiveRoleHandler::siblingStateChange(BMCState state)
     }
 }
 
-void ActiveRoleHandler::siblingHBChange(bool hb)
+void ActiveRoleHandler::siblingHealthChange(bool alive)
 {
-    if (hb)
+    if (alive)
     {
-        siblingHBTimer.stop();
-        ctx.spawn(siblingHBStarted());
+        siblingHealthTimer.stop();
+        ctx.spawn(siblingHealthy());
     }
     else
     {
-        lg2::info("Sibling BMC heartbeat lost");
+        lg2::info("Sibling BMC health changed to bad");
         if (redundancyInterface.redundancy_enabled())
         {
             lg2::info(
-                "Disabling redundancy in {TIME} minutes if sibling heartbeat doesn't recover",
-                "TIME", siblingHBTimeout.count());
-            siblingHBTimer.start(siblingHBTimeout);
+                "Disabling redundancy in {TIME} minutes if sibling doesn't come back",
+                "TIME", siblingHealthTimeout.count());
+            siblingHealthTimer.start(siblingHealthTimeout);
         }
     }
 }
 
-void ActiveRoleHandler::siblingHBCritical()
+void ActiveRoleHandler::siblingHealthCritical()
 {
-    lg2::error("Sibling heartbeat timer expired, disabling redundancy");
+    lg2::error("Sibling health timer expired, disabling redundancy");
     redMgr.determineAndSetRedundancy();
 }
 
 // NOLINTNEXTLINE
-sdbusplus::async::task<> ActiveRoleHandler::siblingHBStarted()
+sdbusplus::async::task<> ActiveRoleHandler::siblingHealthy()
 {
-    lg2::info("Passive BMC heartbeat started");
+    lg2::info("Passive BMC health changed to good");
 
     stopSiblingWatches();
 
@@ -96,8 +96,6 @@ sdbusplus::async::task<> ActiveRoleHandler::siblingHBStarted()
     lg2::info("Attempting to enable redundancy now that sibling is back");
     providers.getSyncInterface().clearFullSyncComplete();
     co_await redMgr.determineRedundancyAndSync();
-
-    // TODO: full sync, etc
 
     startSiblingWatches();
 
@@ -139,7 +137,7 @@ sdbusplus::async::task<> ActiveRoleHandler::syncHealthCritical()
     lg2::info("Waiting to see if sibling heartbeat stops");
     co_await providers.getSibling().pauseForHeartbeatChange();
 
-    if (providers.getSibling().hasHeartbeat())
+    if (providers.getSibling().alive())
     {
         lg2::error("Disabling redundancy due to critical sync health");
 

--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -31,8 +31,9 @@ class ActiveRoleHandler : public RoleHandler
     ActiveRoleHandler(sdbusplus::async::context& ctx, Providers& providers,
                       RedundancyInterface& iface) :
         RoleHandler(ctx, providers, iface), redMgr(ctx, providers, iface),
-        siblingHBTimer(
-            ctx, std::bind_front(&ActiveRoleHandler::siblingHBCritical, this))
+        siblingHealthTimer(
+            ctx,
+            std::bind_front(&ActiveRoleHandler::siblingHealthCritical, this))
     {}
 
     /**
@@ -121,7 +122,7 @@ class ActiveRoleHandler : public RoleHandler
 
         sibling.addHealthCallback(
             Role::Active,
-            std::bind_front(&ActiveRoleHandler::siblingHBChange, this));
+            std::bind_front(&ActiveRoleHandler::siblingHealthChange, this));
 
         sibling.addFailoverImminentCallback(
             Role::Active,
@@ -133,7 +134,7 @@ class ActiveRoleHandler : public RoleHandler
      */
     inline void stopSiblingWatches()
     {
-        siblingHBTimer.stop();
+        siblingHealthTimer.stop();
         providers.getSibling().clearCallbacks(Role::Active);
     }
 
@@ -149,30 +150,30 @@ class ActiveRoleHandler : public RoleHandler
     void siblingStateChange(BMCState state);
 
     /**
-     * @brief Called when the sibling's heartbeat changes
+     * @brief Called when the sibling's health changes
      *        assuming the callback has been enabled.
      *
-     * Spawns siblingHBStarted() on a start, and calls
-     * siblingHBCritical() on a stop.
+     * Spawns siblingHealthy() when changes to good, and calls
+     * siblingHealthCritical() when changes to bad.
      *
-     * @param[in] hb - The new heartbeat status
+     * @param[in] alive - If sibling is alive and healthy
      */
-    void siblingHBChange(bool hb);
+    void siblingHealthChange(bool alive);
 
     /**
-     * @brief Called when the sibling heartbeat starts after
+     * @brief Called when the sibling becomes good after
      *        sibling monitoring has been enabled.
      *
      * This will attempt to re-enable redundancy, though it might
      * not be possible for other reasons.
      */
-    sdbusplus::async::task<> siblingHBStarted();
+    sdbusplus::async::task<> siblingHealthy();
 
     /**
-     * @brief Called when the sibling heartbeat has been stopped
+     * @brief Called when the sibling health changes to bad
      *        long enough to explicitly disable redundancy.
      */
-    void siblingHBCritical();
+    void siblingHealthCritical();
 
     /**
      * @brief Starts watching the data sync health status property
@@ -216,11 +217,11 @@ class ActiveRoleHandler : public RoleHandler
     RedundancyMgr redMgr;
 
     /**
-     * @brief Timer used when the sibling's heartbeat stops
+     * @brief Timer used when the sibling's health changes to bad
      *
      * Upon expiration redundancy will be disabled.
      */
-    Timer siblingHBTimer;
+    Timer siblingHealthTimer;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -119,7 +119,7 @@ class ActiveRoleHandler : public RoleHandler
             Role::Active,
             std::bind_front(&ActiveRoleHandler::siblingStateChange, this));
 
-        sibling.addHeartbeatCallback(
+        sibling.addHealthCallback(
             Role::Active,
             std::bind_front(&ActiveRoleHandler::siblingHBChange, this));
 

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -210,7 +210,7 @@ role_determination::RoleInfo Manager::determineRole()
             .bmcPosition = services.getBMCPosition(),
             .previousRole = previousRole,
             .siblingRole = siblingRole,
-            .siblingHeartbeat = sibling.hasHeartbeat(),
+            .siblingAlive = sibling.alive(),
             .siblingProvisioned = siblingProvisioned,
             .failoverInProgress = redundancyInterface.failover_in_progress(),
             .siblingFailoverInProgress = siblingFailoverInProgress};
@@ -253,7 +253,7 @@ sdbusplus::async::task<std::optional<role_determination::RoleInfo>>
     }
 
     // The sibling service must be up and running.
-    if (!providers->getSibling().getInterfacePresent())
+    if (!providers->getSibling().alive())
     {
         auto state =
             co_await providers->getServices().getUnitState(Sibling::unitName);

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -297,7 +297,7 @@ auto PassiveRoleHandler::getFailoverBlockedReason(
     auto& sibling = providers.getSibling();
 
     fo_blocked::Input input{
-        .siblingHeartbeat = sibling.hasHeartbeat(),
+        .siblingAlive = sibling.alive(),
         .siblingState = sibling.getBMCState().value_or(BMCState::NotReady),
         .redundancyEnabled = sibling.getRedundancyEnabled().value_or(false),
         .syncInProgress = providers.getSyncInterface().isFullSyncInProgress(),

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -66,7 +66,7 @@ sdbusplus::async::task<> PassiveRoleHandler::start()
 
     setupSiblingFailoversAllowedWatch();
 
-    setupSiblingHBWatch();
+    setupSiblingHealthWatch();
 
     try
     {
@@ -168,7 +168,7 @@ void PassiveRoleHandler::disableRedPropChanged(bool /*disable*/)
 // NOLINTNEXTLINE
 sdbusplus::async::task<> PassiveRoleHandler::tryFullSync()
 {
-    if (providers.getSibling().hasHeartbeat() &&
+    if (providers.getSibling().alive() &&
         providers.getSibling().getRedundancyEnabled().value_or(false) &&
         (providers.getSibling().getRole().value_or(Role::Unknown) ==
          Role::Active))
@@ -246,7 +246,7 @@ sdbusplus::async::task<> PassiveRoleHandler::syncHealthCritical()
     lg2::info("Waiting to see if sibling heartbeat stops");
     co_await providers.getSibling().pauseForHeartbeatChange();
 
-    if (providers.getSibling().hasHeartbeat())
+    if (providers.getSibling().alive())
     {
         lg2::error("Sync fail was not caused by a sibling BMC problem");
         // TODO: Create error log
@@ -258,11 +258,11 @@ sdbusplus::async::task<> PassiveRoleHandler::syncHealthCritical()
     }
 }
 
-void PassiveRoleHandler::siblingHBChange(bool hb)
+void PassiveRoleHandler::siblingHealthChange(bool alive)
 {
-    lg2::info("Sibling heartbeat changed to {HB}", "HB", hb);
+    lg2::info("Sibling health changed to {ALIVE}", "ALIVE", alive);
 
-    if (hb)
+    if (alive)
     {
         // Probably redundancy would be disabled here,
         // but try anyway just in case.

--- a/redundant-bmc/src/passive_role_handler.hpp
+++ b/redundant-bmc/src/passive_role_handler.hpp
@@ -108,7 +108,7 @@ class PassiveRoleHandler : public RoleHandler
      */
     inline void setupSiblingHBWatch()
     {
-        providers.getSibling().addHeartbeatCallback(
+        providers.getSibling().addHealthCallback(
             Role::Passive, [this](bool hb) { siblingHBChange(hb); });
     }
 

--- a/redundant-bmc/src/passive_role_handler.hpp
+++ b/redundant-bmc/src/passive_role_handler.hpp
@@ -104,12 +104,12 @@ class PassiveRoleHandler : public RoleHandler
     void disableRedPropChanged(bool disable) override;
 
     /**
-     * @brief Setup watching the sibling BMC's heartbeat
+     * @brief Setup watching the sibling BMC's health
      */
-    inline void setupSiblingHBWatch()
+    inline void setupSiblingHealthWatch()
     {
         providers.getSibling().addHealthCallback(
-            Role::Passive, [this](bool hb) { siblingHBChange(hb); });
+            Role::Passive, [this](bool hb) { siblingHealthChange(hb); });
     }
 
     /**
@@ -133,11 +133,11 @@ class PassiveRoleHandler : public RoleHandler
     sdbusplus::async::task<> stopSync();
 
     /**
-     * @brief Called when the sibling BMC heartbeat changes.
+     * @brief Called when the sibling BMC health changes.
      *
      * Will try to start or stop syncing as appropriate.
      */
-    void siblingHBChange(bool hb);
+    void siblingHealthChange(bool alive);
 
     /**
      * @brief Called when the sync health property changes

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -10,7 +10,6 @@
 #include <xyz/openbmc_project/Software/Version/client.hpp>
 #include <xyz/openbmc_project/State/BMC/Redundancy/client.hpp>
 #include <xyz/openbmc_project/State/BMC/client.hpp>
-#include <xyz/openbmc_project/State/Decorator/Heartbeat/client.hpp>
 
 #include <format>
 #include <print>
@@ -20,8 +19,6 @@ using Redundancy =
 using BMCState = sdbusplus::client::xyz::openbmc_project::state::BMC<>;
 using Role = Redundancy::Role;
 using Failover = sdbusplus::client::xyz::openbmc_project::control::Failover<>;
-using Heartbeat =
-    sdbusplus::client::xyz::openbmc_project::state::decorator::Heartbeat<>;
 using Version = sdbusplus::client::xyz::openbmc_project::software::Version<>;
 
 constexpr auto siblingService =
@@ -174,16 +171,6 @@ sdbusplus::async::task<> displaySiblingBMCInfo(sdbusplus::async::context& ctx,
 
     try
     {
-        auto hbActive = co_await Heartbeat(ctx)
-                            .service(siblingService)
-                            .path(path.str)
-                            .active();
-        if (!hbActive)
-        {
-            std::println("No sibling heartbeat");
-            co_return;
-        }
-
         auto rProps = co_await Redundancy(ctx)
                           .service(siblingService)
                           .path(path.str)
@@ -219,8 +206,7 @@ sdbusplus::async::task<> displaySiblingBMCInfo(sdbusplus::async::context& ctx,
     }
     catch (const sdbusplus::exception_t& e)
     {
-        std::println("Cannot get to a sibling interface on D-Bus: {}",
-                     e.what());
+        std::println("Sibling data not available");
     }
 }
 

--- a/redundant-bmc/src/redundancy.cpp
+++ b/redundant-bmc/src/redundancy.cpp
@@ -33,9 +33,9 @@ NoRedundancyReasons getNoRedundancyReasons(const Input& input)
     }
     else
     {
-        if (!input.siblingHeartbeat)
+        if (!input.siblingAlive)
         {
-            reasons.insert(noSiblingHeartbeat);
+            reasons.insert(siblingNotAlive);
         }
         else
         {
@@ -95,8 +95,8 @@ std::string getNoRedundancyDescription(NoRedundancyReason reason)
         case siblingMissing:
             desc = "Sibling is missing"s;
             break;
-        case noSiblingHeartbeat:
-            desc = "No sibling heartbeat"s;
+        case siblingNotAlive:
+            desc = "Sibling not alive"s;
             break;
         case siblingNotProvisioned:
             desc = "Sibling is not provisioned"s;
@@ -195,7 +195,7 @@ namespace fo_blocked
 
 Reason getFailoverBlockedReason(const Input& input)
 {
-    if (input.siblingHeartbeat)
+    if (input.siblingAlive)
     {
         if (!input.redundancyEnabled)
         {
@@ -242,7 +242,7 @@ Reason getFailoverBlockedReason(const Input& input)
         }
 
         lg2::info(
-            "There is no sibling heartbeat but redundancy was last known to be enabled");
+            "Sibling not alive but redundancy was last known to be enabled");
 
         if (input.failoversNotAllowed)
         {

--- a/redundant-bmc/src/redundancy.hpp
+++ b/redundant-bmc/src/redundancy.hpp
@@ -24,7 +24,7 @@ struct Input
 {
     Role role;
     bool siblingPresent;
-    bool siblingHeartbeat;
+    bool siblingAlive;
     bool siblingProvisioned;
     Role siblingRole;
     BMCState siblingState;
@@ -44,7 +44,7 @@ enum class NoRedundancyReason
     bmcNotActive,
     manuallyDisabled,
     siblingMissing,
-    noSiblingHeartbeat,
+    siblingNotAlive,
     siblingNotProvisioned,
     siblingNotPassive,
     codeMismatch,
@@ -126,7 +126,7 @@ namespace fo_blocked
  */
 struct Input
 {
-    bool siblingHeartbeat;
+    bool siblingAlive;
     BMCState siblingState;
     bool redundancyEnabled;
     bool syncInProgress;

--- a/redundant-bmc/src/redundancy_mgr.cpp
+++ b/redundant-bmc/src/redundancy_mgr.cpp
@@ -107,7 +107,7 @@ redundancy::NoRedundancyReasons RedundancyMgr::getNoRedundancyReasons()
     redundancy::Input input{
         .role = redundancyInterface.role(),
         .siblingPresent = sibling.isBMCPresent(),
-        .siblingHeartbeat = sibling.hasHeartbeat(),
+        .siblingAlive = sibling.alive(),
         .siblingProvisioned = sibling.getProvisioned().value_or(false),
         .siblingRole = sibling.getRole().value_or(Role::Unknown),
         .siblingState = sibling.getBMCState().value_or(BMCState::NotReady),

--- a/redundant-bmc/src/role_determination.cpp
+++ b/redundant-bmc/src/role_determination.cpp
@@ -10,9 +10,9 @@ RoleInfo determineRole(const Input& input)
     RoleInfo result;
 
     // Must check this before any other sibling fields
-    if (!input.siblingHeartbeat)
+    if (!input.siblingAlive)
     {
-        result = {Role::Active, RoleReason::noSiblingHeartbeat};
+        result = {Role::Active, RoleReason::siblingNotAlive};
     }
 
     else if (!input.siblingProvisioned)
@@ -73,8 +73,8 @@ std::string getRoleReasonDescription(RoleReason reason)
         case RoleReason::unknown:
             desc = "Unknown reason"s;
             break;
-        case RoleReason::noSiblingHeartbeat:
-            desc = "No sibling heartbeat"s;
+        case RoleReason::siblingNotAlive:
+            desc = "Sibling not alive"s;
             break;
         case RoleReason::siblingNotProvisioned:
             desc = "Sibling is not provisioned"s;

--- a/redundant-bmc/src/role_determination.hpp
+++ b/redundant-bmc/src/role_determination.hpp
@@ -20,7 +20,7 @@ struct Input
     size_t bmcPosition;
     Role previousRole;
     Role siblingRole;
-    bool siblingHeartbeat;
+    bool siblingAlive;
     bool siblingProvisioned;
     bool failoverInProgress;
     bool siblingFailoverInProgress;
@@ -32,7 +32,7 @@ struct Input
 enum class RoleReason
 {
     unknown,
-    noSiblingHeartbeat,
+    siblingNotAlive,
     siblingNotProvisioned,
     siblingPassive,
     siblingActive,

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -46,21 +46,11 @@ class Sibling
         "xyz.openbmc_project.State.BMC.Redundancy.Sibling.service";
 
     /**
-     * @brief Returns if the Sibling interface is on D-Bus
-     */
-    virtual bool getInterfacePresent() const = 0;
-
-    /**
      * @brief Sets up the D-Bus matches
      *
      * @return - The task object
      */
     virtual sdbusplus::async::task<> init() = 0;
-
-    /**
-     * @brief Returns if the sibling heartbeat is active
-     */
-    virtual bool hasHeartbeat() const = 0;
 
     /**
      * @brief Returns if the sibling BMC has a good heartbeat

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -28,7 +28,7 @@ class Sibling
         sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState;
     using RedundancyEnabledCallback = std::function<void(bool)>;
     using BMCStateCallback = std::function<void(BMCState)>;
-    using HeartbeatCallback = std::function<void(bool)>;
+    using HealthCallback = std::function<void(bool)>;
     using FailoversAllowedCallback = std::function<void(bool)>;
     using FailoverImminentCallback = std::function<void(bool)>;
 
@@ -61,6 +61,12 @@ class Sibling
      * @brief Returns if the sibling heartbeat is active
      */
     virtual bool hasHeartbeat() const = 0;
+
+    /**
+     * @brief Returns if the sibling BMC has a good heartbeat
+     *        and there is valid data on D-Bus for it.
+     */
+    virtual bool alive() const = 0;
 
     /**
      * @brief Waits up to 6 minutes for the sibling interface to
@@ -160,7 +166,7 @@ class Sibling
     {
         redEnabledCBs.erase(role);
         bmcStateCBs.erase(role);
-        heartbeatCBs.erase(role);
+        healthCBs.erase(role);
         foAllowedCBs.erase(role);
         foImminentCBs.erase(role);
     }
@@ -192,14 +198,15 @@ class Sibling
 
     /**
      * @brief Adds a callback function to invoke when the sibling's
-     *        Heartbeat property changes
+     *        health changes, i.e. its D-Bus interfaces either show
+     *        up or disappear.
      *
      * @param[in] role - The role to register with
      * @param[in] callback - The callback function
      */
-    void addHeartbeatCallback(Role role, HeartbeatCallback callback)
+    void addHealthCallback(Role role, HealthCallback callback)
     {
-        heartbeatCBs.emplace(role, std::move(callback));
+        healthCBs.emplace(role, std::move(callback));
     }
 
     /**
@@ -240,9 +247,9 @@ class Sibling
     std::map<Role, BMCStateCallback> bmcStateCBs;
 
     /**
-     * @brief Callbacks for Heartbeat
+     * @brief Callbacks for when the health changes
      */
-    std::map<Role, HeartbeatCallback> heartbeatCBs;
+    std::map<Role, HealthCallback> healthCBs;
 
     /**
      * @brief Callbacks for FailoversAllowed

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -6,7 +6,6 @@
 #include <xyz/openbmc_project/Software/Version/common.hpp>
 #include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
 #include <xyz/openbmc_project/State/BMC/common.hpp>
-#include <xyz/openbmc_project/State/Decorator/Heartbeat/common.hpp>
 
 #include <ranges>
 
@@ -16,8 +15,6 @@ namespace rbmc
 using RedIntf = sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy;
 using VersionIntf = sdbusplus::common::xyz::openbmc_project::software::Version;
 using BMCStateIntf = sdbusplus::common::xyz::openbmc_project::state::BMC;
-using HBIntf =
-    sdbusplus::common::xyz::openbmc_project::state::decorator::Heartbeat;
 
 SiblingImpl::SiblingImpl(sdbusplus::async::context& ctx) :
     ctx(ctx), objectPath(std::string{RedIntf::namespace_path::value} + '/' +
@@ -57,8 +54,7 @@ sdbusplus::async::task<> SiblingImpl::init()
         co_await initProperties();
     }
 
-    lg2::info("In Sibling init, interface present is {PRESENT}", "PRESENT",
-              getInterfacePresent());
+    lg2::info("In Sibling init, sibling alive is {ALIVE}", "ALIVE", alive());
 
     initialized = true;
 }
@@ -170,27 +166,6 @@ void SiblingImpl::loadStateProps(const SiblingImpl::PropertyMap& propertyMap)
     }
 }
 
-void SiblingImpl::loadHeartbeatProps(
-    const SiblingImpl::PropertyMap& propertyMap)
-{
-    heartbeat.present = true;
-
-    auto it = propertyMap.find("Active");
-    if (it != propertyMap.end())
-    {
-        auto old = heartbeat.active;
-        heartbeat.active = std::get<bool>(it->second);
-        if (heartbeat.active != old)
-        {
-            for (const auto& callback :
-                 std::ranges::views::values(heartbeatCBs))
-            {
-                callback(heartbeat.active);
-            }
-        }
-    }
-}
-
 // NOLINTNEXTLINE
 sdbusplus::async::task<> SiblingImpl::watchInterfaceAdded()
 {
@@ -202,6 +177,8 @@ sdbusplus::async::task<> SiblingImpl::watchInterfaceAdded()
         auto [_, interfaces] =
             co_await match
                 .next<sdbusplus::message::object_path, InterfaceMap>();
+
+        auto prevAlive = alive();
 
         std::ranges::for_each(interfaces, [this](const auto& entry) {
             loadFromPropertyMap(entry.first, entry.second);
@@ -228,6 +205,16 @@ sdbusplus::async::task<> SiblingImpl::watchInterfaceAdded()
                 ctx.spawn(watchNameOwnerChanged());
             }
         }
+
+        // If not alive before and now all interfaces are
+        // on D-Bus invoke the callbacks.
+        if (!prevAlive && alive())
+        {
+            for (const auto& callback : std::ranges::views::values(healthCBs))
+            {
+                callback(true);
+            }
+        }
     }
 }
 
@@ -244,6 +231,8 @@ sdbusplus::async::task<> SiblingImpl::watchInterfaceRemoved()
             co_await match.next<sdbusplus::message::object_path,
                                 std::vector<std::string>>();
 
+        auto prevAlive = alive();
+
         if (std::ranges::contains(interfaces, RedIntf::interface))
         {
             redundancy.present = false;
@@ -256,19 +245,13 @@ sdbusplus::async::task<> SiblingImpl::watchInterfaceRemoved()
         {
             bmcState.present = false;
         }
-        if (std::ranges::contains(interfaces, HBIntf::interface))
-        {
-            heartbeat.present = false;
 
-            auto old = heartbeat.active;
-            heartbeat.active = false;
-            if (old != heartbeat.active)
+        // If alive before and all interfaces are now gone invoke the callbacks
+        if (prevAlive && !alive())
+        {
+            for (const auto& callback : std::ranges::views::values(healthCBs))
             {
-                for (const auto& callback :
-                     std::ranges::views::values(heartbeatCBs))
-                {
-                    callback(heartbeat.active);
-                }
+                callback(false);
             }
         }
     }
@@ -310,6 +293,12 @@ sdbusplus::async::task<> SiblingImpl::watchNameOwnerChanged()
         {
             lg2::info("Sibling D-Bus name lost");
             setInterfacesNotPresent();
+
+            // Invoke any health callbacks as sibling is gone.
+            for (const auto& callback : std::ranges::views::values(healthCBs))
+            {
+                callback(false);
+            }
         }
     }
 }
@@ -357,10 +346,6 @@ void SiblingImpl::loadFromPropertyMap(const std::string& interface,
     {
         loadVersionProps(propertyMap);
     }
-    else if (interface == HBIntf::interface)
-    {
-        loadHeartbeatProps(propertyMap);
-    }
 }
 
 // NOLINTNEXTLINE
@@ -371,25 +356,20 @@ sdbusplus::async::task<> SiblingImpl::waitForSiblingUp()
     std::chrono::minutes timeout{6};
     auto waiting = false;
 
-    while ((!getInterfacePresent() || !hasHeartbeat()) &&
-           ((std::chrono::steady_clock::now() - start) < timeout))
+    while (!alive() && ((std::chrono::steady_clock::now() - start) < timeout))
     {
         if (!waiting)
         {
             lg2::info(
-                "Waiting up to {TIME} minutes for sibling interface and/or heartbeat: "
-                "Present = {PRES}, Heartbeat = {HB}",
-                "TIME", timeout.count(), "PRES", getInterfacePresent(), "HB",
-                heartbeat.active);
+                "Waiting up to {TIME} minutes for sibling to become alive",
+                "TIME", timeout.count());
             waiting = true;
         }
 
         co_await sdbusplus::async::sleep_for(ctx, 500ms);
     }
 
-    lg2::info(
-        "Done waiting for sibling. Interface present = {PRES}, heartbeat = {HB}",
-        "PRES", getInterfacePresent(), "HB", heartbeat.active);
+    lg2::info("Done waiting for sibling, alive = {ALIVE}", "ALIVE", alive());
 }
 
 // NOLINTNEXTLINE
@@ -403,7 +383,7 @@ sdbusplus::async::task<> SiblingImpl::waitForSiblingRole()
         return getRole().value_or(Role::Unknown) == Role::Unknown;
     };
 
-    if (!hasHeartbeat() || !noRole())
+    if (!alive() || !noRole())
     {
         co_return;
     }
@@ -433,7 +413,7 @@ sdbusplus::async::task<> SiblingImpl::waitForBMCSteadyState() const
     bool waiting = false;
 
     // If sibling isn't alive don't bother waiting
-    if (!hasHeartbeat())
+    if (!alive())
     {
         co_return;
     }

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -35,24 +35,6 @@ class SiblingImpl : public Sibling
      */
     explicit SiblingImpl(sdbusplus::async::context& ctx);
 
-    // TODO: remove this function when it is no longer called
-    /**
-     * @brief Returns if the Sibling interfaces are on D-Bus
-     */
-    bool getInterfacePresent() const override
-    {
-        return alive();
-    }
-
-    // TODO: remove this function when it is no longer called
-    /**
-     * @brief Returns if the sibling heartbeat is active
-     */
-    bool hasHeartbeat() const override
-    {
-        return alive();
-    }
-
     /**
      * @brief Returns if the sibling BMC has a good heartbeat
      *        and there is valid data on D-Bus for it.

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -35,21 +35,34 @@ class SiblingImpl : public Sibling
      */
     explicit SiblingImpl(sdbusplus::async::context& ctx);
 
+    // TODO: remove this function when it is no longer called
     /**
      * @brief Returns if the Sibling interfaces are on D-Bus
      */
     bool getInterfacePresent() const override
     {
-        return version.present && redundancy.present && bmcState.present &&
-               heartbeat.present;
+        return alive();
     }
 
+    // TODO: remove this function when it is no longer called
     /**
      * @brief Returns if the sibling heartbeat is active
      */
     bool hasHeartbeat() const override
     {
-        return heartbeat.active;
+        return alive();
+    }
+
+    /**
+     * @brief Returns if the sibling BMC has a good heartbeat
+     *        and there is valid data on D-Bus for it.
+     *
+     * The sibling daemon only puts the interfaces on D-Bus when
+     * the heartbeat is active.
+     */
+    bool alive() const override
+    {
+        return version.present && redundancy.present && bmcState.present;
     }
 
     /**
@@ -84,7 +97,7 @@ class SiblingImpl : public Sibling
      */
     std::optional<BMCState> getBMCState() const override
     {
-        if (getInterfacePresent() && hasHeartbeat())
+        if (alive())
         {
             return bmcState.state;
         }
@@ -99,7 +112,7 @@ class SiblingImpl : public Sibling
      */
     std::optional<Role> getRole() const override
     {
-        if (getInterfacePresent() && hasHeartbeat())
+        if (alive())
         {
             return redundancy.role;
         }
@@ -114,7 +127,7 @@ class SiblingImpl : public Sibling
      */
     std::optional<bool> getRedundancyEnabled() const override
     {
-        if (getInterfacePresent() && hasHeartbeat())
+        if (alive())
         {
             return redundancy.redundancyEnabled;
         }
@@ -129,7 +142,7 @@ class SiblingImpl : public Sibling
      */
     std::optional<bool> getProvisioned() const override
     {
-        if (getInterfacePresent() && hasHeartbeat())
+        if (alive())
         {
             // TBD which interface to use.
             return true;
@@ -145,7 +158,7 @@ class SiblingImpl : public Sibling
      */
     std::optional<std::string> getFWVersion() const override
     {
-        if (getInterfacePresent() && hasHeartbeat())
+        if (alive())
         {
             return version.version;
         }
@@ -160,7 +173,7 @@ class SiblingImpl : public Sibling
      */
     std::optional<bool> getFailoversAllowed() const override
     {
-        if (getInterfacePresent() && hasHeartbeat())
+        if (alive())
         {
             return redundancy.failoversAllowed;
         }
@@ -175,7 +188,7 @@ class SiblingImpl : public Sibling
      */
     std::optional<bool> getFailoverInProgress() const override
     {
-        if (getInterfacePresent() && hasHeartbeat())
+        if (alive())
         {
             return redundancy.failoverInProgress;
         }
@@ -190,7 +203,7 @@ class SiblingImpl : public Sibling
      */
     std::optional<bool> getFailoverImminent() const override
     {
-        if (getInterfacePresent() && hasHeartbeat())
+        if (alive())
         {
             return redundancy.failoverImminent;
         }
@@ -288,8 +301,6 @@ class SiblingImpl : public Sibling
         redundancy.present = false;
         bmcState.present = false;
         version.present = false;
-        heartbeat.present = false;
-        heartbeat.active = false;
     }
 
     /**
@@ -350,17 +361,6 @@ class SiblingImpl : public Sibling
      * @brief State presence and value
      */
     State bmcState;
-
-    struct Heartbeat
-    {
-        bool present = false;
-        bool active = false;
-    };
-
-    /**
-     * @brief Heartbeat presence and value
-     */
-    Heartbeat heartbeat;
 
     /**
      * @brief The D-Bus object path for the sibling.

--- a/redundant-bmc/test/redundancy_test.cpp
+++ b/redundant-bmc/test/redundancy_test.cpp
@@ -13,7 +13,7 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
     const Input golden{
         .role = rbmc::Role::Active,
         .siblingPresent = true,
-        .siblingHeartbeat = true,
+        .siblingAlive = true,
         .siblingProvisioned = true,
         .siblingRole = rbmc::Role::Passive,
         .siblingState = rbmc::BMCState::Ready,
@@ -48,14 +48,14 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
         EXPECT_EQ(*reasons.begin(), siblingMissing);
     }
 
-    // No sibling heartbeat
+    // Sibling not alive
     {
         auto input = golden;
-        input.siblingHeartbeat = false;
+        input.siblingAlive = false;
 
         auto reasons = getNoRedundancyReasons(input);
         ASSERT_EQ(reasons.size(), 1);
-        EXPECT_EQ(*reasons.begin(), noSiblingHeartbeat);
+        EXPECT_EQ(*reasons.begin(), siblingNotAlive);
     }
 
     // Sibling isn't provisioned
@@ -221,7 +221,7 @@ TEST(RedundancyTest, GetFailoversNotAllowedDescTest)
 TEST(RedundancyTest, FailoverBlockedTest)
 {
     rbmc::fo_blocked::Input golden{
-        .siblingHeartbeat = true,
+        .siblingAlive = true,
         .siblingState = rbmc::BMCState::Ready,
         .redundancyEnabled = true,
         .syncInProgress = false,
@@ -278,7 +278,7 @@ TEST(RedundancyTest, FailoverBlockedTest)
     // Sibling not responding, but redundancy was enabled
     {
         auto input = golden;
-        input.siblingHeartbeat = false;
+        input.siblingAlive = false;
         EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
                   rbmc::fo_blocked::Reason::none);
     }
@@ -286,7 +286,7 @@ TEST(RedundancyTest, FailoverBlockedTest)
     // Sibling not responding, redundancy was enabled and failovers not allowed
     {
         auto input = golden;
-        input.siblingHeartbeat = false;
+        input.siblingAlive = false;
         input.failoversNotAllowed = true;
         EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
                   rbmc::fo_blocked::Reason::none);
@@ -295,7 +295,7 @@ TEST(RedundancyTest, FailoverBlockedTest)
     // Sibling not responding, redundancy was enabled, but this BMC in Quiesced.
     {
         auto input = golden;
-        input.siblingHeartbeat = false;
+        input.siblingAlive = false;
         input.state = rbmc::BMCState::Quiesced;
         EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
                   rbmc::fo_blocked::Reason::notAtReady);
@@ -304,7 +304,7 @@ TEST(RedundancyTest, FailoverBlockedTest)
     // Sibling not responding, but redundancy wasn't enabled
     {
         auto input = golden;
-        input.siblingHeartbeat = false;
+        input.siblingAlive = false;
         input.lastKnownRedundancyEnabled = false;
         EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
                   rbmc::fo_blocked::Reason::siblingDeadButRedundancyNotEnabled);

--- a/redundant-bmc/test/role_determination_test.cpp
+++ b/redundant-bmc/test/role_determination_test.cpp
@@ -16,7 +16,7 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
         Input input{.bmcPosition = 0,
                     .previousRole = Unknown,
                     .siblingRole = Unknown,
-                    .siblingHeartbeat = true,
+                    .siblingAlive = true,
                     .siblingProvisioned = true,
                     .failoverInProgress = false,
                     .siblingFailoverInProgress = false};
@@ -31,7 +31,7 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
         Input input{.bmcPosition = 1,
                     .previousRole = Unknown,
                     .siblingRole = Unknown,
-                    .siblingHeartbeat = true,
+                    .siblingAlive = true,
                     .siblingProvisioned = true,
                     .failoverInProgress = false,
                     .siblingFailoverInProgress = false};
@@ -46,15 +46,14 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
         Input input{.bmcPosition = 1,
                     .previousRole = Unknown,
                     .siblingRole = Unknown,
-                    .siblingHeartbeat = false,
+                    .siblingAlive = false,
                     .siblingProvisioned = true,
                     .failoverInProgress = false,
                     .siblingFailoverInProgress = false};
 
-        RoleInfo info{Active, noSiblingHeartbeat};
+        RoleInfo info{Active, siblingNotAlive};
         EXPECT_EQ(determineRole(input), info);
-        EXPECT_EQ(getRoleReasonDescription(info.reason),
-                  "No sibling heartbeat");
+        EXPECT_EQ(getRoleReasonDescription(info.reason), "Sibling not alive");
     }
 
     // Sibling not provisioned
@@ -62,7 +61,7 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
         Input input{.bmcPosition = 1,
                     .previousRole = Unknown,
                     .siblingRole = Unknown,
-                    .siblingHeartbeat = true,
+                    .siblingAlive = true,
                     .siblingProvisioned = false,
                     .failoverInProgress = false,
                     .siblingFailoverInProgress = false};
@@ -78,7 +77,7 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
         Input input{.bmcPosition = 0,
                     .previousRole = Unknown,
                     .siblingRole = Active,
-                    .siblingHeartbeat = true,
+                    .siblingAlive = true,
                     .siblingProvisioned = true,
                     .failoverInProgress = false,
                     .siblingFailoverInProgress = false};
@@ -94,7 +93,7 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
         Input input{.bmcPosition = 1,
                     .previousRole = Unknown,
                     .siblingRole = Passive,
-                    .siblingHeartbeat = true,
+                    .siblingAlive = true,
                     .siblingProvisioned = true,
                     .failoverInProgress = false,
                     .siblingFailoverInProgress = false};
@@ -110,7 +109,7 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
         Input input{.bmcPosition = 0,
                     .previousRole = Passive,
                     .siblingRole = Unknown,
-                    .siblingHeartbeat = true,
+                    .siblingAlive = true,
                     .siblingProvisioned = true,
                     .failoverInProgress = false,
                     .siblingFailoverInProgress = false};
@@ -127,7 +126,7 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
         Input input{.bmcPosition = 1,
                     .previousRole = Active,
                     .siblingRole = Unknown,
-                    .siblingHeartbeat = true,
+                    .siblingAlive = true,
                     .siblingProvisioned = true,
                     .failoverInProgress = false,
                     .siblingFailoverInProgress = false};
@@ -145,7 +144,7 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
         Input input{.bmcPosition = 1,
                     .previousRole = Active,
                     .siblingRole = Unknown,
-                    .siblingHeartbeat = true,
+                    .siblingAlive = true,
                     .siblingProvisioned = true,
                     .failoverInProgress = true,
                     .siblingFailoverInProgress = false};
@@ -164,7 +163,7 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
         Input input{.bmcPosition = 0,
                     .previousRole = Active,
                     .siblingRole = Unknown,
-                    .siblingHeartbeat = true,
+                    .siblingAlive = true,
                     .siblingProvisioned = true,
                     .failoverInProgress = false,
                     .siblingFailoverInProgress = true};


### PR DESCRIPTION
Now that the CFAM daemon removes the state/bmc1 interfaces from D-Bus when the sibling BMC's heartbeat stops, this code no longer needs to check the heartbeat itself.  So remove all references to heartbeat and use new 'alive' terminology to refer to the state/bmc1 being present.