### PR TITLE
RBMC: Get BMC position from inventory

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -53,6 +53,7 @@ There are some error cases that require that the BMC is passive regardless of
 what the sibling is doing. These are:
 
 1. The BMC is not provisioned.
+1. The BMC position cannot be determined.
 1. The systemd service that maintains the sibling API isn't running. Without
    this service running, the sibling BMC will think this BMC is dead and will
    become active.

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -104,7 +104,7 @@ sdbusplus::async::task<> Manager::startup()
             }
         }
 
-        updateRole(determineRole());
+        updateRole(co_await determineRole());
     }
 
     co_await postStartupClearFOInProgress();
@@ -188,7 +188,8 @@ sdbusplus::async::task<> Manager::doHeartBeat()
     co_return;
 }
 
-role_determination::RoleInfo Manager::determineRole()
+// NOLINTNEXTLINE
+sdbusplus::async::task<role_determination::RoleInfo> Manager::determineRole()
 {
     auto& services = providers->getServices();
     auto& sibling = providers->getSibling();
@@ -206,8 +207,17 @@ role_determination::RoleInfo Manager::determineRole()
         auto siblingFailoverInProgress =
             sibling.getFailoverInProgress().value_or(false);
 
+        // determineRole() doesn't support an empty BMC position because
+        // it should have been caught in determinePassiveRoleIfRequired.
+        auto bmcPos = co_await services.getBMCPosition();
+        if (!bmcPos.has_value())
+        {
+            lg2::error("determineRole: No BMC position");
+            co_return RoleInfo{Role::Passive, RoleReason::unknownBMCPosition};
+        }
+
         role_determination::Input input{
-            .bmcPosition = services.getBMCPosition(),
+            .bmcPosition = bmcPos.value(),
             .previousRole = previousRole,
             .siblingRole = siblingRole,
             .siblingHeartbeat = sibling.hasHeartbeat(),
@@ -235,7 +245,7 @@ role_determination::RoleInfo Manager::determineRole()
 
     // TODO, probably: Create an error log if passive due to an error
 
-    return roleInfo;
+    co_return roleInfo;
 }
 
 // clang-tidy appears to get confused on some code down in stdexec
@@ -245,6 +255,13 @@ sdbusplus::async::task<std::optional<role_determination::RoleInfo>>
     Manager::determinePassiveRoleIfRequired()
 {
     using namespace role_determination;
+
+    // A BMC with no position cannot be active.
+    auto bmcPos = co_await providers->getServices().getBMCPosition();
+    if (!bmcPos.has_value())
+    {
+        co_return RoleInfo{Role::Passive, RoleReason::unknownBMCPosition};
+    }
 
     // An unprovisioned BMC cannot be active.
     if (!providers->getServices().getProvisioned())

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -79,7 +79,7 @@ class Manager :
      *
      * @return roleInfo - The role + role error if any
      */
-    role_determination::RoleInfo determineRole();
+    sdbusplus::async::task<role_determination::RoleInfo> determineRole();
 
     /**
      * @brief Determine if the BMC must be passive due to a problem.

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -122,7 +122,9 @@ sdbusplus::async::task<> displayLocalBMCInfo(sdbusplus::async::context& ctx,
         printParam("Role:", role);
 
         rbmc::ServicesImpl services{ctx};
-        printParam("BMC Position:", services.getBMCPosition());
+        auto pos = co_await services.getBMCPosition();
+        auto bmcPos = pos.has_value() ? std::to_string(pos.value()) : "Unknown";
+        printParam("BMC Position:", bmcPos);
 
         printParam("Redundancy Enabled:", props.redundancy_enabled);
 

--- a/redundant-bmc/src/role_determination.cpp
+++ b/redundant-bmc/src/role_determination.cpp
@@ -112,6 +112,9 @@ std::string getRoleReasonDescription(RoleReason reason)
         case RoleReason::failover:
             desc = "Failover"s;
             break;
+        case RoleReason::unknownBMCPosition:
+            desc = "Cannot determine BMC position"s;
+            break;
     }
 
     return desc;
@@ -121,7 +124,7 @@ bool isErrorReason(RoleReason reason)
 {
     using enum RoleReason;
     return (reason == notProvisioned) || (reason == siblingServiceNotRunning) ||
-           (reason == exception);
+           (reason == exception) || (reason == unknownBMCPosition);
 }
 
 } // namespace rbmc::role_determination

--- a/redundant-bmc/src/role_determination.hpp
+++ b/redundant-bmc/src/role_determination.hpp
@@ -44,7 +44,8 @@ enum class RoleReason
     exception,
     failover,
     failoverInProgress,
-    siblingFailoverInProgress
+    siblingFailoverInProgress,
+    unknownBMCPosition
 };
 
 /**

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -47,9 +47,10 @@ class Services
     /**
      * @brief Returns this BMC's position.
      *
-     * @return - The position
+     * @return - The position if it can be obtained
      */
-    virtual size_t getBMCPosition() const = 0;
+    virtual sdbusplus::async::task<std::optional<size_t>> getBMCPosition()
+        const = 0;
 
     /**
      * @brief Starts a systemd unit

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -4,6 +4,7 @@
 #include <openssl/evp.h>
 
 #include <phosphor-logging/lg2.hpp>
+#include <xyz/openbmc_project/Inventory/Decorator/Position/client.hpp>
 #include <xyz/openbmc_project/ObjectMapper/client.hpp>
 #include <xyz/openbmc_project/State/BMC/client.hpp>
 #include <xyz/openbmc_project/State/Boot/Progress/client.hpp>
@@ -18,6 +19,8 @@ using HostState = sdbusplus::client::xyz::openbmc_project::state::Host<>;
 using ObjectMapper = sdbusplus::client::xyz::openbmc_project::ObjectMapper<>;
 using BootProgress =
     sdbusplus::client::xyz::openbmc_project::state::boot::Progress<>;
+using Position =
+    sdbusplus::client::xyz::openbmc_project::inventory::decorator::Position<>;
 
 using HostProperties =
     std::variant<std::string, HostState::HostState, HostState::RestartCause,
@@ -31,6 +34,7 @@ namespace rules = sdbusplus::bus::match::rules;
 namespace object_path
 {
 constexpr auto systemd = "/org/freedesktop/systemd1";
+const auto systemInv = "/xyz/openbmc_project/inventory/system";
 
 // host0 represents the overall host state
 const std::string hostState = std::string{HostState::namespace_path::value} +
@@ -356,50 +360,39 @@ void ServicesImpl::updateSystemState()
     }
 }
 
-size_t ServicesImpl::getBMCPosition() const
+// NOLINTNEXTLINE
+sdbusplus::async::task<std::optional<size_t>> ServicesImpl::getBMCPosition()
+    const
 {
-    size_t bmcPosition = 0;
-
-    // NOTE:  This a temporary solution for simulation until the
-    // daemon that should be providing this information is in place.
-    // Most likely, this will then have to return a task<uint32_t>.
-
-    // Read it out of the bmc_position uboot environment variable
-    // This was written by a simulation script.
-    std::string cmd{"/sbin/fw_printenv -n bmc_position"};
-
-    // NOLINTBEGIN(cert-env33-c)
-    FILE* pipe = popen(cmd.c_str(), "r");
-    // NOLINTEND(cert-env33-c)
-    if (pipe == nullptr)
+    try
     {
-        throw std::runtime_error("Error calling popen to get bmc_position");
+        static std::string service;
+        if (service.empty())
+        {
+            service = co_await util::getService(ctx, object_path::systemInv,
+                                                Position::interface);
+        }
+
+        size_t position = co_await Position(ctx)
+                              .service(service)
+                              .path(object_path::systemInv)
+                              .position();
+
+        // max() is a special value meaning position cannot be obtained.
+        if (position == std::numeric_limits<size_t>::max())
+        {
+            lg2::error("BMC position value is not valid");
+            co_return std::nullopt;
+        }
+
+        co_return position;
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("D-Bus error obtaining BMC position: {ERROR}", "ERROR", e);
     }
 
-    std::string output;
-    std::array<char, 128> buffer;
-    while (fgets(buffer.data(), buffer.size(), pipe) != nullptr)
-    {
-        output.append(buffer.data());
-    }
-
-    int rc = pclose(pipe);
-    if (WEXITSTATUS(rc) != 0)
-    {
-        throw std::runtime_error{std::format(
-            "Error running cmd: {}, output = {}, rc = {}", cmd, output, rc)};
-    }
-
-    auto [_,
-          ec] = std::from_chars(&*output.begin(), &*output.end(), bmcPosition);
-    if (ec != std::errc())
-    {
-        throw std::runtime_error{
-            std::format("Could not extract position from {}: rc {}", output,
-                        std::to_underlying(ec))};
-    }
-
-    return bmcPosition;
+    co_return std::nullopt;
 }
 
 // NOLINTBEGIN

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -41,9 +41,10 @@ class ServicesImpl : public Services
     /**
      * @brief Returns this BMC's position.
      *
-     * @return - The position
+     * @return - The position if it can be obtained
      */
-    size_t getBMCPosition() const override;
+    sdbusplus::async::task<std::optional<size_t>> getBMCPosition()
+        const override;
 
     /**
      * @brief Starts a systemd unit


### PR DESCRIPTION
Each BMC needs to know its own position, and was previously just getting it from a uboot environment variable set by the simulator.

Now get the position from the real place, which is the Position property on the xyz.openbmc_project.Inventory.Decorator.Position interface on /xyz/openbmc_project/inventory/system.

If the value is the 'maxint' value it means the position could not be obtained due to a hardware issue.  In that case, or if there is some D-bus failure getting the position, the BMC will have to be passive because a known position is required to become active.

Tested:
Position is obtained:
```
$ rbmctool -de |grep Position
BMC Position:         0

$ rbmctool -de | grep Position
BMC Position:         1
```

Change-Id: If2855cec9dbaaca0a233915ae1ad5490c15bb7c8