### PR TITLE
RBMC: Use Available prop to get sib BMC presence

### DIFF
--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -6,6 +6,7 @@
 #include <xyz/openbmc_project/Software/Version/common.hpp>
 #include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
 #include <xyz/openbmc_project/State/BMC/common.hpp>
+#include <xyz/openbmc_project/State/Decorator/Availability/client.hpp>
 
 #include <ranges>
 
@@ -15,18 +16,13 @@ namespace rbmc
 using RedIntf = sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy;
 using VersionIntf = sdbusplus::common::xyz::openbmc_project::software::Version;
 using BMCStateIntf = sdbusplus::common::xyz::openbmc_project::state::BMC;
+using AvailIntf =
+    sdbusplus::common::xyz::openbmc_project::state::decorator::Availability;
 
 SiblingImpl::SiblingImpl(sdbusplus::async::context& ctx) :
     ctx(ctx), objectPath(std::string{RedIntf::namespace_path::value} + '/' +
                          RedIntf::namespace_path::sibling_bmc)
 {}
-
-bool SiblingImpl::isBMCPresent()
-{
-    // TODO: Actually check this.
-    // May also need to check if it has Vcs PGOOD.
-    return true;
-}
 
 // NOLINTNEXTLINE
 sdbusplus::async::task<> SiblingImpl::init()
@@ -64,7 +60,7 @@ sdbusplus::async::task<std::string> SiblingImpl::getServiceName()
 {
     using ObjectMapper =
         sdbusplus::client::xyz::openbmc_project::ObjectMapper<>;
-    std::vector<std::string> interface{RedIntf::interface};
+    std::vector<std::string> interface{AvailIntf::interface};
 
     try
     {
@@ -163,6 +159,18 @@ void SiblingImpl::loadStateProps(const SiblingImpl::PropertyMap& propertyMap)
     if (it != propertyMap.end())
     {
         bmcState.state = std::get<BMCState>(it->second);
+    }
+}
+
+void SiblingImpl::loadAvailabilityProps(
+    const SiblingImpl::PropertyMap& propertyMap)
+{
+    availability.present = true;
+
+    auto it = propertyMap.find("Available");
+    if (it != propertyMap.end())
+    {
+        availability.available = std::get<bool>(it->second);
     }
 }
 
@@ -345,6 +353,10 @@ void SiblingImpl::loadFromPropertyMap(const std::string& interface,
     else if (interface == VersionIntf::interface)
     {
         loadVersionProps(propertyMap);
+    }
+    else if (interface == AvailIntf::interface)
+    {
+        loadAvailabilityProps(propertyMap);
     }
 }
 

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -44,7 +44,8 @@ class SiblingImpl : public Sibling
      */
     bool alive() const override
     {
-        return version.present && redundancy.present && bmcState.present;
+        return version.present && redundancy.present && bmcState.present &&
+               availability.present;
     }
 
     /**
@@ -198,7 +199,10 @@ class SiblingImpl : public Sibling
      *
      * @return bool - if present
      */
-    bool isBMCPresent() override;
+    bool isBMCPresent() override
+    {
+        return availability.available;
+    }
 
     /**
      * @brief Waits for up to 10 minutes for the sibling BMC to
@@ -260,11 +264,12 @@ class SiblingImpl : public Sibling
     void loadStateProps(const PropertyMap& propertyMap);
 
     /**
-     * @brief Sets heartbeat data members with whatever is in the property map
+     * @brief Sets Availability data members with whatever is in the property
+     * map
      *
      * @param[in] propertyMap - The property name -> value map
      */
-    void loadHeartbeatProps(const PropertyMap& propertyMap);
+    void loadAvailabilityProps(const PropertyMap& propertyMap);
 
     /**
      * @brief Sets data members with whatever is in the property map
@@ -283,6 +288,7 @@ class SiblingImpl : public Sibling
         redundancy.present = false;
         bmcState.present = false;
         version.present = false;
+        availability.present = false;
     }
 
     /**
@@ -343,6 +349,17 @@ class SiblingImpl : public Sibling
      * @brief State presence and value
      */
     State bmcState;
+
+    struct Availability
+    {
+        bool present = false;
+        bool available = false;
+    };
+
+    /**
+     * @brief Availability presence and value
+     */
+    Availability availability;
 
     /**
      * @brief The D-Bus object path for the sibling.


### PR DESCRIPTION
Previously, the Sibling::isBMCPresent check was just hardcoded to return true, which of course doesn't work if the BMC may not be present.

Ideally there would be GPIOs that could be used for this, however not all of IBM's redundant BMC systems have them, and the one that will isn't far enough along to code against.

So for now, just look at the Availability interface on the state/bmc1 object path which reflects if the communication path to the sibling BMC was detected.

When more information is known about the presence GPIO, it can be checked first and then code can fall back to the availability check if the GPIO read fails due to a hardware error or if the system doesn't have a GPIO.

Add this new interface and property to the Sibling handling of the other interfaces on that object path which already watch for all the D-Bus signals to track changes, and return the value of Available in the isBMCPresent() function.

The interface will be present as soon as the sibling daemon starts up regardless of if the BMC is responding or not.

Tested:

When available, works the same as before.

When not available:
```
Local BMC
-----------------------------
Role:                 Active
BMC Position:         0
Redundancy Enabled:   false
BMC State:            Ready
Failovers Allowed:    false
Failover In Progress: false
FW Version Hash:      76A7D135
Provisioned:          true
Role Reason:          Sibling not alive
Reasons for no BMC redundancy:
    Sibling is missing

Sibling BMC
-----------------------------
Sibling data not available
```

Change-Id: I5bdfa18d8e15b261c75e9f55a605d58cc115617c