### PR TITLE
Adapt PSM services to handle new active/passive concept

### DIFF
--- a/service_files/phosphor-bmc-security-check.service
+++ b/service_files/phosphor-bmc-security-check.service
@@ -2,6 +2,8 @@
 Description=Phosphor BMC Security Check
 Wants=xyz.openbmc_project.Settings.service
 After=xyz.openbmc_project.Settings.service
+Wants=mapper-wait@-xyz-openbmc_project-logging-settings.service
+After=mapper-wait@-xyz-openbmc_project-logging-settings.service
 
 
 [Service]

--- a/service_files/phosphor-discover-system-state@.service
+++ b/service_files/phosphor-discover-system-state@.service
@@ -11,7 +11,6 @@ After=mapper-wait@-xyz-openbmc_project-state-bmc0.service
 After=phosphor-reset-chassis-on@%i.service
 Wants=xyz.openbmc_project.Settings.service
 After=xyz.openbmc_project.Settings.service
-After=multi-user.target
 ConditionPathExists=!/run/openbmc/chassis@%i-on
 
 [Service]


### PR DESCRIPTION
Two commits here. 

One that fixes a race condition found during testing with the bmc-security-check service. That fix has been sent upstream with https://gerrit.openbmc.org/c/openbmc/phosphor-state-manager/+/84292.

The second commit is a revert of a change upstream that's causing some issues with redundant BMC support. See the commit for details but basically it's not something we need on our systems so we'll just revert it downstream for now.