### PR TITLE
RBMC: Log failover requesters/timestamps

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -274,6 +274,14 @@ The failover sequence is:
    issues a full sync. Otherwise it sets `RedundancyEnabled` to false.
 1. When the full sync is complete, `FailoversAllowed` is now set to true.
 
+### Failover History
+
+The BMC driving the failover logs the requester and timestamp of each failover
+in the file `/var/lib/phosphor-state-manager/redundant-bmc/bmcN_failovers`,
+where `N` is the BMC position.
+
+The most recent 10 failovers are kept.
+
 ### Reboots in the middle of a failover
 
 If the new active BMC is rebooted in the middle of a failover while the other

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -319,8 +319,11 @@ void Manager::disableRedPropChanged(bool disable)
 
 // NOLINTNEXTLINE
 sdbusplus::async::task<> Manager::method_call(start_failover_t /* unused */,
+                                              Requester requester,
                                               const FailoverOptions& options)
 {
+    lg2::info("Failover requester is {REQUESTER}", "REQUESTER", requester);
+
     if (redundancyInterface.failover_imminent() ||
         redundancyInterface.failover_in_progress())
     {
@@ -346,7 +349,7 @@ sdbusplus::async::task<> Manager::method_call(start_failover_t /* unused */,
 
     if (redundancyInterface.role() == Role::Passive)
     {
-        ctx.spawn(doFailoverFromPassive());
+        ctx.spawn(doFailoverFromPassive(requester));
     }
     else
     {
@@ -357,9 +360,10 @@ sdbusplus::async::task<> Manager::method_call(start_failover_t /* unused */,
 }
 
 // NOLINTNEXTLINE
-sdbusplus::async::task<> Manager::doFailoverFromPassive()
+sdbusplus::async::task<> Manager::doFailoverFromPassive(Requester requester)
 {
     lg2::info("Starting failover");
+    time_t now = time(nullptr);
 
     // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
     co_await providers->getSyncInterface().disableBackgroundSync();
@@ -384,6 +388,12 @@ sdbusplus::async::task<> Manager::doFailoverFromPassive()
     // is rebooted it could handle it.
     lg2::info("Setting failover in progress");
     redundancyInterface.failover_in_progress(true);
+
+    // After the point of no return, log it
+    data::logFailover(
+        providers->getServices().getPersistentDataPath(),
+        (co_await providers->getServices().getBMCPosition()).value_or(0xFF),
+        requester, now);
 
     lg2::info("Claiming active role");
     updateRole(role_determination::RoleInfo{

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -12,6 +12,9 @@
 namespace rbmc
 {
 
+using Requester =
+    sdbusplus::common::xyz::openbmc_project::control::Failover::Requester;
+
 /**
  * @class Manager
  *
@@ -50,9 +53,11 @@ class Manager :
     /**
      * @brief Implements the StartFailover D-Bus method.
      *
+     * @param[in] requester - For logging who requested the failover
      * @param[in] options - The failover options
      */
     sdbusplus::async::task<> method_call(start_failover_t /* unused */,
+                                         Requester requester,
                                          const FailoverOptions& options);
 
   private:
@@ -109,8 +114,11 @@ class Manager :
     /**
      * @brief Drives the failover from passive to active when
      *        this BMC is the starting passive one.
+     *
+     * @param[in] requester - The failover requester passed into the
+     *                        StartFailover D-Bus method.
      */
-    sdbusplus::async::task<> doFailoverFromPassive();
+    sdbusplus::async::task<> doFailoverFromPassive(Requester requester);
 
     /**
      * @brief Clears 'failover in progress' if it is on and

--- a/redundant-bmc/src/persistent_data.cpp
+++ b/redundant-bmc/src/persistent_data.cpp
@@ -9,6 +9,9 @@
 
 namespace data
 {
+
+constexpr size_t maxFailoverLogEntries = 10;
+
 namespace util
 {
 
@@ -47,6 +50,25 @@ void writeFile(const nlohmann::json& json, const std::filesystem::path& path)
     }
 }
 
+static std::filesystem::path makeFailoverLogFilePath(
+    const std::filesystem::path& dirPath, size_t bmcPos)
+{
+    std::string filename = "bmc" + std::to_string(bmcPos) + "_failovers";
+    return dirPath / filename;
+}
+
+static std::string makeTimestampString(const time_t& timestamp)
+{
+    tm utcTime{};
+    gmtime_r(&timestamp, &utcTime);
+
+    std::string timeBuf(50, '\0');
+    auto size = strftime(timeBuf.data(), timeBuf.size(),
+                         "%Y-%m-%d %H:%M:%S UTC", &utcTime);
+    timeBuf.resize(size);
+    return timeBuf;
+}
+
 } // namespace util
 
 void remove(std::string_view name, const std::filesystem::path& path)
@@ -61,6 +83,70 @@ void remove(std::string_view name, const std::filesystem::path& path)
     {
         util::writeFile(json.value(), path);
     }
+}
+
+void logFailover(const std::filesystem::path& dirPath, size_t bmcPos,
+                 Requester requester, const time_t& timestamp)
+{
+    try
+    {
+        auto file = util::makeFailoverLogFilePath(dirPath, bmcPos);
+        auto logs = util::readFile(file);
+
+        if (!logs.has_value())
+        {
+            logs = nlohmann::json::array();
+        }
+
+        if (!logs->is_array())
+        {
+            lg2::error("failover log {FILE} isn't a JSON array", "FILE", file);
+            return;
+        }
+
+        // If at the max number of entries, drop the oldest.
+        if (logs->size() == maxFailoverLogEntries)
+        {
+            logs->erase(logs->begin());
+        }
+
+        // Just save the last segment of the enum string, e.g. 'Host'.
+        auto r = sdbusplus::common::xyz::openbmc_project::control::Failover::
+            convertRequesterToString(requester);
+        r = r.substr(r.find_last_of('.') + 1);
+
+        nlohmann::json log = {
+            {"requester", r},
+            {"timestamp", util::makeTimestampString(timestamp)}};
+        logs->push_back(std::move(log));
+        util::writeFile(logs.value(), file);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Error while logging a failover: {ERROR}", "ERROR", e);
+    }
+}
+
+FailoverLogs getFailoverLogs(const std::filesystem::path& dirPath,
+                             size_t bmcPos)
+{
+    FailoverLogs logs;
+    auto jsonLogs =
+        util::readFile(util::makeFailoverLogFilePath(dirPath, bmcPos));
+
+    if (!jsonLogs.has_value())
+    {
+        return logs;
+    }
+
+    std::ranges::transform(
+        jsonLogs.value(), std::back_inserter(logs), [](const auto& log) {
+            std::string requester = log.value("requester", "bad data");
+            std::string timestamp = log.value("timestamp", "bad data");
+            return std::pair{requester, timestamp};
+        });
+
+    return logs;
 }
 
 } // namespace data

--- a/redundant-bmc/src/persistent_data.hpp
+++ b/redundant-bmc/src/persistent_data.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <nlohmann/json.hpp>
+#include <xyz/openbmc_project/Control/Failover/common.hpp>
 
 #include <filesystem>
 #include <optional>
@@ -11,6 +12,11 @@ namespace data
 
 const std::filesystem::path dataFile{
     "/var/lib/phosphor-state-manager/redundant-bmc/data.json"};
+
+using FailoverLogs = std::vector<std::pair<std::string, std::string>>;
+
+using Requester =
+    sdbusplus::common::xyz::openbmc_project::control::Failover::Requester;
 
 namespace key
 {
@@ -121,5 +127,31 @@ std::optional<T> read(std::string_view name,
  */
 void remove(std::string_view name,
             const std::filesystem::path& path = dataFile);
+
+/**
+ * @brief Log the requester and timestamp of a failover.
+ *
+ * The BMC driving the failover uses this.  It will keep the 10 most
+ * recent entries in a file called bmc<position>_failovers.
+ *
+ * @param[in] dirPath - The directory to save the log file in.
+ * @param[in] bmcPos - The BMC position driving the failover.
+ * @param[in] requester - The failover requester, e.g. 'host'.
+ * @param[in] timestamp - The time the failover was initiated.
+ */
+void logFailover(const std::filesystem::path& dirPath, size_t bmcPos,
+                 Requester requester, const time_t& timestamp);
+
+/**
+ * @brief Returns the failover logs as a vector of pairs.
+ *
+ * pair.first is the requester, and pair.second is the UTC timestamp
+ * that looks like: "YYYY-MM-DD HH:MM:SS UTC"
+ *
+ * @param[in] dirPath - The directory to save the log file in.
+ * @param[in] bmcPos - The BMC position driving the failover.
+ */
+FailoverLogs getFailoverLogs(const std::filesystem::path& dirPath,
+                             size_t bmcPos);
 
 } // namespace data

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -94,6 +94,21 @@ void printFONotAllowedReasons()
     }
 }
 
+void printLastFailoverDetails(const std::filesystem::path& dataPath,
+                              size_t bmcPos)
+{
+    auto logs = data::getFailoverLogs(dataPath, bmcPos);
+
+    if (!logs.empty())
+    {
+        std::println("Last failover driven by this BMC:");
+
+        const auto& last = logs.back();
+        printReason(std::format("Requester: {}", last.first));
+        printReason(std::format("Timestamp: {}", last.second));
+    }
+}
+
 // NOLINTBEGIN
 sdbusplus::async::task<> displayLocalBMCInfo(sdbusplus::async::context& ctx,
                                              bool extended)
@@ -150,6 +165,12 @@ sdbusplus::async::task<> displayLocalBMCInfo(sdbusplus::async::context& ctx,
                 !props.failovers_allowed)
             {
                 printFONotAllowedReasons();
+            }
+
+            if ((role == "Active") && pos.has_value())
+            {
+                printLastFailoverDetails(services.getPersistentDataPath(),
+                                         pos.value());
             }
         }
     }
@@ -303,7 +324,7 @@ sdbusplus::async::task<> startFailover(sdbusplus::async::context& ctx,
         co_await Failover(ctx)
             .service(Redundancy::interface)
             .path(path.str)
-            .start_failover(options);
+            .start_failover(Failover::Requester::Tool, options);
     }
     catch (const sdbusplus::exception_t& e)
     {

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -3,6 +3,8 @@
 #include <sdbusplus/async.hpp>
 #include <xyz/openbmc_project/State/BMC/common.hpp>
 
+#include <filesystem>
+
 namespace rbmc
 {
 
@@ -115,6 +117,11 @@ class Services
      * @brief Flush the journal to the filesystem.
      */
     virtual sdbusplus::async::task<> flushJournal() const = 0;
+
+    /**
+     * @brief Returns the persistent data directory
+     */
+    virtual std::filesystem::path getPersistentDataPath() const = 0;
 
     /**
      * @brief Returns the string name for the system state enum

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -9,6 +9,9 @@
 namespace rbmc
 {
 
+const std::filesystem::path persistentDataPath =
+    "/var/lib/phosphor-state-manager/redundant-bmc";
+
 /**
  * @class ServicesImpl
  *
@@ -110,6 +113,14 @@ class ServicesImpl : public Services
      *        "journalctl --sync"
      */
     sdbusplus::async::task<> flushJournal() const override;
+
+    /**
+     * @brief Returns the persistent data directory
+     */
+    std::filesystem::path getPersistentDataPath() const override
+    {
+        return persistentDataPath;
+    }
 
   private:
     /**

--- a/redundant-bmc/test/persistent_data_test.cpp
+++ b/redundant-bmc/test/persistent_data_test.cpp
@@ -14,19 +14,21 @@ class PersistentDataTest : public ::testing::Test
     static void SetUpTestCase()
     {
         char d[] = "/tmp/datatestXXXXXX";
-        saveFile = mkdtemp(d);
-        saveFile /= "save.json";
+        dataDir = mkdtemp(d);
+        saveFile = dataDir / "save.json";
     }
 
     static void TearDownTestCase()
     {
-        std::filesystem::remove_all(saveFile.parent_path());
+        std::filesystem::remove_all(dataDir);
     }
 
     static std::filesystem::path saveFile;
+    static std::filesystem::path dataDir;
 };
 
 std::filesystem::path PersistentDataTest::saveFile;
+std::filesystem::path PersistentDataTest::dataDir;
 
 TEST_F(PersistentDataTest, WriteAndReadTest)
 {
@@ -121,4 +123,41 @@ TEST_F(PersistentDataTest, RemoveTest)
 
     // Not found
     data::remove("Blah");
+}
+
+TEST_F(PersistentDataTest, FailoverLogTest)
+{
+    using Requester =
+        sdbusplus::common::xyz::openbmc_project::control::Failover::Requester;
+
+    data::logFailover(dataDir, 0, Requester::Host, time(nullptr));
+
+    ASSERT_TRUE(std::filesystem::exists(dataDir / "bmc0_failovers"));
+
+    auto logs = data::getFailoverLogs(dataDir, 0);
+
+    ASSERT_EQ(logs.size(), 1);
+    EXPECT_EQ(logs.begin()->first, "Host");
+    EXPECT_TRUE(!logs.begin()->second.empty());
+
+    // log 9 more so there are now the max of 10
+    for (auto _ : std::views::iota(0, 9))
+    {
+        data::logFailover(dataDir, 0, Requester::Tool, time(nullptr));
+    }
+
+    logs = data::getFailoverLogs(dataDir, 0);
+
+    ASSERT_EQ(logs.size(), 10);
+    EXPECT_EQ(logs.begin()->first, "Host");
+    EXPECT_EQ(logs.back().first, "Tool");
+
+    // Add one more to cause oldest to be dropped
+    data::logFailover(dataDir, 0, Requester::SystemConfig, time(nullptr));
+
+    logs = data::getFailoverLogs(dataDir, 0);
+
+    ASSERT_EQ(logs.size(), 10);
+    EXPECT_EQ(logs.begin()->first, "Tool");
+    EXPECT_EQ(logs.back().first, "SystemConfig");
 }


### PR DESCRIPTION
The 'requester' parameter of the StartFailover method says who is requesting the failover.  Save that and the timestamp the failover was requested in a file so that it can be displayed by rbmctool and also captured in BMC dumps.

A new 'logFailover' function is used for this. It is called by the BMC driving the failover after the point of no return which is after the original active BMC is reset.  It writes to a JSON file that keeps the most recent 10 failovers.

The file is in the same directory the existing 'data.json' file is in, and is named bmcN_failovers, where N is the BMC position.  To get a full view of every failover in the system from a single BMC, the files would need to be synced so each BMC has the file for both positions.

The 'rbmctool -de' option will now display the requester and timestamp of the most recent failover when run on the active BMC. It doesn't do this on the passive BMC because the most recent failover saved on that BMC isn't the actual most recent one, as that would be on the current active BMC.  If the files are synced in the future, then possibly it could use the file synced over from the active BMC.

Tested:

Most recent failover is shown:
```
Local BMC
-----------------------------
Role:                 Active
BMC Position:         1
Redundancy Enabled:   true
BMC State:            Ready
Failovers Allowed:    true
Failover In Progress: false
FW Version Hash:      7D719923
Provisioned:          true
Role Reason:          Failover
Last failover driven by this BMC:
    Requester: Tool                    <----
    Timestamp: 2025-10-08 17:14:24 UTC <----

```

And the file itself:
```
$ cat /var/lib/phosphor-state-manager/redundant-bmc/bmc1_failovers
[
    {
        "requester": "Tool",
        "timestamp": "2025-10-08 16:23:54 UTC"
    },
    {
        "requester": "Tool",
        "timestamp": "2025-10-08 17:14:24 UTC"
    }
]
```

Also, new testcases pass.

Change-Id: I1fc538c0f5fcb3e14f7b1159d23f19717c350820