### PR TITLE
RBMC: Handle Avail iface on sib ifaces removed

### DIFF
--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -253,6 +253,10 @@ sdbusplus::async::task<> SiblingImpl::watchInterfaceRemoved()
         {
             bmcState.present = false;
         }
+        if (std::ranges::contains(interfaces, AvailIntf::interface))
+        {
+            availability.present = false;
+        }
 
         // If alive before and all interfaces are now gone invoke the callbacks
         if (prevAlive && !alive())


### PR DESCRIPTION
The watchInterfaceRemoved() function was missing a check for the Availability interface.  That's needed so the "if prevAlive != alive()" check works right.

Change-Id: I972fc2fa17cccfc8397d19eab16966c33d4d12c2