### PR TITLE
RBMC: Fill in ReasonsForNoRedundancy D-Bus prop

### DIFF
--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -70,18 +70,6 @@ sdbusplus::async::task<> PassiveRoleHandler::start()
 
     try
     {
-        // Only the active needs NoRedundancyDetails persisted.
-        data::remove(data::key::noRedDetails);
-    }
-    catch (const std::exception& e)
-    {
-        lg2::error(
-            "Failed while removing NoRedundancyDetails saved value: {ERROR}",
-            "ERROR", e);
-    }
-
-    try
-    {
         // This is only valid on the active BMC
         data::remove(data::key::redundancyOffAtRuntime);
     }

--- a/redundant-bmc/src/persistent_data.hpp
+++ b/redundant-bmc/src/persistent_data.hpp
@@ -23,7 +23,7 @@ namespace key
 constexpr auto role = "Role";
 constexpr auto passiveError = "PassiveDueToError";
 constexpr auto roleReason = "RoleReason";
-constexpr auto noRedDetails = "NoRedundancyDetails";
+constexpr auto noRedReasons = "NoRedundancyReasons";
 constexpr auto disableRed = "DisableRedundancy";
 constexpr auto redundancyOffAtRuntime = "RedundancyOffAtRuntime";
 constexpr auto failoversNotAllowedReasons = "FailoversNotAllowedReasons";

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -53,19 +53,17 @@ sdbusplus::async::task<std::string> getBMCState(const rbmc::Services& services)
     }
 }
 
-void printNoRedReasons()
+void printNoRedReasons(const rbmc::redundancy::ReasonsForNoRedundancy& reasons)
 {
-    using NoRedDetails =
-        std::map<rbmc::redundancy::NoRedundancyReason, std::string>;
-    auto details = data::read<NoRedDetails>(data::key::noRedDetails)
-                       .value_or(NoRedDetails{});
     std::println("Reasons for no BMC redundancy:");
-    if (!details.empty())
+    if (!reasons.empty())
     {
-        for (const auto& d : std::views::values(details))
-        {
-            printReason(d);
-        }
+        std::ranges::for_each(reasons, [](const auto& r) {
+            auto shortName =
+                Redundancy::convertReasonForNoRedundancyToString(r);
+            shortName = shortName.substr(shortName.find_last_of('.') + 1);
+            printReason(shortName);
+        });
     }
     else
     {
@@ -158,7 +156,7 @@ sdbusplus::async::task<> displayLocalBMCInfo(sdbusplus::async::context& ctx,
 
             if ((role == "Active") && !props.redundancy_enabled)
             {
-                printNoRedReasons();
+                printNoRedReasons(props.reasons_for_no_redundancy);
             }
 
             if ((role == "Active") && props.redundancy_enabled &&

--- a/redundant-bmc/src/redundancy.cpp
+++ b/redundant-bmc/src/redundancy.cpp
@@ -8,122 +8,69 @@ namespace rbmc
 namespace redundancy
 {
 
-NoRedundancyReasons getNoRedundancyReasons(const Input& input)
+ReasonsForNoRedundancy getNoRedundancyReasons(const Input& input)
 {
-    using enum NoRedundancyReason;
-    NoRedundancyReasons reasons;
+    using enum ReasonForNoRedundancy;
+    ReasonsForNoRedundancy reasons;
 
     // TODO:
-    // - Network and/or sync health
-    // - Can't enable redundancy if system wasn't booted with it enabled
+    // - Network health
 
     if (input.role != Role::Active)
     {
-        reasons.insert(bmcNotActive);
+        reasons.insert(BMCNotActive);
     }
 
     if (input.manualDisable)
     {
-        reasons.insert(manuallyDisabled);
+        reasons.insert(ManuallyDisabled);
     }
 
     if (!input.siblingPresent)
     {
-        reasons.insert(siblingMissing);
+        reasons.insert(SiblingMissing);
     }
     else
     {
         if (!input.siblingAlive)
         {
-            reasons.insert(siblingNotAlive);
+            reasons.insert(SiblingNotAlive);
         }
         else
         {
             if (!input.siblingProvisioned)
             {
-                reasons.insert(siblingNotProvisioned);
+                reasons.insert(SiblingNotProvisioned);
             }
 
             if (input.siblingRole != Role::Passive)
             {
-                reasons.insert(siblingNotPassive);
+                reasons.insert(SiblingNotPassive);
             }
 
             if (!input.codeVersionsMatch)
             {
-                reasons.insert(codeMismatch);
+                reasons.insert(CodeVersionMismatch);
             }
 
             if (input.siblingState != BMCState::Ready)
             {
-                reasons.insert(siblingNotAtReady);
+                reasons.insert(SiblingNotAtReady);
             }
 
             if (input.syncFailed)
             {
-                reasons.insert(syncFailed);
+                reasons.insert(DataSyncFailed);
             }
         }
     }
 
     if (input.redundancyOffAtRuntimeStart)
     {
-        reasons.insert(redundancyOffAtRuntimeStart);
+        reasons.insert(RedundancyOffAtRuntimeStart);
     }
 
     return reasons;
-}
-
-std::string getNoRedundancyDescription(NoRedundancyReason reason)
-{
-    using enum NoRedundancyReason;
-    using namespace std::string_literals;
-    std::string desc;
-
-    // Use a switch so that the compiler will catch missing enums.
-    switch (reason)
-    {
-        case none:
-            desc = "None"s;
-            break;
-        case bmcNotActive:
-            desc = "BMC is not active"s;
-            break;
-        case manuallyDisabled:
-            desc = "Manually disabled"s;
-            break;
-        case siblingMissing:
-            desc = "Sibling is missing"s;
-            break;
-        case siblingNotAlive:
-            desc = "Sibling not alive"s;
-            break;
-        case siblingNotProvisioned:
-            desc = "Sibling is not provisioned"s;
-            break;
-        case siblingNotPassive:
-            desc = "Sibling is not passive"s;
-            break;
-        case codeMismatch:
-            desc = "Firmware version mismatch"s;
-            break;
-        case siblingNotAtReady:
-            desc = "Sibling is not at ready state"s;
-            break;
-        case systemHardwareConfigIssue:
-            desc = "System hardware configuration issue"s;
-            break;
-        case redundancyOffAtRuntimeStart:
-            desc = "Redundancy was off upon reaching runtime"s;
-            break;
-        case syncFailed:
-            desc = "Data sync failed"s;
-            break;
-        case other:
-            desc = "Other";
-            break;
-    }
-    return desc;
 }
 
 } // namespace redundancy

--- a/redundant-bmc/src/redundancy.hpp
+++ b/redundant-bmc/src/redundancy.hpp
@@ -12,6 +12,9 @@ namespace rbmc
 using Role =
     sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy::Role;
 
+using ReasonForNoRedundancy = sdbusplus::common::xyz::openbmc_project::state::
+    bmc::Redundancy::ReasonForNoRedundancy;
+
 using BMCState = sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState;
 
 namespace redundancy
@@ -34,42 +37,14 @@ struct Input
     bool syncFailed;
 };
 
-// TODO: Move this to PDI Enums
-/**
- * @brief Reasons why redundancy can't be enabled
- */
-enum class NoRedundancyReason
-{
-    none,
-    bmcNotActive,
-    manuallyDisabled,
-    siblingMissing,
-    siblingNotAlive,
-    siblingNotProvisioned,
-    siblingNotPassive,
-    codeMismatch,
-    siblingNotAtReady,
-    systemHardwareConfigIssue,
-    redundancyOffAtRuntimeStart,
-    syncFailed,
-    other
-};
-
-using NoRedundancyReasons = std::set<NoRedundancyReason>;
+using ReasonsForNoRedundancy = std::set<ReasonForNoRedundancy>;
 
 /**
  * @brief Returns the reasons that redundancy can't be enabled.
  *
  * @return The reasons.  Empty if it can be enabled.
  */
-NoRedundancyReasons getNoRedundancyReasons(const Input& input);
-
-/**
- * @brief Return the string description of the reason
- *
- * @return The human readable description.
- */
-std::string getNoRedundancyDescription(NoRedundancyReason reason);
+ReasonsForNoRedundancy getNoRedundancyReasons(const Input& input);
 
 } // namespace redundancy
 

--- a/redundant-bmc/src/redundancy_interface.cpp
+++ b/redundant-bmc/src/redundancy_interface.cpp
@@ -44,6 +44,16 @@ RedundancyInterface::RedundancyInterface(sdbusplus::async::context& ctx,
                    "ERROR", e);
     }
 
+    // This is recalculated each time.
+    try
+    {
+        data::remove(data::key::noRedReasons);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed removing NoRedundancyReasons: {ERROR}", "ERROR", e);
+    }
+
     emit_added();
 }
 
@@ -95,6 +105,38 @@ bool RedundancyInterface::set_property(
     }
 
     failover_in_progress_ = inProgress;
+    return true;
+}
+
+bool RedundancyInterface::set_property(
+    [[maybe_unused]] reasons_for_no_redundancy_t type,
+    const std::set<ReasonForNoRedundancy>& reasons)
+{
+    if (reasons == reasons_for_no_redundancy_)
+    {
+        return false;
+    }
+
+    // Use the last segment of the string name to trace and save for debug
+    std::set<std::string> names;
+    std::ranges::for_each(reasons, [&names](const auto& reason) {
+        auto shortName = convertReasonForNoRedundancyToString(reason);
+        shortName = shortName.substr(shortName.find_last_of('.') + 1);
+        lg2::info("No redundancy because: {DESC}", "DESC", shortName);
+        names.insert(shortName);
+    });
+
+    try
+    {
+        data::write(data::key::noRedReasons, names);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed serializing NoRedundancyReasons: {ERROR}", "ERROR",
+                   e);
+    }
+
+    reasons_for_no_redundancy_ = reasons;
     return true;
 }
 

--- a/redundant-bmc/src/redundancy_interface.hpp
+++ b/redundant-bmc/src/redundancy_interface.hpp
@@ -55,6 +55,18 @@ class RedundancyInterface :
      */
     bool set_property(failover_in_progress_t type, bool inProgress);
 
+    /**
+     * @brief Implements property set for the
+     *        NoRedundancyReasons property
+     *
+     * @param[in] reasons_for_no_redundancy_t - The type
+     * @param[in] reasons - the value being set
+     *
+     * @return If the property value changed
+     */
+    bool set_property(reasons_for_no_redundancy_t type,
+                      const std::set<ReasonForNoRedundancy>& reasons);
+
   private:
     /**
      * @brief Reference to the Manager class

--- a/redundant-bmc/src/redundancy_mgr.cpp
+++ b/redundant-bmc/src/redundancy_mgr.cpp
@@ -16,15 +16,6 @@ RedundancyMgr::RedundancyMgr(sdbusplus::async::context& ctx,
 {
     try
     {
-        data::remove(data::key::noRedDetails);
-    }
-    catch (const std::exception& e)
-    {
-        lg2::error("Failed removing NoRedundancyDetails: {ERROR}", "ERROR", e);
-    }
-
-    try
-    {
         data::remove(data::key::failoversNotAllowedReasons);
     }
     catch (const std::exception& e)
@@ -99,7 +90,7 @@ void RedundancyMgr::handleBackgroundSyncFailed()
     syncFailed = false;
 }
 
-redundancy::NoRedundancyReasons RedundancyMgr::getNoRedundancyReasons()
+redundancy::ReasonsForNoRedundancy RedundancyMgr::getNoRedundancyReasons()
 {
     auto& sibling = providers.getSibling();
     auto& services = providers.getServices();
@@ -117,33 +108,11 @@ redundancy::NoRedundancyReasons RedundancyMgr::getNoRedundancyReasons()
         .redundancyOffAtRuntimeStart = isRedundancyOffAtRuntime(),
         .syncFailed = syncFailed};
 
-    auto reasons = redundancy::getNoRedundancyReasons(input);
-
-    std::map<redundancy::NoRedundancyReason, std::string> details;
-
-    std::ranges::transform(
-        reasons, std::inserter(details, details.begin()),
-        [](const auto& reason) {
-            auto desc = redundancy::getNoRedundancyDescription(reason);
-            lg2::info("No redundancy because: {DESC}", "DESC", desc);
-            return std::pair{reason, desc};
-        });
-
-    try
-    {
-        data::write(data::key::noRedDetails, details);
-    }
-    catch (const std::exception& e)
-    {
-        lg2::error("Failed serializing NoRedundancyReasons: {ERROR}", "ERROR",
-                   e);
-    }
-
-    return reasons;
+    return redundancy::getNoRedundancyReasons(input);
 }
 
 void RedundancyMgr::enableOrDisableRedundancy(
-    const redundancy::NoRedundancyReasons& disableReasons)
+    const redundancy::ReasonsForNoRedundancy& disableReasons)
 {
     auto enable = disableReasons.empty();
 
@@ -156,6 +125,7 @@ void RedundancyMgr::enableOrDisableRedundancy(
         lg2::info("Redundancy must be disabled");
     }
 
+    redundancyInterface.reasons_for_no_redundancy(disableReasons);
     redundancyInterface.redundancy_enabled(enable);
 }
 

--- a/redundant-bmc/src/redundancy_mgr.hpp
+++ b/redundant-bmc/src/redundancy_mgr.hpp
@@ -97,7 +97,7 @@ class RedundancyMgr
      *
      * @return The reasons.  If empty, then redundancy can be enabled.
      */
-    redundancy::NoRedundancyReasons getNoRedundancyReasons();
+    redundancy::ReasonsForNoRedundancy getNoRedundancyReasons();
 
     /**
      * @brief Based on if disableReasons is empty or not, disables
@@ -107,7 +107,7 @@ class RedundancyMgr
      *            disabled, if any.
      */
     void enableOrDisableRedundancy(
-        const redundancy::NoRedundancyReasons& disableReasons);
+        const redundancy::ReasonsForNoRedundancy& disableReasons);
 
     /**
      * @brief Called when the system state changes to do

--- a/redundant-bmc/test/persistent_data_test.cpp
+++ b/redundant-bmc/test/persistent_data_test.cpp
@@ -141,7 +141,7 @@ TEST_F(PersistentDataTest, FailoverLogTest)
     EXPECT_TRUE(!logs.begin()->second.empty());
 
     // log 9 more so there are now the max of 10
-    for (auto _ : std::views::iota(0, 9))
+    for ([[maybe_unused]] auto _ : std::views::iota(0, 9))
     {
         data::logFailover(dataDir, 0, Requester::Tool, time(nullptr));
     }

--- a/redundant-bmc/test/redundancy_test.cpp
+++ b/redundant-bmc/test/redundancy_test.cpp
@@ -7,7 +7,7 @@ using namespace rbmc::redundancy;
 
 TEST(RedundancyTest, NoRedundancyReasonsTest)
 {
-    using enum NoRedundancyReason;
+    using enum rbmc::ReasonForNoRedundancy;
 
     // Golden inputs - redundancy can be enabled.
     const Input golden{
@@ -35,7 +35,7 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
 
         auto reasons = getNoRedundancyReasons(input);
         ASSERT_EQ(reasons.size(), 1);
-        EXPECT_EQ(*reasons.begin(), bmcNotActive);
+        EXPECT_EQ(*reasons.begin(), BMCNotActive);
     }
 
     // No sibling
@@ -45,7 +45,7 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
 
         auto reasons = getNoRedundancyReasons(input);
         ASSERT_EQ(reasons.size(), 1);
-        EXPECT_EQ(*reasons.begin(), siblingMissing);
+        EXPECT_EQ(*reasons.begin(), SiblingMissing);
     }
 
     // Sibling not alive
@@ -55,7 +55,7 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
 
         auto reasons = getNoRedundancyReasons(input);
         ASSERT_EQ(reasons.size(), 1);
-        EXPECT_EQ(*reasons.begin(), siblingNotAlive);
+        EXPECT_EQ(*reasons.begin(), SiblingNotAlive);
     }
 
     // Sibling isn't provisioned
@@ -65,7 +65,7 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
 
         auto reasons = getNoRedundancyReasons(input);
         ASSERT_EQ(reasons.size(), 1);
-        EXPECT_EQ(*reasons.begin(), siblingNotProvisioned);
+        EXPECT_EQ(*reasons.begin(), SiblingNotProvisioned);
     }
 
     // Sibling isn't passive
@@ -75,7 +75,7 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
 
         auto reasons = getNoRedundancyReasons(input);
         ASSERT_EQ(reasons.size(), 1);
-        EXPECT_EQ(*reasons.begin(), siblingNotPassive);
+        EXPECT_EQ(*reasons.begin(), SiblingNotPassive);
     }
 
     // FW versions don't match
@@ -85,7 +85,7 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
 
         auto reasons = getNoRedundancyReasons(input);
         ASSERT_EQ(reasons.size(), 1);
-        EXPECT_EQ(*reasons.begin(), codeMismatch);
+        EXPECT_EQ(*reasons.begin(), CodeVersionMismatch);
     }
 
     // Sibling is in Quiesce state
@@ -95,7 +95,7 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
 
         auto reasons = getNoRedundancyReasons(input);
         ASSERT_EQ(reasons.size(), 1);
-        EXPECT_EQ(*reasons.begin(), siblingNotAtReady);
+        EXPECT_EQ(*reasons.begin(), SiblingNotAtReady);
     }
 
     // Redundancy is manually disabled
@@ -105,7 +105,7 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
 
         auto reasons = getNoRedundancyReasons(input);
         ASSERT_EQ(reasons.size(), 1);
-        EXPECT_EQ(*reasons.begin(), manuallyDisabled);
+        EXPECT_EQ(*reasons.begin(), ManuallyDisabled);
     }
 
     // Redundancy was off at runtime
@@ -115,7 +115,7 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
 
         auto reasons = getNoRedundancyReasons(input);
         ASSERT_EQ(reasons.size(), 1);
-        EXPECT_EQ(*reasons.begin(), redundancyOffAtRuntimeStart);
+        EXPECT_EQ(*reasons.begin(), RedundancyOffAtRuntimeStart);
     }
 
     // Sync failed
@@ -125,7 +125,7 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
 
         auto reasons = getNoRedundancyReasons(input);
         ASSERT_EQ(reasons.size(), 1);
-        EXPECT_EQ(*reasons.begin(), syncFailed);
+        EXPECT_EQ(*reasons.begin(), DataSyncFailed);
     }
 
     // Multiple fails
@@ -138,16 +138,10 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
         auto reasons = getNoRedundancyReasons(input);
 
         EXPECT_EQ(reasons.size(), 3);
-        EXPECT_TRUE(std::ranges::contains(reasons, codeMismatch));
-        EXPECT_TRUE(std::ranges::contains(reasons, siblingNotAtReady));
-        EXPECT_TRUE(std::ranges::contains(reasons, siblingNotPassive));
+        EXPECT_TRUE(std::ranges::contains(reasons, CodeVersionMismatch));
+        EXPECT_TRUE(std::ranges::contains(reasons, SiblingNotAtReady));
+        EXPECT_TRUE(std::ranges::contains(reasons, SiblingNotPassive));
     }
-}
-
-TEST(RedundancyTest, GetNoRedundancyDescTest)
-{
-    EXPECT_EQ(getNoRedundancyDescription(NoRedundancyReason::codeMismatch),
-              "Firmware version mismatch");
 }
 
 TEST(RedundancyTest, FailoversNotAllowedTest)


### PR DESCRIPTION
There is now a 'ReasonsForNoRedundancy' D-Bus property that is a set of ReasonForNoRedundancy PDI enums.  It needs to be on D-Bus so that the reasons can be displayed in Redfish.

Switch to returning those enums in the getNoRedundancyReasons() function, and set the D-Bus property with the result.

The property set itself will now handle writing the values to the data.json file.  This doesn't need to be done for technical reasons as redundancy is recalculated on each startup of the active BMC, but it will make data.json more useful for debug if it's included in dumps or error logs.

The rbmctool can now just get the reasons from D-Bus when it displays them instead of data.json.

Since the string versions of the enums are fairly readable, remove the function that was translating the old enums to a description, and just use the last segment of the enum string value in data.json and rbmctool output.

Tested:
Can see the properties on D-Bus:
```
$ busctl get-property xyz.openbmc_project.State.BMC.Redundancy \
         /xyz/openbmc_project/state/bmc0 xyz.openbmc_project.State.BMC.Redundancy ReasonsForNoRedundancy

as 2 "xyz.openbmc_project.State.BMC.Redundancy.ReasonForNoRedundancy.ManuallyDisabled"
     "xyz.openbmc_project.State.BMC.Redundancy.ReasonForNoRedundancy.SiblingNotAtReady"
```

And in rbmctool:
```
Reasons for no BMC redundancy:
    ManuallyDisabled
    SiblingNotAtReady
```

And in data.json:
```
    "NoRedundancyReasons": [
        "ManuallyDisabled",
        "SiblingNotAtReady"
    ],
```

Change-Id: I99172e1033476141a35ff1b7e4504657b320424a