### PR TITLE
Reapply "phosphor-discover-system-state: set after multi-user.target"

### DIFF
--- a/service_files/phosphor-discover-system-state@.service
+++ b/service_files/phosphor-discover-system-state@.service
@@ -11,6 +11,7 @@ After=mapper-wait@-xyz-openbmc_project-state-bmc0.service
 After=phosphor-reset-chassis-on@%i.service
 Wants=xyz.openbmc_project.Settings.service
 After=xyz.openbmc_project.Settings.service
+After=multi-user.target
 ConditionPathExists=!/run/openbmc/chassis@%i-on
 
 [Service]


### PR DESCRIPTION
This reverts commit 0a7f8f9a1a1a9f856a9777aed12577ceab92f1a1.

It turns out that if you have the only-allow-boot-when-bmc-ready feature enabled (which we do on all IBM systems), then it requires we have the APR service configured to run after multi-user.target.

Otherwise, the APR service must complete before we can get to BMC Ready and even with its 30s delay we end up not being at BMC Ready when the power on is requested, which means it immediately fails.

Will need to revisit this problem in our 1210 release to support redundant BMC machines.