### PR TITLE
remove installs on templated services and targets

### DIFF
--- a/host_condition_gpio/phosphor-host-condition-gpio@.service
+++ b/host_condition_gpio/phosphor-host-condition-gpio@.service
@@ -8,4 +8,4 @@ Type=dbus
 BusName=xyz.openbmc_project.State.HostCondition.Gpio%i
 
 [Install]
-WantedBy=multi-user.target
+# Handled by bitbake recipe

--- a/service_files/obmc-power-start@.service
+++ b/service_files/obmc-power-start@.service
@@ -17,4 +17,4 @@ ExecStart=/bin/sh -c "busctl call `mapper get-service /org/openbmc/control/power
 SyslogIdentifier=phosphor-power-start
 
 [Install]
-WantedBy=obmc-chassis-poweron@%i.target
+# Handled by bitbake recipe

--- a/service_files/obmc-power-stop@.service
+++ b/service_files/obmc-power-stop@.service
@@ -14,4 +14,4 @@ ExecStart=/bin/sh -c "busctl call `mapper get-service /org/openbmc/control/power
 SyslogIdentifier=obmc-power-stop
 
 [Install]
-WantedBy=obmc-chassis-poweroff@%i.target
+# Handled by bitbake recipe

--- a/service_files/obmc-powered-off@.service
+++ b/service_files/obmc-powered-off@.service
@@ -18,4 +18,4 @@ SyslogIdentifier=phosphor-powered-off
 
 
 [Install]
-WantedBy=obmc-chassis-poweroff@%i.target
+# Handled by bitbake recipe

--- a/service_files/phosphor-chassis-check-power-status@.service
+++ b/service_files/phosphor-chassis-check-power-status@.service
@@ -15,4 +15,4 @@ RemainAfterExit=yes
 ExecStart=/usr/bin/phosphor-chassis-check-power-status --chassis %i
 
 [Install]
-RequiredBy=obmc-chassis-poweron@%i.target
+# Handled by bitbake recipe

--- a/service_files/phosphor-clear-one-time@.service
+++ b/service_files/phosphor-clear-one-time@.service
@@ -9,4 +9,4 @@ Type=oneshot
 ExecStart=/bin/sh -c "busctl set-property `mapper get-service /xyz/openbmc_project/control/host%i/auto_reboot/one_time` /xyz/openbmc_project/control/host%i/auto_reboot/one_time xyz.openbmc_project.Control.Boot.RebootPolicy AutoReboot b true"
 
 [Install]
-WantedBy=obmc-chassis-poweroff@%i.target
+# Handled by bitbake recipe

--- a/service_files/phosphor-create-chassis-poweron-log@.service
+++ b/service_files/phosphor-create-chassis-poweron-log@.service
@@ -17,4 +17,4 @@ ExecStart=/bin/sh -c \
    xyz.openbmc_project.Logging.Entry.Level.Informational 1 CHASSIS_ID %i"
 
 [Install]
-WantedBy=obmc-chassis-poweron@%i.target
+# Handled by bitbake recipe

--- a/service_files/phosphor-discover-system-state@.service
+++ b/service_files/phosphor-discover-system-state@.service
@@ -21,4 +21,4 @@ RemainAfterExit=yes
 ExecStart=/usr/bin/phosphor-discover-system-state --host %i
 
 [Install]
-WantedBy=multi-user.target
+# Handled by bitbake recipe

--- a/service_files/phosphor-reboot-host@.service
+++ b/service_files/phosphor-reboot-host@.service
@@ -16,4 +16,4 @@ After=obmc-host-stopped@%i.target
 ExecStart=/usr/libexec/phosphor-state-manager/host-reboot %i
 
 [Install]
-WantedBy=obmc-host-reboot@%i.target
+# Handled by bitbake recipe

--- a/service_files/phosphor-reset-chassis-on@.service
+++ b/service_files/phosphor-reset-chassis-on@.service
@@ -12,4 +12,4 @@ ExecStart=/bin/systemctl start obmc-chassis-poweron@%i.target
 SyslogIdentifier=phosphor-reset-chassis-on
 
 [Install]
-WantedBy=obmc-chassis-powerreset@%i.target
+# Handled by bitbake recipe

--- a/service_files/phosphor-reset-chassis-running@.service
+++ b/service_files/phosphor-reset-chassis-running@.service
@@ -13,4 +13,4 @@ ExecStart=/bin/sh -c "if [ $(busctl get-property `mapper get-service /org/openbm
 SyslogIdentifier=phosphor-reset-chassis-running
 
 [Install]
-WantedBy=obmc-chassis-powerreset@%i.target
+# Handled by bitbake recipe

--- a/service_files/phosphor-reset-host-reboot-attempts@.service
+++ b/service_files/phosphor-reset-host-reboot-attempts@.service
@@ -10,4 +10,4 @@ Type=oneshot
 ExecStart=/bin/sh -c "busctl set-property `mapper get-service /xyz/openbmc_project/state/host%i` /xyz/openbmc_project/state/host%i xyz.openbmc_project.Control.Boot.RebootAttempts AttemptsLeft u 3"
 
 [Install]
-WantedBy=obmc-host-start@%i.target
+# Handled by bitbake recipe

--- a/service_files/phosphor-reset-host-recovery@.service
+++ b/service_files/phosphor-reset-host-recovery@.service
@@ -17,4 +17,4 @@ ExecStart=/usr/bin/phosphor-host-reset-recovery
 
 
 [Install]
-WantedBy=obmc-chassis-poweron@%i.target
+# Handled by bitbake recipe

--- a/service_files/phosphor-reset-host-running@.service
+++ b/service_files/phosphor-reset-host-running@.service
@@ -10,4 +10,4 @@ ExecStart=/bin/systemctl start obmc-host-start@%i.target
 
 
 [Install]
-WantedBy=obmc-host-reset@%i.target
+# Handled by bitbake recipe

--- a/service_files/phosphor-reset-sensor-states@.service
+++ b/service_files/phosphor-reset-sensor-states@.service
@@ -14,4 +14,4 @@ ExecStart=/bin/sh -c "busctl set-property `mapper get-service /xyz/openbmc_proje
 
 
 [Install]
-WantedBy=multi-user.target
+# Handled by bitbake recipe

--- a/service_files/phosphor-set-chassis-transition-to-off@.service
+++ b/service_files/phosphor-set-chassis-transition-to-off@.service
@@ -13,4 +13,4 @@ SyslogIdentifier=phosphor-set-chassis-transition-to-off
 ExecStart=/bin/sh -c "busctl set-property `mapper get-service /xyz/openbmc_project/state/chassis%i` /xyz/openbmc_project/state/chassis%i xyz.openbmc_project.State.Chassis CurrentPowerState s xyz.openbmc_project.State.Chassis.PowerState.TransitioningToOff"
 
 [Install]
-WantedBy=obmc-chassis-poweroff@%i.target
+# Handled by bitbake recipe

--- a/service_files/phosphor-set-chassis-transition-to-on@.service
+++ b/service_files/phosphor-set-chassis-transition-to-on@.service
@@ -14,4 +14,4 @@ SyslogIdentifier=phosphor-set-chassis-transition-to-on
 ExecStart=/bin/sh -c "busctl set-property `mapper get-service /xyz/openbmc_project/state/chassis%i` /xyz/openbmc_project/state/chassis%i xyz.openbmc_project.State.Chassis CurrentPowerState s xyz.openbmc_project.State.Chassis.PowerState.TransitioningToOn"
 
 [Install]
-WantedBy=obmc-chassis-poweron@%i.target
+# Handled by bitbake recipe

--- a/service_files/phosphor-set-host-transition-to-off@.service
+++ b/service_files/phosphor-set-host-transition-to-off@.service
@@ -13,4 +13,4 @@ RemainAfterExit=yes
 ExecStart=/bin/sh -c "busctl set-property `mapper get-service /xyz/openbmc_project/state/host%i` /xyz/openbmc_project/state/host%i xyz.openbmc_project.State.Host CurrentHostState s xyz.openbmc_project.State.Host.HostState.TransitioningToOff"
 
 [Install]
-WantedBy=obmc-host-stop@%i.target
+# Handled by bitbake recipe

--- a/service_files/phosphor-set-host-transition-to-running@.service
+++ b/service_files/phosphor-set-host-transition-to-running@.service
@@ -14,4 +14,4 @@ RemainAfterExit=yes
 ExecStart=/bin/sh -c "busctl set-property `mapper get-service /xyz/openbmc_project/state/host%i` /xyz/openbmc_project/state/host%i xyz.openbmc_project.State.Host CurrentHostState s xyz.openbmc_project.State.Host.HostState.TransitioningToRunning"
 
 [Install]
-WantedBy=obmc-host-startmin@%i.target
+# Handled by bitbake recipe

--- a/service_files/xyz.openbmc_project.State.Chassis@.service
+++ b/service_files/xyz.openbmc_project.State.Chassis@.service
@@ -11,4 +11,4 @@ Type=dbus
 BusName=xyz.openbmc_project.State.Chassis%i
 
 [Install]
-WantedBy=multi-user.target
+# Handled by bitbake recipe

--- a/service_files/xyz.openbmc_project.State.Host@.service
+++ b/service_files/xyz.openbmc_project.State.Host@.service
@@ -19,4 +19,4 @@ Type=dbus
 BusName=xyz.openbmc_project.State.Host%i
 
 [Install]
-WantedBy=multi-user.target
+# Handled by bitbake recipe

--- a/service_files/xyz.openbmc_project.State.ScheduledHostTransition@.service
+++ b/service_files/xyz.openbmc_project.State.ScheduledHostTransition@.service
@@ -10,4 +10,4 @@ Type=dbus
 BusName=xyz.openbmc_project.State.ScheduledHostTransition%i
 
 [Install]
-WantedBy=multi-user.target
+# Handled by bitbake recipe

--- a/target_files/obmc-chassis-powerreset@.target
+++ b/target_files/obmc-chassis-powerreset@.target
@@ -3,4 +3,4 @@ Description=Chassis%i (Reset Check)
 Conflicts=obmc-chassis-poweroff@%i.target
 
 [Install]
-WantedBy=multi-user.target
+# Handled by bitbake recipe

--- a/target_files/obmc-host-reset@.target
+++ b/target_files/obmc-host-reset@.target
@@ -3,4 +3,4 @@ Description=Host%i (Reset Check)
 Conflicts=obmc-host-stop@%i.target
 
 [Install]
-WantedBy=multi-user.target
+# Handled by bitbake recipe


### PR DESCRIPTION
New yocto is getting more stringent on installation of templated service and targets.

Templated services are installed by bitbake recipes so there's no need to have the WantedBy/RequiredBy in those services.

Here's a summary of the error we get for packages which have templated services doing an install:
```
ERROR: obmc-phosphor-image-1.0-r0 do_rootfs: Postinstall scriptlets of
['<package>' 'inst returned 1, marking as unpacked only, configuration
required on target']
If the intention is to defer them to first boot,
then please place them into pkg_postinst_ontarget:${PN} ().
Deferring to first boot via 'exit 1' is no longer supported.
```

Tested:
- Confirmed image builds with new yocto and services are still installed as expected

Change-Id: I56d9ac7a73dfd6bdaa05eba39d890a8af3605d18