### PR TITLE
RBMC: Check if the passive BMC has a reason for no redundancy

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -89,6 +89,7 @@ items to see if redundancy can be enabled:
 1. The sibling BMC is present and is alive (has a heartbeat).
 1. The sibling is at the Ready state.
 1. The sibling BMC has the Passive role.
+1. If the sibling BMC indicates that it can never be active.
 1. Redundancy hasn't been manually disabled with the D-bus property that does
    so.
 1. The sibling BMC has been provisioned.

--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "active_role_handler.hpp"
 
+#include "persistent_data.hpp"
+
 #include <phosphor-logging/lg2.hpp>
 
 namespace rbmc
@@ -14,6 +16,16 @@ sdbusplus::async::task<> ActiveRoleHandler::start()
 {
     auto& services = providers.getServices();
     auto& sibling = providers.getSibling();
+
+    try
+    {
+        data::write(data::key::passiveError, false);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed clearing the PassiveDueToError field: {ERROR}",
+                   "ERROR", e);
+    }
 
     try
     {

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -296,7 +296,7 @@ void Manager::updateRole(const role_determination::RoleInfo& roleInfo)
     catch (const std::exception& e)
     {
         lg2::error(
-            "Failed serializing the role error value of {VALUE}: {ERROR}",
+            "Failed serializing the PassiveDueToError value of {VALUE}: {ERROR}",
             "VALUE", chosePassiveDueToError, "ERROR", e);
     }
 

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -6,6 +6,7 @@
 #include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
 #include <xyz/openbmc_project/Control/Failover/common.hpp>
+#include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
 
 namespace rbmc
 {
@@ -13,6 +14,8 @@ namespace rbmc
 constexpr auto bmcPassiveTarget = "obmc-bmc-passive.target";
 
 using Failover = sdbusplus::common::xyz::openbmc_project::control::Failover;
+using Redundancy =
+    sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy;
 
 namespace util
 {
@@ -45,6 +48,36 @@ std::optional<T> getFailoverOption(Failover::Options option,
 }
 
 } // namespace util
+
+PassiveRoleHandler::PassiveRoleHandler(sdbusplus::async::context& ctx,
+                                       Providers& providers,
+                                       RedundancyInterface& iface) :
+    RoleHandler(ctx, providers, iface)
+{
+    try
+    {
+        // If passiveDueToError is true, then this BMC can never
+        // be active.  Add a value into ReasonsForNoRedundancy so
+        // the active can get it and not enable redundancy.
+        if (data::read<bool>(data::key::passiveError).value_or(false))
+        {
+            lg2::info(
+                "Setting 'SiblingCannotBeActive' in ReasonsForNoRedundancy property");
+            iface.reasons_for_no_redundancy(
+                {Redundancy::ReasonForNoRedundancy::SiblingCannotBeActive});
+        }
+        else
+        {
+            iface.reasons_for_no_redundancy({});
+        }
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed trying to obtain PassiveDueToError: {ERROR}",
+                   "ERROR", e);
+        iface.reasons_for_no_redundancy({});
+    }
+}
 
 // NOLINTNEXTLINE
 sdbusplus::async::task<> PassiveRoleHandler::start()

--- a/redundant-bmc/src/passive_role_handler.hpp
+++ b/redundant-bmc/src/passive_role_handler.hpp
@@ -28,9 +28,7 @@ class PassiveRoleHandler : public RoleHandler
      * @param[in] iface - The redundancy D-Bus interface object
      */
     PassiveRoleHandler(sdbusplus::async::context& ctx, Providers& providers,
-                       RedundancyInterface& iface) :
-        RoleHandler(ctx, providers, iface)
-    {}
+                       RedundancyInterface& iface);
 
     /**
      * @brief Destructor

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -207,6 +207,11 @@ sdbusplus::async::task<> getLocalBMCInfo(sdbusplus::async::context& ctx,
         {
             addNoRedReasons(props.reasons_for_no_redundancy, output);
         }
+        else if (role == "Passive")
+        {
+            output["Cannot Be Active"] =
+                !props.reasons_for_no_redundancy.empty();
+        }
 
         if ((role == "Active") && props.redundancy_enabled &&
             !props.failovers_allowed)

--- a/redundant-bmc/src/redundancy.cpp
+++ b/redundant-bmc/src/redundancy.cpp
@@ -48,6 +48,11 @@ ReasonsForNoRedundancy getNoRedundancyReasons(const Input& input)
                 reasons.insert(SiblingNotPassive);
             }
 
+            if (input.siblingCannotBeActive)
+            {
+                reasons.insert(SiblingCannotBeActive);
+            }
+
             if (!input.codeVersionsMatch)
             {
                 reasons.insert(CodeVersionMismatch);

--- a/redundant-bmc/src/redundancy.hpp
+++ b/redundant-bmc/src/redundancy.hpp
@@ -30,6 +30,7 @@ struct Input
     bool siblingAlive;
     bool siblingProvisioned;
     Role siblingRole;
+    bool siblingCannotBeActive;
     BMCState siblingState;
     bool codeVersionsMatch;
     bool manualDisable;

--- a/redundant-bmc/src/redundancy_mgr.cpp
+++ b/redundant-bmc/src/redundancy_mgr.cpp
@@ -101,6 +101,8 @@ redundancy::ReasonsForNoRedundancy RedundancyMgr::getNoRedundancyReasons()
         .siblingAlive = sibling.alive(),
         .siblingProvisioned = sibling.getProvisioned().value_or(false),
         .siblingRole = sibling.getRole().value_or(Role::Unknown),
+        .siblingCannotBeActive =
+            sibling.getHasReasonForNoRedundancy().value_or(false),
         .siblingState = sibling.getBMCState().value_or(BMCState::NotReady),
         .codeVersionsMatch =
             services.getFWVersion() == sibling.getFWVersion().value_or(""),

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -26,6 +26,8 @@ class Sibling
         sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy::Role;
     using BMCState =
         sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState;
+    using ReasonForNoRedundancy = sdbusplus::common::xyz::openbmc_project::
+        state::bmc::Redundancy::ReasonForNoRedundancy;
     using RedundancyEnabledCallback = std::function<void(bool)>;
     using BMCStateCallback = std::function<void(BMCState)>;
     using HealthCallback = std::function<void(bool)>;
@@ -133,6 +135,13 @@ class Sibling
      * @return - If imminent, or nullopt if not available
      */
     virtual std::optional<bool> getFailoverImminent() const = 0;
+
+    /**
+     * @brief Returns if the sibling a reason redundancy can't be enabled
+     *
+     * @return - If there is a reason, or nullopt if not available
+     */
+    virtual std::optional<bool> getHasReasonForNoRedundancy() const = 0;
 
     /**
      * @brief Returns if the sibling BMC is plugged in

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -138,6 +138,14 @@ void SiblingImpl::loadRedundancyProps(
     {
         redundancy.role = std::get<Role>(it->second);
     }
+
+    it = propertyMap.find("ReasonsForNoRedundancy");
+    if (it != propertyMap.end())
+    {
+        const auto& reasons =
+            std::get<std::set<ReasonForNoRedundancy>>(it->second);
+        redundancy.hasReasonForNoRedundancy = !reasons.empty();
+    }
 }
 
 void SiblingImpl::loadVersionProps(const SiblingImpl::PropertyMap& propertyMap)

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -2,6 +2,8 @@
 #pragma once
 #include "sibling.hpp"
 
+#include <set>
+
 namespace rbmc
 {
 
@@ -16,7 +18,8 @@ class SiblingImpl : public Sibling
 {
   public:
     using PropertyVariant =
-        std::variant<std::string, bool, Role, size_t, BMCState>;
+        std::variant<std::string, bool, Role, size_t, BMCState,
+                     std::set<ReasonForNoRedundancy>>;
     using PropertyMap = std::unordered_map<std::string, PropertyVariant>;
     using InterfaceMap = std::map<std::string, PropertyMap>;
     using ManagedObjects =
@@ -195,6 +198,21 @@ class SiblingImpl : public Sibling
     }
 
     /**
+     * @brief Returns if the sibling a reason redundancy can't be enabled
+     *
+     * @return - If there is a reason, or nullopt if not available
+     */
+    std::optional<bool> getHasReasonForNoRedundancy() const override
+    {
+        if (alive())
+        {
+            return redundancy.hasReasonForNoRedundancy;
+        }
+
+        return std::nullopt;
+    }
+
+    /**
      * @brief Returns if the sibling BMC is plugged in
      *
      * @return bool - if present
@@ -332,6 +350,7 @@ class SiblingImpl : public Sibling
         bool failoversAllowed = false;
         bool failoverInProgress = false;
         bool failoverImminent = false;
+        bool hasReasonForNoRedundancy = false;
     };
 
     /**

--- a/redundant-bmc/test/redundancy_test.cpp
+++ b/redundant-bmc/test/redundancy_test.cpp
@@ -16,6 +16,7 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
         .siblingAlive = true,
         .siblingProvisioned = true,
         .siblingRole = rbmc::Role::Passive,
+        .siblingCannotBeActive = false,
         .siblingState = rbmc::BMCState::Ready,
         .codeVersionsMatch = true,
         .manualDisable = false,
@@ -96,6 +97,16 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
         auto reasons = getNoRedundancyReasons(input);
         ASSERT_EQ(reasons.size(), 1);
         EXPECT_EQ(*reasons.begin(), SiblingNotAtReady);
+    }
+
+    // Sibling cannot be active
+    {
+        auto input = golden;
+        input.siblingCannotBeActive = true;
+
+        auto reasons = getNoRedundancyReasons(input);
+        ASSERT_EQ(reasons.size(), 1);
+        EXPECT_EQ(*reasons.begin(), SiblingCannotBeActive);
     }
 
     // Redundancy is manually disabled


### PR DESCRIPTION
In some cases, the passive BMC cannot ever be active. For example, if it couldn't read system VPD.  Instead of having a new bit in the CFAM for every possible reason that that active has to check for, this commit makes use of a new summary bit that says the passive BMC can never be active.  

Include that check when enabling redundancy.