### PR TITLE
RBMC: Check D-Bus service name for sib service

### DIFF
--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -249,17 +249,11 @@ sdbusplus::async::task<std::optional<role_determination::RoleInfo>>
                            RoleReason::systemInventoryNotAvailable};
     }
 
-    // The sibling service must be up and running.
-    if (!providers->getSibling().alive())
+    // If the sibling service isn't on D-Bus, the BMC can't be active.
+    if (providers->getSibling().getServiceName().empty())
     {
-        auto state =
-            co_await providers->getServices().getUnitState(Sibling::unitName);
-        if ((state != "active") && (state != "activating"))
-        {
-            lg2::info("Sibling service state is {STATE}", "STATE", state);
-            co_return RoleInfo{Role::Passive,
-                               RoleReason::siblingServiceNotRunning};
-        }
+        lg2::error("Sibling service is not running");
+        co_return RoleInfo{Role::Passive, RoleReason::siblingServiceNotRunning};
     }
 
     co_return std::nullopt;

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -157,6 +157,13 @@ class Sibling
     virtual sdbusplus::async::task<> pauseForHeartbeatChange() const = 0;
 
     /**
+     * @brief Returns the D-Bus service name for the sibling service.
+     *
+     * Returns an empty string if it isn't on D-Bus.
+     */
+    virtual const std::string& getServiceName() const = 0;
+
+    /**
      * @brief Clears callbacks held based on role
      *
      * @param[in] role - The role to clear

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -41,7 +41,7 @@ sdbusplus::async::task<> SiblingImpl::init()
 
     // Attempt to get the D-Bus service name.  It would only
     // be there if the sibling BMC is present.
-    serviceName = co_await getServiceName();
+    serviceName = co_await lookupServiceName();
 
     if (!serviceName.empty())
     {
@@ -55,8 +55,7 @@ sdbusplus::async::task<> SiblingImpl::init()
     initialized = true;
 }
 
-// NOLINTNEXTLINE
-sdbusplus::async::task<std::string> SiblingImpl::getServiceName()
+sdbusplus::async::task<std::string> SiblingImpl::lookupServiceName() const
 {
     using ObjectMapper =
         sdbusplus::client::xyz::openbmc_project::ObjectMapper<>;
@@ -211,7 +210,7 @@ sdbusplus::async::task<> SiblingImpl::watchInterfaceAdded()
             {
                 using namespace std::chrono_literals;
                 co_await sdbusplus::async::sleep_for(ctx, 100ms);
-                serviceName = co_await getServiceName();
+                serviceName = co_await lookupServiceName();
                 lg2::info("After interfacesAdded, sibling service is {SERVICE}",
                           "SERVICE", serviceName);
             } while (serviceName.empty() && (count++ < mapperRetries));

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -234,6 +234,16 @@ class SiblingImpl : public Sibling
      */
     sdbusplus::async::task<> pauseForHeartbeatChange() const override;
 
+    /**
+     * @brief Returns the D-Bus service name for the sibling service.
+     *
+     * Returns an empty string if it isn't on D-Bus.
+     */
+    const std::string& getServiceName() const override
+    {
+        return serviceName;
+    }
+
   private:
     /**
      * @brief Starts a Sibling InterfacesAdded watch
@@ -310,11 +320,11 @@ class SiblingImpl : public Sibling
     }
 
     /**
-     * @brief Gets the sibling D-Bus service name from the mapper
+     * @brief Looks up the sibling D-Bus service name from the mapper
      *
-     * @return std::string - The service name
+     * @return std::string - The service name or empty string if not found.
      */
-    sdbusplus::async::task<std::string> getServiceName();
+    sdbusplus::async::task<std::string> lookupServiceName() const;
 
     /**
      * @brief The async context object


### PR DESCRIPTION
For a BMC to be active, the sibling BMC application must be up and running so that it can get info about the sibling BMC.

Simplify the check to see if the sibling service is running by checking if it is providing the State.Decorator.Availability interface on the '/xyz/openbmc_project/state/bmc1' path, which will be present by the time it requests its bus name.  Only after that is done would systemd start the RBMC daemon via the service file dependency.

The previous method didn't always work in some of the error cases when the sibling service was in the middle of crashing and  restarting, which could lead to two active BMCs.

Tested:

When the sibling service is dead the Passive role is properly chosen:

```
Local BMC
-----------------------------
Role:                 Passive
BMC Position:         0
Redundancy Enabled:   false
BMC State:            Ready
Failovers Allowed:    false
Failover In Progress: false
FW Version Hash:      C5EABAEA
Provisioned:          true
Role Reason:          Sibling BMC service is not running
Cannot Be Active:     true

Sibling BMC
-----------------------------
Sibling BMC data not available
```

Change-Id: I193e42c8a5122827c8060edddd787536b307d534