### PR TITLE
RBMC: Explicitly acquire hardware access

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -265,7 +265,7 @@ The failover sequence is:
 1. The passive BMC toggles the reset on the sibling BMC to reboot it.
 1. The passive BMC now switches its role to Active.
 1. The new active BMC sets `FailoversAllowed` to false.
-1. The new active BMC takes over the hardware access bus. (TODO in code still)
+1. The new active BMC takes over the hardware access bus.
 1. The new active BMC starts obmc-bmc-active.target. This starts all of the
    active only services. It will not proceed until all active services have been
    started which may take some time.

--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -29,6 +29,16 @@ sdbusplus::async::task<> ActiveRoleHandler::start()
 
     try
     {
+        lg2::info("Acquiring hardware access");
+        co_await services.acquireFullHardwareAccess();
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed acquiring hardware access: {ERROR}", "ERROR", e);
+    }
+
+    try
+    {
         // NOLINTNEXTLINE
         co_await services.startUnit(bmcActiveTarget);
     }
@@ -179,6 +189,17 @@ auto ActiveRoleHandler::getFailoverBlockedReason(
 // NOLINTNEXTLINE
 sdbusplus::async::task<> ActiveRoleHandler::failoverStartActiveTarget()
 {
+    try
+    {
+        lg2::info("Acquiring hardware access");
+        co_await providers.getServices().acquireFullHardwareAccess();
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed acquiring hardware access during failover: {ERROR}",
+                   "ERROR", e);
+    }
+
     try
     {
         co_await providers.getServices().startUnit(bmcActiveTarget);

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -405,9 +405,6 @@ sdbusplus::async::task<> Manager::doFailoverFromPassive(Requester requester)
 
     active->clearFailoversAllowedDuringFailover();
 
-    // TODO: Grab local bus.  Not needed if it would be linked
-    // into the active target instead.
-
     co_await active->failoverStartActiveTarget();
 
     co_await active->failoverWaitForSibling();

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -177,6 +177,12 @@ class Services
      */
     virtual sdbusplus::async::task<bool> checkSystemInventoryStatus() = 0;
 
+    /**
+     * @brief Acquires hardware access to the rest of the
+     * system from this BMC if the hardware requires it.
+     */
+    virtual sdbusplus::async::task<> acquireFullHardwareAccess() = 0;
+
   protected:
     /**
      * @brief The functions to call when the system state changes

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -5,6 +5,7 @@
 
 #include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Common/Progress/client.hpp>
+#include <xyz/openbmc_project/Control/SideBandBus/client.hpp>
 #include <xyz/openbmc_project/Inventory/Decorator/Position/client.hpp>
 #include <xyz/openbmc_project/Inventory/Item/System/common.hpp>
 #include <xyz/openbmc_project/ObjectMapper/client.hpp>
@@ -26,6 +27,8 @@ using Position =
 using SystemInv =
     sdbusplus::common::xyz::openbmc_project::inventory::item::System;
 using InvProgress = sdbusplus::client::xyz::openbmc_project::common::Progress<>;
+using SidebandBus =
+    sdbusplus::client::xyz::openbmc_project::control::SideBandBus<>;
 
 using HostProperties =
     std::variant<std::string, HostState::HostState, HostState::RestartCause,
@@ -725,6 +728,21 @@ sdbusplus::async::task<bool> ServicesImpl::checkSystemInventoryStatus()
 
     lg2::error("Timed out waiting for system inventory status");
     co_return false;
+}
+
+sdbusplus::async::task<> ServicesImpl::acquireFullHardwareAccess()
+{
+    using Options = std::map<std::string, std::variant<bool>>;
+    Options options;
+
+    options.emplace(SidebandBus::convertAcquireOptionsToString(
+                        SidebandBus::AcquireOptions::Force),
+                    true);
+
+    co_await SidebandBus(ctx)
+        .service(SidebandBus::interface)
+        .path(SidebandBus::instance_path)
+        .acquire(options);
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -135,6 +135,12 @@ class ServicesImpl : public Services
      */
     sdbusplus::async::task<bool> checkSystemInventoryStatus() override;
 
+    /**
+     * @brief Acquires hardware access to the rest of the
+     * system from this BMC if the hardware requires it.
+     */
+    sdbusplus::async::task<> acquireFullHardwareAccess() override;
+
   private:
     /**
      * @brief Returns the D-Bus object path for the unit in the


### PR DESCRIPTION
Call the 'Acquire' method on the interface
'xyz.openbmc_project.Control.SideBandBus' right before starting the active target, both on startup and a failover, to ensure only this BMC has access to the hardware buses in the system and not the passive BMC.

After this point, assuming the system implements it, the passive BMC will not have access to those buses.

The 'force' argument is set to true to ensure the acquire won't be rejected if the other BMC already has it.

The daemon that implements that function will handle error logging if anything fails internally.

Tested:
The calls succeed on both startup and failovers and everything still works.

The architecture specific registers that show ownership reflect the calls.

Change-Id: I98589767a9504eee6c44404220e4f7f39d33f669