### PR TITLE
RBMC: Add retries to lookup sibling service

### DIFF
--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -8,6 +8,7 @@
 #include <xyz/openbmc_project/State/BMC/common.hpp>
 #include <xyz/openbmc_project/State/Decorator/Availability/client.hpp>
 
+#include <chrono>
 #include <ranges>
 
 namespace rbmc
@@ -39,8 +40,6 @@ sdbusplus::async::task<> SiblingImpl::init()
     ctx.spawn(watchInterfaceRemoved());
     ctx.spawn(watchPropertyChanged());
 
-    // Attempt to get the D-Bus service name.  It would only
-    // be there if the sibling BMC is present.
     serviceName = co_await lookupServiceName();
 
     if (!serviceName.empty())
@@ -59,19 +58,44 @@ sdbusplus::async::task<std::string> SiblingImpl::lookupServiceName() const
 {
     using ObjectMapper =
         sdbusplus::client::xyz::openbmc_project::ObjectMapper<>;
+
     std::vector<std::string> interface{AvailIntf::interface};
+    const std::chrono::milliseconds delay{100};
+    const size_t retries = 100; // 10 seconds total
+    size_t count = 0;
+    bool traced = false;
 
-    try
+    do
     {
-        auto object = co_await ObjectMapper(ctx)
-                          .service(ObjectMapper::default_service)
-                          .path(ObjectMapper::instance_path)
-                          .get_object(objectPath, interface);
+        try
+        {
+            auto object = co_await ObjectMapper(ctx)
+                              .service(ObjectMapper::default_service)
+                              .path(ObjectMapper::instance_path)
+                              .get_object(objectPath, interface);
 
-        co_return object.begin()->first;
-    }
-    catch (const sdbusplus::exception_t&)
-    {}
+            if (object.size() != 1)
+            {
+                lg2::warning(
+                    "Unexpected number of services found for {PATH} = {NUM_SERVICES}",
+                    "PATH", objectPath, "NUM_SERVICES", object.size());
+            }
+
+            co_return object.begin()->first;
+        }
+        catch (const sdbusplus::exception_t&)
+        {}
+
+        if (!traced)
+        {
+            traced = true;
+            lg2::warning("Sibling service not in mapper, will retry for 10s");
+        }
+        co_await sdbusplus::async::sleep_for(ctx, delay);
+
+    } while (++count < retries);
+
+    lg2::warning("Could not find sibling service name in mapper");
 
     co_return std::string{};
 }
@@ -203,17 +227,10 @@ sdbusplus::async::task<> SiblingImpl::watchInterfaceAdded()
         // the mapper and then start the nameOwnerChanged watch.
         if (serviceName.empty())
         {
-            const size_t mapperRetries = 200;
-            size_t count = 0;
+            serviceName = co_await lookupServiceName();
 
-            do
-            {
-                using namespace std::chrono_literals;
-                co_await sdbusplus::async::sleep_for(ctx, 100ms);
-                serviceName = co_await lookupServiceName();
-                lg2::info("After interfacesAdded, sibling service is {SERVICE}",
-                          "SERVICE", serviceName);
-            } while (serviceName.empty() && (count++ < mapperRetries));
+            lg2::info("After interfacesAdded, sibling service is {SERVICE}",
+                      "SERVICE", serviceName);
 
             if (!serviceName.empty())
             {

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -322,6 +322,8 @@ class SiblingImpl : public Sibling
     /**
      * @brief Looks up the sibling D-Bus service name from the mapper
      *
+     * Will do retries for up to 10 seconds.
+     *
      * @return std::string - The service name or empty string if not found.
      */
     sdbusplus::async::task<std::string> lookupServiceName() const;


### PR DESCRIPTION
There is a small race condition between the mapper consuming the name of the sibling D-Bus service and this code looking for it that showed up once on real hardware that caused the RBMC manager to think the sibling service was dead.

While there is a service dependency so that the sibling service starts first, a mapper-wait dependency can't be used since this service needs to start regardless of if the sibling one does or not.

Add a 10 second wait when looking up the service name to fix this.

Tested:
When service is down:

```
Feb 05 07:48:49 phosphor-rbmc-state-manager[19168]: Sibling service not in mapper, will retry for 10s
Feb 05 07:48:59 phosphor-rbmc-state-manager[19168]: Could not find sibling service name in mapper
```

Change-Id: I576fe9cf9845d86fc3b61db06b8abb490448f854