### PR TITLE
Don't let passive BMC sync in progress block a failover

### DIFF
--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -87,10 +87,10 @@ void ActiveRoleHandler::siblingHealthChange(bool alive)
     }
     else
     {
-        lg2::info("Sibling BMC health changed to bad");
+        lg2::warning("Sibling BMC health changed to bad");
         if (redundancyInterface.redundancy_enabled())
         {
-            lg2::info(
+            lg2::warning(
                 "Disabling redundancy in {TIME} minutes if sibling doesn't come back",
                 "TIME", siblingHealthTimeout.count());
             siblingHealthTimer.start(siblingHealthTimeout);
@@ -146,7 +146,7 @@ sdbusplus::async::task<> ActiveRoleHandler::syncHealthCritical()
 {
     using namespace std::chrono_literals;
 
-    lg2::info("Disabling background sync because it is failing");
+    lg2::warning("Disabling background sync because it is failing");
     co_await providers.getSyncInterface().disableBackgroundSync();
 
     // A passive BMC reboot should not result in redundancy being
@@ -168,7 +168,7 @@ sdbusplus::async::task<> ActiveRoleHandler::syncHealthCritical()
     }
     else
     {
-        lg2::info(
+        lg2::warning(
             "Sync health is critical, but there is also a sibling heartbeat loss");
     }
 
@@ -252,7 +252,7 @@ void ActiveRoleHandler::siblingFailoverImminent(bool imminent)
 {
     if (imminent)
     {
-        lg2::info("A failover is imminent");
+        lg2::warning("A failover is imminent");
 
         ctx.spawn(providers.getSyncInterface().disableBackgroundSync());
         ctx.spawn(providers.getServices().flushJournal());

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -39,7 +39,7 @@ Manager::Manager(sdbusplus::async::context& ctx,
             data::read<bool>(data::key::passiveError).value_or(false);
         if (chosePassiveDueToError)
         {
-            lg2::info("Was previously passive due to error");
+            lg2::warning("BMC was previously passive due to error");
         }
     }
     catch (const std::exception& e)
@@ -300,8 +300,8 @@ void Manager::updateRole(const role_determination::RoleInfo& roleInfo)
     }
     catch (const std::exception& e)
     {
-        lg2::info("Could not serialize RoleReason value of {REASON}: {ERROR}",
-                  "REASON", reasonDesc, "ERROR", e);
+        lg2::error("Could not serialize RoleReason value of {REASON}: {ERROR}",
+                   "REASON", reasonDesc, "ERROR", e);
     }
 }
 
@@ -355,7 +355,7 @@ sdbusplus::async::task<> Manager::method_call(start_failover_t /* unused */,
     else
     {
         // Shouldn't get here, would have failed in getFailoverBlockedReason
-        lg2::info("StartFailover on active BMC not supported yet");
+        lg2::error("StartFailover on active BMC not supported yet");
         throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
     }
 }

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -256,7 +256,7 @@ void PassiveRoleHandler::syncHealthPropertyChanged(
 // NOLINTNEXTLINE
 sdbusplus::async::task<> PassiveRoleHandler::syncHealthCritical()
 {
-    lg2::info("Disabling sync because it is failing");
+    lg2::warning("Disabling sync because it is failing");
     co_await stopSync();
 
     // Redundancy doesn't need to be disabled if a background sync fails on a
@@ -274,7 +274,7 @@ sdbusplus::async::task<> PassiveRoleHandler::syncHealthCritical()
     }
     else
     {
-        lg2::info(
+        lg2::warning(
             "Sync health is critical, but there is also a sibling heartbeat loss");
     }
 }

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -321,7 +321,6 @@ auto PassiveRoleHandler::getFailoverBlockedReason(
         .siblingAlive = sibling.alive(),
         .siblingState = sibling.getBMCState().value_or(BMCState::NotReady),
         .redundancyEnabled = sibling.getRedundancyEnabled().value_or(false),
-        .syncInProgress = providers.getSyncInterface().isFullSyncInProgress(),
         .state = bmcState,
         .failoversNotAllowed = !redundancyInterface.failovers_allowed(),
         .forceOption = force,

--- a/redundant-bmc/src/redundancy.cpp
+++ b/redundant-bmc/src/redundancy.cpp
@@ -176,11 +176,6 @@ Reason getFailoverBlockedReason(const Input& input)
                 return Reason::failoversNotAllowed;
             }
         }
-        else if (input.syncInProgress)
-        {
-            // The passive BMC is in the middle of its full sync
-            return Reason::fullSyncInProgress;
-        }
     }
     else
     {
@@ -227,9 +222,6 @@ std::string getFailoverBlockedDescription(Reason reason)
             break;
         case Reason::redundancyNotEnabled:
             desc = "Redundancy is not enabled"s;
-            break;
-        case Reason::fullSyncInProgress:
-            desc = "Full sync is in progress"s;
             break;
         case Reason::failoversNotAllowed:
             desc = "Failovers are not allowed"s;

--- a/redundant-bmc/src/redundancy.hpp
+++ b/redundant-bmc/src/redundancy.hpp
@@ -105,7 +105,6 @@ struct Input
     bool siblingAlive;
     BMCState siblingState;
     bool redundancyEnabled;
-    bool syncInProgress;
     BMCState state;
     bool failoversNotAllowed;
     bool forceOption;
@@ -119,7 +118,6 @@ enum class Reason
 {
     none,
     redundancyNotEnabled,
-    fullSyncInProgress,
     failoversNotAllowed,
     siblingDeadButRedundancyNotEnabled,
     notAtReady,

--- a/redundant-bmc/src/redundancy_mgr.cpp
+++ b/redundant-bmc/src/redundancy_mgr.cpp
@@ -124,7 +124,7 @@ void RedundancyMgr::enableOrDisableRedundancy(
     }
     else
     {
-        lg2::info("Redundancy must be disabled");
+        lg2::warning("Redundancy must be disabled");
     }
 
     redundancyInterface.reasons_for_no_redundancy(disableReasons);
@@ -157,7 +157,7 @@ void RedundancyMgr::disableRedPropChanged(bool disable)
     if (!redundancyDetermined)
     {
         // Must be before we've handled redundancy, it should happen soon
-        lg2::info(
+        lg2::warning(
             "Redundancy has not been determined yet, will not change redundancy now.");
         return;
     }
@@ -275,7 +275,8 @@ void RedundancyMgr::determineAndSetFailoversAllowed()
         notAllowedReasons, std::inserter(descs, descs.begin()),
         [](const auto& reason) {
             auto desc = fona::getFailoversNotAllowedDescription(reason);
-            lg2::info("Failovers not allowed because {REASON}", "REASON", desc);
+            lg2::warning("Failovers not allowed because {REASON}", "REASON",
+                         desc);
             return desc;
         });
 

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -30,7 +30,7 @@ sdbusplus::async::task<> SiblingImpl::init()
 {
     if (initialized)
     {
-        lg2::info("Sibling::init called more than once");
+        lg2::warning("Sibling::init called more than once");
         co_return;
     }
 
@@ -327,7 +327,7 @@ sdbusplus::async::task<> SiblingImpl::watchNameOwnerChanged()
 
         if (!oldOwner.empty() && newOwner.empty())
         {
-            lg2::info("Sibling D-Bus name lost");
+            lg2::warning("Sibling D-Bus name lost");
             setInterfacesNotPresent();
 
             // Invoke any health callbacks as sibling is gone.

--- a/redundant-bmc/test/redundancy_test.cpp
+++ b/redundant-bmc/test/redundancy_test.cpp
@@ -229,7 +229,6 @@ TEST(RedundancyTest, FailoverBlockedTest)
         .siblingAlive = true,
         .siblingState = rbmc::BMCState::Ready,
         .redundancyEnabled = true,
-        .syncInProgress = false,
         .state = rbmc::BMCState::Ready,
         .failoversNotAllowed = false,
         .forceOption = false,
@@ -270,14 +269,6 @@ TEST(RedundancyTest, FailoverBlockedTest)
         input.siblingState = rbmc::BMCState::Quiesced;
         EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
                   rbmc::fo_blocked::Reason::none);
-    }
-
-    // Sync in progress
-    {
-        auto input = golden;
-        input.syncInProgress = true;
-        EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
-                  rbmc::fo_blocked::Reason::fullSyncInProgress);
     }
 
     // Sibling not responding, but redundancy was enabled


### PR DESCRIPTION
There isn't really a need for the passive BMC to block a failover if it has a sync in progress, since it will sync again anyway when it is active.

The other commit changes some info traces to warning or error so they stand out more.