### PR TITLE
datetime: Add the necessary targets and service files

### DIFF
--- a/service_files/active-ntp.service
+++ b/service_files/active-ntp.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Active NTP Service
+
+[Service]
+Type=oneshot
+# Reload settings manager to get the preserved time sync method
+ExecStart=/bin/sh -c 'systemctl reload phosphor-settings-manager.service || true'
+# Wait a moment for settings to be loaded
+ExecStart=/bin/sleep 1
+# Read the saved sync method and apply it
+ExecStart=/bin/sh -c ' \
+    SETTINGS_FILE="/var/lib/phosphor-settings-manager/settings/xyz/openbmc_project/time/sync_method"; \
+    if [ -f "$SETTINGS_FILE" ]; then \
+        SYNC_METHOD=$(grep -oP "(?<=\"TimeSyncMethod\": \")[^\"]*" "$SETTINGS_FILE" 2>/dev/null || echo "xyz.openbmc_project.Time.Synchronization.Method.Manual"); \
+    else \
+        SYNC_METHOD="xyz.openbmc_project.Time.Synchronization.Method.Manual"; \
+    fi; \
+    busctl set-property xyz.openbmc_project.Settings /xyz/openbmc_project/time/sync_method xyz.openbmc_project.Time.Synchronization TimeSyncMethod s "$SYNC_METHOD" \
+'
+
+[Install]
+WantedBy=multi-user.target

--- a/service_files/passive-ntp.service
+++ b/service_files/passive-ntp.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Passive NTP Service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c ' \
+    POSITION=$(cat /run/openbmc/position 2>/dev/null || echo "0"); \
+    if [ "$POSITION" = "0" ]; then \
+        NTP_IP="9.6.28.101"; \
+    else \
+        NTP_IP="9.6.28.100"; \
+    fi; \
+    busctl set-property xyz.openbmc_project.Settings /xyz/openbmc_project/time/sync_method xyz.openbmc_project.Time.Synchronization TimeSyncMethod s "xyz.openbmc_project.Time.Synchronization.Method.NTP"; \
+    busctl set-property xyz.openbmc_project.Network /xyz/openbmc_project/network/eth0 xyz.openbmc_project.Network.EthernetInterface StaticNTPServers as 1 "$NTP_IP" \
+'
+
+[Install]
+WantedBy=multi-user.target

--- a/target_files/obmc-bmc-active.target
+++ b/target_files/obmc-bmc-active.target
@@ -1,3 +1,5 @@
 [Unit]
 Description=Active BMC Target
 Conflicts=obmc-bmc-passive.target
+Requires=active-ntp.service chronyd.service
+After=network.target

--- a/target_files/obmc-bmc-passive.target
+++ b/target_files/obmc-bmc-passive.target
@@ -1,3 +1,6 @@
 [Unit]
 Description=Passive BMC Target
-Conflicts=obmc-bmc-active.target
+Conflicts=obmc-bmc-active.target chronyd.service
+After=network.target
+Wants=systemd-timesyncd.service
+Requires=passive-ntp.service


### PR DESCRIPTION
The active and passive BMCs must have necessary deamon and settings to be loaded when the targets are triggered. Added the necessary service files and tagged them to the respective targets.

Testing in progress


Signed-off-by: Pavithra Barithaya <pavithrabarithaya07@gmail.com>