### PR TITLE
RBMC: Add timeout to startUnit function

### DIFF
--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -39,12 +39,11 @@ sdbusplus::async::task<> ActiveRoleHandler::start()
 
     try
     {
-        // NOLINTNEXTLINE
-        co_await services.startUnit(bmcActiveTarget);
+        // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
+        co_await services.startUnit(bmcActiveTarget, std::chrono::minutes{10});
     }
-    catch (const sdbusplus::exception_t& e)
+    catch (const std::exception& e)
     {
-        // TODO: error log
         lg2::error("Failed while starting BMC active target: {ERROR}", "ERROR",
                    e);
     }
@@ -202,11 +201,12 @@ sdbusplus::async::task<> ActiveRoleHandler::failoverStartActiveTarget()
 
     try
     {
-        co_await providers.getServices().startUnit(bmcActiveTarget);
+        // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
+        co_await providers.getServices().startUnit(bmcActiveTarget,
+                                                   std::chrono::minutes{10});
     }
-    catch (const sdbusplus::exception_t& e)
+    catch (const std::exception& e)
     {
-        // TODO: error log
         lg2::error(
             "Failed while starting BMC active target during failover: {ERROR}",
             "ERROR", e);

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -84,12 +84,12 @@ sdbusplus::async::task<> PassiveRoleHandler::start()
 {
     try
     {
-        // NOLINTNEXTLINE
-        co_await providers.getServices().startUnit(bmcPassiveTarget);
+        // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
+        co_await providers.getServices().startUnit(bmcPassiveTarget,
+                                                   std::chrono::minutes{5});
     }
-    catch (const sdbusplus::exception_t& e)
+    catch (const std::exception& e)
     {
-        // TODO: error log
         lg2::error("Failed while starting BMC passive target: {ERROR}", "ERROR",
                    e);
     }

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -57,12 +57,16 @@ class Services
     /**
      * @brief Starts a systemd unit
      *
-     * Waits for it to be active or failed before returning.
+     * Will return after unit becomes active, otherwise will
+     * throw if:
+     *   1. Unit goes to failed
+     *   2. The timeout is reached.
      *
      * @param[in] unitName - The unit name
+     * @param[in] timeout - Timeout value.
      */
     virtual sdbusplus::async::task<> startUnit(
-        const std::string& unitName) const = 0;
+        const std::string& unitName, std::chrono::seconds timeout) const = 0;
 
     /**
      * @brief Gets the systemd unit state

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -13,6 +13,7 @@
 #include <xyz/openbmc_project/State/Boot/Progress/client.hpp>
 #include <xyz/openbmc_project/State/Host/client.hpp>
 
+#include <format>
 #include <fstream>
 
 namespace rbmc
@@ -496,10 +497,39 @@ sdbusplus::async::task<std::string> ServicesImpl::getUnitState(
     co_return "inactive";
 }
 
-// NOLINTBEGIN
+sdbusplus::async::task<> ServicesImpl::listAndLogSystemdJobs() const
+{
+    try
+    {
+        constexpr auto systemd = sdbusplus::async::proxy()
+                                     .service(service::systemd)
+                                     .path(object_path::systemd)
+                                     .interface(interface::systemdMgr);
+
+        using JobInfo = std::tuple<uint32_t, std::string, std::string,
+                                   std::string, sdbusplus::message::object_path,
+                                   sdbusplus::message::object_path>;
+
+        auto jobs =
+            co_await systemd.call<std::vector<JobInfo>>(ctx, "ListJobs");
+
+        lg2::error("Active systemd jobs at timeout ({COUNT} total):", "COUNT",
+                   jobs.size());
+
+        for (const auto& [id, name, type, state, jobPath, unitPath] : jobs)
+        {
+            lg2::error("  Job {ID}: {NAME} State: {STATE}", "ID", id, "NAME",
+                       name, "STATE", state);
+        }
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        lg2::error("Failed to list systemd jobs: {ERROR}", "ERROR", e);
+    }
+}
+
 sdbusplus::async::task<> ServicesImpl::startUnit(
-    const std::string& unitName) const
-// NOLINTEND
+    const std::string& unitName, std::chrono::seconds timeout) const
 {
     using namespace std::chrono_literals;
     constexpr auto systemd = sdbusplus::async::proxy()
@@ -513,9 +543,18 @@ sdbusplus::async::task<> ServicesImpl::startUnit(
         ctx, "StartUnit", unitName, std::string{"replace"});
 
     std::string state;
+    auto end = std::chrono::steady_clock::now() + timeout;
 
     while ((state != "active") && (state != "failed"))
     {
+        if (std::chrono::steady_clock::now() > end)
+        {
+            lg2::error("Timed out waiting for {UNIT} to start after {TIME}s",
+                       "UNIT", unitName, "TIME", timeout.count());
+            co_await listAndLogSystemdJobs();
+            break;
+        }
+
         co_await sdbusplus::async::sleep_for(ctx, 1s);
         state = co_await getUnitState(unitName);
     }
@@ -523,7 +562,11 @@ sdbusplus::async::task<> ServicesImpl::startUnit(
     lg2::info("Finished waiting for {UNIT} to start (result = {STATE})", "UNIT",
               unitName, "STATE", state);
 
-    co_return;
+    if (state != "active")
+    {
+        throw std::runtime_error{
+            std::format("{} final state is {}", unitName, state)};
+    }
 }
 
 bool ServicesImpl::getProvisioned() const

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -52,12 +52,17 @@ class ServicesImpl : public Services
     /**
      * @brief Starts a systemd unit
      *
-     * Waits for it to be active or failed before returning.
+     * Will return after unit becomes active, otherwise will
+     * throw if:
+     *   1. Unit goes to failed
+     *   2. The timeout is reached.
      *
      * @param[in] unitName - The unit name
+     * @param[in] timeout - Timeout value.
      */
     sdbusplus::async::task<> startUnit(
-        const std::string& unitName) const override;
+        const std::string& unitName,
+        std::chrono::seconds timeout) const override;
 
     /**
      * @brief Gets the systemd unit state
@@ -152,6 +157,14 @@ class ServicesImpl : public Services
      */
     sdbusplus::async::task<sdbusplus::message::object_path> getUnitPath(
         const std::string& unitName) const;
+
+    /**
+     * @brief Lists all active systemd jobs and logs them to the journal
+     *
+     * This is useful for debugging when a unit fails to start within
+     * the expected timeout period.
+     */
+    sdbusplus::async::task<> listAndLogSystemdJobs() const;
 
     /**
      * @brief Starts the InterfacesAdded watch for the host state


### PR DESCRIPTION
The timeout ensures the code will not get stuck waiting for the unit to start forever, which was seen when service crashed such that a mapper wait was never satisfied.

Now even if the target does time out starting, the code can continue on and attempt to enable redundancy, which if successful would allow a failover to the other BMC that would hopefully work better.

Use starting timeout values of a 10 minutes for the active target and 5 minutes for the passive target.

Tested:
Normal operation remains unchanged.

Forced a timeout by lowering it to 1 minute and putting in some dummy services:
```
phosphor-rbmc-state-manager[14915]: Timed out waiting for obmc-bmc-active.target to start after 60s
phosphor-rbmc-state-manager[14915]: Active systemd jobs at timeout (3 total):
phosphor-rbmc-state-manager[14915]:   Job 4523: mapper-wait@-xyz-openbmc_project-state-chassis9.service State: running
phosphor-rbmc-state-manager[14915]:   Job 5327: obmc-bmc-active.target State: waiting
phosphor-rbmc-state-manager[14915]:   Job 5435: delay-active-role.service State: running
```

Change-Id: I49280dd821722520399440fbf019a153d1a0ab53