### PR TITLE
RBMC: Error Logging Infrastructure + logging one error

### DIFF
--- a/redundant-bmc/src/error_data.cpp
+++ b/redundant-bmc/src/error_data.cpp
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright OpenBMC Authors
+
+#include "error_data.hpp"
+
+#include "persistent_data.hpp"
+
+namespace rbmc::errors
+{
+
+namespace
+{
+
+template <typename T>
+std::string getPDIEnumString(T value)
+    requires(std::is_enum_v<T>)
+{
+    try
+    {
+        auto v = sdbusplus::message::convert_to_string(value);
+        return v.substr(v.find_last_of('.') + 1);
+    }
+    catch (const std::exception& e)
+    {
+        return "BadEnum:" + std::to_string(std::to_underlying(value));
+    }
+}
+
+std::string boolToYesOrNo(bool value)
+{
+    return value ? "Yes" : "No";
+}
+
+void addRedundancyData(const RedundancyInterface& iface, AdditionalData& data)
+{
+    data["Role"] = getPDIEnumString(iface.role());
+    data["RedEnabled"] = boolToYesOrNo(iface.redundancy_enabled());
+    data["FOAllowed"] = boolToYesOrNo(iface.failovers_allowed());
+
+    if (!iface.reasons_for_no_redundancy().empty())
+    {
+        data["RedDisabledReasons"] = std::ranges::fold_left(
+            iface.reasons_for_no_redundancy(), std::string{},
+            [](const auto& front, auto r) {
+                auto enumString = getPDIEnumString(r);
+                return front.empty() ? enumString : front + ' ' + enumString;
+            });
+    }
+
+    // TODO: FailoverNotAllowedReasons: Move from addFileData() when
+    //       it is on D-Bus.
+
+    // Only save these when they're interesting.
+    if (iface.failover_in_progress())
+    {
+        data["FOInProgress"] = boolToYesOrNo(true);
+    }
+    if (iface.failover_imminent())
+    {
+        data["FOImminent"] = boolToYesOrNo(true);
+    }
+}
+
+void addSiblingData(const Sibling& sibling, AdditionalData& data)
+{
+    if (!sibling.alive())
+    {
+        data["SibStatus"] = "NotResponding";
+        return;
+    }
+
+    auto roleOpt = sibling.getRole();
+    if (roleOpt.has_value())
+    {
+        data["SibRole"] = getPDIEnumString(roleOpt.value());
+    }
+
+    auto reOpt = sibling.getRedundancyEnabled();
+    if (reOpt.has_value())
+    {
+        data["SibRedEnabled"] = boolToYesOrNo(reOpt.value());
+    }
+
+    auto foaOpt = sibling.getFailoversAllowed();
+    if (foaOpt.has_value())
+    {
+        data["SibFOAllowed"] = boolToYesOrNo(foaOpt.value());
+    }
+
+    if (sibling.getFailoverInProgress().value_or(false))
+    {
+        data["SibFOInProgress"] = boolToYesOrNo(true);
+    }
+
+    if (sibling.getFailoverImminent().value_or(false))
+    {
+        data["SibFOImminent"] = boolToYesOrNo(true);
+    }
+
+    if (sibling.getHasReasonForNoRedundancy().value_or(false))
+    {
+        data["SibHasReasonForNoRed"] = boolToYesOrNo(true);
+    }
+
+    auto stateOpt = sibling.getBMCState();
+    if (stateOpt.has_value())
+    {
+        data["SibBMCState"] = getPDIEnumString(stateOpt.value());
+    }
+}
+
+void addServicesData(const Services& services, bool isActive,
+                     AdditionalData& data)
+{
+    data["BMCPos"] = services.getBMCPosition()
+                         .transform([](auto p) { return std::to_string(p); })
+                         .value_or("Unknown");
+    if (isActive)
+    {
+        try
+        {
+            data["SysState"] =
+                Services::getSystemStateName(services.getSystemState());
+        }
+        catch (const std::exception& e)
+        {
+            data["SysStateError"] = e.what();
+        }
+    }
+
+    auto logs = data::getFailoverLogs(services.getPersistentDataPath(), 0);
+    if (!logs.empty())
+    {
+        const auto& last = logs.back();
+        data["BMC0PrevFO"] = std::format("{} {}", last.first, last.second);
+    }
+
+    logs = data::getFailoverLogs(services.getPersistentDataPath(), 1);
+    if (!logs.empty())
+    {
+        const auto& last = logs.back();
+        data["BMC1PrevFO"] = std::format("{} {}", last.first, last.second);
+    }
+}
+
+void addFileData(AdditionalData& data)
+{
+    try
+    {
+        auto reason = data::read<std::string>(data::key::roleReason);
+        if (reason.has_value())
+        {
+            data["RoleReason"] = reason.value();
+        }
+
+        auto redAtRuntime = data::read<std::tuple<bool, bool>>(
+            data::key::redundancyOffAtRuntime);
+
+        if (redAtRuntime.has_value())
+        {
+            const auto& [valid, off] = redAtRuntime.value();
+            if (valid && off)
+            {
+                data["RedOffAtRuntime"] = boolToYesOrNo(true);
+            }
+        }
+
+        auto notAllowedReasons = data::read<std::set<std::string>>(
+            data::key::failoversNotAllowedReasons);
+        if (notAllowedReasons.has_value() && !notAllowedReasons.value().empty())
+        {
+            // TODO: Move to addRedundancyData() when this moves to D-Bus.
+            data["FONotAllowedReasons"] = std::ranges::fold_left(
+                notAllowedReasons.value(), std::string{},
+                [](const auto& front, const auto& r) {
+                    return front.empty() ? r : front + ' ' + r;
+                });
+        }
+    }
+    catch (const std::exception& e)
+    {
+        data["DataError"] = e.what();
+    }
+}
+
+void addFWData(const Services& services, const Sibling& sibling,
+               AdditionalData& data)
+{
+    if (!sibling.alive())
+    {
+        return;
+    }
+
+    auto localVersion = services.getFWVersion();
+    auto sibVersion = sibling.getFWVersion().value_or("DEAD");
+    if (localVersion != sibVersion)
+    {
+        data["FWVersionMismatch"] =
+            std::format("Local: {} Sibling: {}", localVersion, sibVersion);
+    }
+}
+
+} // namespace
+
+void addDefaultData(const RedundancyInterface& iface, Providers& providers,
+                    AdditionalData& data)
+{
+    data.emplace("_PID", std::to_string(getpid()));
+    addRedundancyData(iface, data);
+    addSiblingData(providers.getSibling(), data);
+    addServicesData(providers.getServices(),
+                    iface.role() == RedundancyInterface::Role::Active, data);
+    addFileData(data);
+    addFWData(providers.getServices(), providers.getSibling(), data);
+}
+
+} // namespace rbmc::errors

--- a/redundant-bmc/src/error_data.hpp
+++ b/redundant-bmc/src/error_data.hpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright OpenBMC Authors
+#pragma once
+
+#include "errors.hpp"
+#include "providers.hpp"
+#include "redundancy_interface.hpp"
+
+namespace rbmc::errors
+{
+
+/**
+ * @brief Adds the default set of redundancy related data to the
+ *        AdditionalData map passed in.
+ *
+ * @param[in] iface - The RedundancyInterface object, for collecting data
+ * @param[in] providers - The Providers object, for collecting data
+ * @param[inout] data - Map to add the data to
+ */
+void addDefaultData(const RedundancyInterface& iface, Providers& providers,
+                    AdditionalData& data);
+
+} // namespace rbmc::errors

--- a/redundant-bmc/src/errors.hpp
+++ b/redundant-bmc/src/errors.hpp
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright OpenBMC Authors
+
+#pragma once
+
+#include <xyz/openbmc_project/Logging/Entry/common.hpp>
+
+#include <map>
+#include <string>
+
+namespace rbmc::errors
+{
+
+using Level = sdbusplus::common::xyz::openbmc_project::logging::Entry::Level;
+
+using AdditionalData = std::map<std::string, std::string>;
+
+namespace error_msg
+{
+const std::string failoverStarted =
+    "xyz.openbmc_project.State.BMC.Redundancy.FailoverStarted";
+
+const std::string failoverBlocked =
+    "xyz.openbmc_project.State.BMC.Redundancy.FailoverBlocked";
+
+const std::string redundancyManuallyDisabled =
+    "xyz.openbmc_project.State.BMC.Redundancy.RedundancyManuallyDisabled";
+
+const std::string bmcIsPassiveDueToError =
+    "xyz.openbmc_project.State.BMC.Redundancy.PassiveDueToError";
+
+const std::string noRedundancy =
+    "xyz.openbmc_project.State.BMC.Redundancy.NoRedundancy";
+
+} // namespace error_msg
+
+} // namespace rbmc::errors

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -2,6 +2,8 @@
 #include "manager.hpp"
 
 #include "active_role_handler.hpp"
+#include "error_data.hpp"
+#include "errors.hpp"
 #include "passive_role_handler.hpp"
 #include "persistent_data.hpp"
 
@@ -87,6 +89,17 @@ sdbusplus::async::task<> Manager::startup()
         }
 
         updateRole(co_await determineRole());
+    }
+
+    if (chosePassiveDueToError)
+    {
+        using namespace errors;
+        AdditionalData data{
+            {"RoleReasonVal", std::to_string(std::to_underlying(roleReason))}};
+        addDefaultData(redundancyInterface, *providers, data);
+
+        co_await services.logError(error_msg::bmcIsPassiveDueToError,
+                                   Level::Error, data);
     }
 
     co_await postStartupClearFOInProgress();
@@ -262,6 +275,8 @@ sdbusplus::async::task<std::optional<role_determination::RoleInfo>>
 
 void Manager::updateRole(const role_determination::RoleInfo& roleInfo)
 {
+    roleReason = roleInfo.reason;
+
     auto reasonDesc =
         role_determination::getRoleReasonDescription(roleInfo.reason);
 

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -182,7 +182,7 @@ sdbusplus::async::task<role_determination::RoleInfo> Manager::determineRole()
 
         // determineRole() doesn't support an empty BMC position because
         // it should have been caught in determinePassiveRoleIfRequired.
-        auto bmcPos = co_await services.getBMCPosition();
+        auto bmcPos = services.getBMCPosition();
         if (!bmcPos.has_value())
         {
             lg2::error("determineRole: No BMC position");
@@ -236,7 +236,7 @@ sdbusplus::async::task<std::optional<role_determination::RoleInfo>>
     }
 
     // A BMC with no position cannot be active.
-    auto bmcPos = co_await providers->getServices().getBMCPosition();
+    auto bmcPos = providers->getServices().getBMCPosition();
     if (!bmcPos.has_value())
     {
         co_return RoleInfo{Role::Passive, RoleReason::unknownBMCPosition};
@@ -391,10 +391,9 @@ sdbusplus::async::task<> Manager::doFailoverFromPassive(Requester requester)
     redundancyInterface.failover_in_progress(true);
 
     // After the point of no return, log it
-    data::logFailover(
-        providers->getServices().getPersistentDataPath(),
-        (co_await providers->getServices().getBMCPosition()).value_or(0xFF),
-        requester, now);
+    data::logFailover(providers->getServices().getPersistentDataPath(),
+                      providers->getServices().getBMCPosition().value_or(0xFF),
+                      requester, now);
 
     lg2::info("Claiming active role");
     updateRole(role_determination::RoleInfo{

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -159,6 +159,12 @@ class Manager :
      * Read from the filesystem in the constructor.
      */
     bool chosePassiveDueToError{false};
+
+    /**
+     * @brief The reason the active/passive role was chosen.
+     */
+    role_determination::RoleReason roleReason{
+        role_determination::RoleReason::unknown};
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -17,6 +17,7 @@ rbmc_deps = [
 executable(
     'phosphor-rbmc-state-manager',
     'active_role_handler.cpp',
+    'error_data.cpp',
     'manager.cpp',
     'passive_role_handler.cpp',
     'persistent_data.cpp',

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -178,7 +178,7 @@ sdbusplus::async::task<> getLocalBMCInfo(sdbusplus::async::context& ctx,
         output["Role"] = role;
 
         rbmc::ServicesImpl services{ctx};
-        auto pos = co_await services.getBMCPosition();
+        auto pos = services.getBMCPosition();
         auto bmcPos = pos.has_value() ? std::to_string(pos.value()) : "Unknown";
         output["BMC Position"] = bmcPos;
 

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -1,5 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 #pragma once
+#include "errors.hpp"
+
 #include <sdbusplus/async.hpp>
 #include <xyz/openbmc_project/State/BMC/common.hpp>
 
@@ -121,6 +123,17 @@ class Services
      * @brief Returns the persistent data directory
      */
     virtual std::filesystem::path getPersistentDataPath() const = 0;
+
+    /**
+     * @brief Creates an event log with the specified fields
+     *
+     * @param[in] error - The error enum to use
+     * @param[in] severity - The log severity
+     * @param[in] data - AdditionalData property value
+     */
+    virtual sdbusplus::async::task<> logError(
+        std::string error, errors::Level severity,
+        errors::AdditionalData data) const = 0;
 
     /**
      * @brief Returns the string name for the system state enum

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -51,8 +51,7 @@ class Services
      *
      * @return - The position if it can be obtained
      */
-    virtual sdbusplus::async::task<std::optional<size_t>> getBMCPosition()
-        const = 0;
+    virtual std::optional<size_t> getBMCPosition() const = 0;
 
     /**
      * @brief Starts a systemd unit

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -22,8 +22,6 @@ using HostState = sdbusplus::client::xyz::openbmc_project::state::Host<>;
 using ObjectMapper = sdbusplus::client::xyz::openbmc_project::ObjectMapper<>;
 using BootProgress =
     sdbusplus::client::xyz::openbmc_project::state::boot::Progress<>;
-using Position =
-    sdbusplus::client::xyz::openbmc_project::inventory::decorator::Position<>;
 using SystemInv =
     sdbusplus::common::xyz::openbmc_project::inventory::item::System;
 using InvProgress = sdbusplus::client::xyz::openbmc_project::common::Progress<>;
@@ -395,54 +393,50 @@ void ServicesImpl::updateSystemState()
     }
 }
 
-// NOLINTNEXTLINE
-sdbusplus::async::task<std::optional<size_t>> ServicesImpl::getBMCPosition()
-    const
+std::optional<size_t> ServicesImpl::getBMCPosition() const
 {
-    // This can be called from rbmctool which wouldn't call init().
-    // So may need to look up the path here.
-    auto path = systemInvPath;
-    if (path.empty())
+    static std::optional<size_t> bmcPosition;
+    const std::filesystem::path posFile{"/run/openbmc/bmc_position"};
+
+    if (bmcPosition.has_value())
     {
-        try
-        {
-            path = co_await util::findSystemInventoryPath(ctx);
-        }
-        catch (const std::exception& e)
-        {
-            lg2::error(
-                "There is no system inventory object to find the BMC position for: {ERROR}",
-                "ERROR", e);
-            co_return std::nullopt;
-        }
+        return bmcPosition;
     }
 
-    try
+    std::error_code ec;
+    if (!std::filesystem::exists(posFile, ec))
     {
-        static std::string service;
-        if (service.empty())
-        {
-            service = co_await util::getService(ctx, path, Position::interface);
-        }
-
-        size_t position =
-            co_await Position(ctx).service(service).path(path).position();
-
-        // max() is a special value meaning position cannot be obtained.
-        if (position == std::numeric_limits<size_t>::max())
-        {
-            lg2::error("BMC position value is not valid");
-            co_return std::nullopt;
-        }
-
-        co_return position;
-    }
-    catch (const std::exception& e)
-    {
-        lg2::error("D-Bus error obtaining BMC position: {ERROR}", "ERROR", e);
+        lg2::error("BMC position file {FILE} doesn't exist", "FILE", posFile);
+        return std::nullopt;
     }
 
-    co_return std::nullopt;
+    std::ifstream stream{posFile};
+    if (!stream)
+    {
+        lg2::error("Could not open BMC position file {FILE}", "FILE", posFile);
+        return std::nullopt;
+    }
+
+    size_t position;
+    stream >> position;
+
+    if (stream.fail())
+    {
+        lg2::error("Failed reading BMC position out of {FILE}", "FILE",
+                   posFile);
+        return std::nullopt;
+    }
+
+    if (position == std::numeric_limits<size_t>::max())
+    {
+        lg2::warning("BMC position value could not be obtained from hardware");
+        return std::nullopt;
+    }
+
+    // Don't cache it until there is a good value.
+    bmcPosition = position;
+
+    return bmcPosition;
 }
 
 // NOLINTBEGIN

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -8,6 +8,7 @@
 #include <xyz/openbmc_project/Control/SideBandBus/client.hpp>
 #include <xyz/openbmc_project/Inventory/Decorator/Position/client.hpp>
 #include <xyz/openbmc_project/Inventory/Item/System/common.hpp>
+#include <xyz/openbmc_project/Logging/Create/client.hpp>
 #include <xyz/openbmc_project/ObjectMapper/client.hpp>
 #include <xyz/openbmc_project/State/BMC/client.hpp>
 #include <xyz/openbmc_project/State/Boot/Progress/client.hpp>
@@ -745,6 +746,27 @@ sdbusplus::async::task<> ServicesImpl::acquireFullHardwareAccess()
         .service(SidebandBus::interface)
         .path(SidebandBus::instance_path)
         .acquire(options);
+}
+
+sdbusplus::async::task<> ServicesImpl::logError(
+    std::string error, errors::Level severity,
+    errors::AdditionalData data) const
+{
+    try
+    {
+        using Create =
+            sdbusplus::client::xyz::openbmc_project::logging::Create<>;
+
+        co_await Create(ctx)
+            .service(Create::default_service)
+            .path(Create::instance_path)
+            .create(error, severity, data);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed to create event log {MSG}: {ERROR}", "MSG", error,
+                   "ERROR", e);
+    }
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -528,6 +528,13 @@ bool ServicesImpl::getProvisioned() const
 
 std::string ServicesImpl::getFWVersion() const
 {
+    static std::string hexVersionString;
+
+    if (!hexVersionString.empty())
+    {
+        return hexVersionString;
+    }
+
     std::ifstream versionFile{"/etc/os-release"};
     std::string line;
     std::string keyPattern{"VERSION_ID="};
@@ -565,8 +572,9 @@ std::string ServicesImpl::getFWVersion() const
     EVP_DigestUpdate(context.get(), version.c_str(), strlen(version.c_str()));
     EVP_DigestFinal(context.get(), digest.data(), nullptr);
 
-    return std::format("{:02X}{:02X}{:02X}{:02X}", digest[0], digest[1],
-                       digest[2], digest[3]);
+    hexVersionString = std::format("{:02X}{:02X}{:02X}{:02X}", digest[0],
+                                   digest[1], digest[2], digest[3]);
+    return hexVersionString;
 }
 
 SystemState ServicesImpl::getSystemState() const

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -142,6 +142,17 @@ class ServicesImpl : public Services
      */
     sdbusplus::async::task<> acquireFullHardwareAccess() override;
 
+    /**
+     * @brief Creates an event log with the specified fields
+     *
+     * @param[in] error - The error enum to use
+     * @param[in] severity - The log severity
+     * @param[in] data - AdditionalData property value
+     */
+    sdbusplus::async::task<> logError(
+        std::string error, errors::Level severity,
+        errors::AdditionalData data) const override;
+
   private:
     /**
      * @brief Returns the D-Bus object path for the unit in the

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -6,6 +6,8 @@
 #include <xyz/openbmc_project/State/Boot/Progress/common.hpp>
 #include <xyz/openbmc_project/State/Host/common.hpp>
 
+#include <optional>
+
 namespace rbmc
 {
 
@@ -46,8 +48,7 @@ class ServicesImpl : public Services
      *
      * @return - The position if it can be obtained
      */
-    sdbusplus::async::task<std::optional<size_t>> getBMCPosition()
-        const override;
+    std::optional<size_t> getBMCPosition() const override;
 
     /**
      * @brief Starts a systemd unit


### PR DESCRIPTION
This PR adds the support to log errors with RBMC related FFDC:

- Changes the function to get the BMC position to get it from /run/openbmc/bmc_position so it doesn't need to be a co-routine so it can run in certain error paths.
- Caches the hash of the firmware version so the hash functions only have to run once and not every time an error log is created.
- Adds the functions to capture redundancy related FFDC to add to an error log, and also the new function to log an error.
- Create an error log in the case that the BMC has to be passive due to an error. 
  - The code to log other errors will come in a future PR, this one is included to show an example but also not make the PR even bigger by adding all of them.