### PR TITLE
RBMC: Create redundancy related PELs

### DIFF
--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -59,8 +59,6 @@ sdbusplus::async::task<> ActiveRoleHandler::start()
 
     co_await redMgr.determineRedundancyAndSync();
 
-    // TODO: Create an error if no redundancy
-
     startSiblingWatches();
 
     startSyncHealthWatch();

--- a/redundant-bmc/src/error_data.cpp
+++ b/redundant-bmc/src/error_data.cpp
@@ -214,4 +214,30 @@ void addDefaultData(const RedundancyInterface& iface, Providers& providers,
     addFWData(providers.getServices(), providers.getSibling(), data);
 }
 
+void addFailoverOptsToData(const FailoverOptions& options,
+                           errors::AdditionalData& data)
+{
+    constexpr auto failoverOptPrefix = "FOOpt:";
+
+    for (const auto& [key, value] : options)
+    {
+        std::string adKey = failoverOptPrefix + key;
+
+        data.emplace(adKey, std::visit(
+                                [](auto&& val) -> std::string {
+                                    using T = std::decay_t<decltype(val)>;
+                                    if constexpr (std::is_same_v<T, bool>)
+                                    {
+                                        return val ? "true" : "false";
+                                    }
+                                    else
+                                    {
+                                        // FailoverOptions can only hold bools
+                                        return "Unsupported option type";
+                                    }
+                                },
+                                value));
+    }
+}
+
 } // namespace rbmc::errors

--- a/redundant-bmc/src/error_data.hpp
+++ b/redundant-bmc/src/error_data.hpp
@@ -5,6 +5,7 @@
 #include "errors.hpp"
 #include "providers.hpp"
 #include "redundancy_interface.hpp"
+#include "types.hpp"
 
 namespace rbmc::errors
 {
@@ -19,5 +20,14 @@ namespace rbmc::errors
  */
 void addDefaultData(const RedundancyInterface& iface, Providers& providers,
                     AdditionalData& data);
+
+/**
+ * @brief Adds the failover options keys and values to the
+ *        additional data map.
+ *
+ * Of the form: "FOOpt:<key>  ->  <value>"
+ */
+void addFailoverOptsToData(const FailoverOptions& options,
+                           errors::AdditionalData& data);
 
 } // namespace rbmc::errors

--- a/redundant-bmc/src/errors.hpp
+++ b/redundant-bmc/src/errors.hpp
@@ -8,7 +8,10 @@
 #include <map>
 #include <string>
 
-namespace rbmc::errors
+namespace rbmc
+{
+
+namespace errors
 {
 
 using Level = sdbusplus::common::xyz::openbmc_project::logging::Entry::Level;
@@ -34,4 +37,6 @@ const std::string noRedundancy =
 
 } // namespace error_msg
 
-} // namespace rbmc::errors
+} // namespace errors
+
+} // namespace rbmc

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -333,43 +333,71 @@ void Manager::disableRedPropChanged(bool disable)
     handler->disableRedPropChanged(disable);
 }
 
+sdbusplus::async::task<fo_blocked::Reason> Manager::validateFailoverRequest(
+    const FailoverOptions& options)
+{
+    if (!handler)
+    {
+        co_return fo_blocked::Reason::tooEarly;
+    }
+
+    co_return co_await handler->getFailoverBlockedReason(options);
+}
+
 // NOLINTNEXTLINE
 sdbusplus::async::task<> Manager::method_call(start_failover_t /* unused */,
                                               Requester requester,
                                               const FailoverOptions& options)
 {
-    lg2::info("Failover requester is {REQUESTER}", "REQUESTER", requester);
-
-    if (redundancyInterface.failover_imminent() ||
-        redundancyInterface.failover_in_progress())
+    auto reqString = convertRequesterToString(requester);
+    if (reqString.contains('.'))
     {
-        lg2::error(
-            "Failover not allowed because a failover is already imminent or in progress ");
-        throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
+        reqString = reqString.substr(reqString.find_last_of('.') + 1);
     }
 
-    if (!handler)
-    {
-        lg2::error("Failover not allowed because it is too early");
-        throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
-    }
+    lg2::info("Failover requester is {REQUESTER}", "REQUESTER", reqString);
 
-    // Do more in depth checking of system state
-    auto reason = co_await handler->getFailoverBlockedReason(options);
-    if (reason != fo_blocked::Reason::none)
+    errors::AdditionalData data{
+        {"FORequester", reqString},
+        {"FORequesterVal", std::to_string(std::to_underlying(requester))}};
+
+    errors::addDefaultData(redundancyInterface, *providers, data);
+    errors::addFailoverOptsToData(options, data);
+
+    auto blockedReason = co_await validateFailoverRequest(options);
+
+    if (blockedReason != fo_blocked::Reason::none)
     {
-        lg2::error("Failover is blocked because: {REASON}", "REASON",
-                   fo_blocked::getFailoverBlockedDescription(reason));
+        auto blockedReasonDesc =
+            fo_blocked::getFailoverBlockedDescription(blockedReason);
+
+        lg2::error("StartFailover failed because: {REASON}", "REASON",
+                   blockedReasonDesc);
+
+        data.emplace("FOBlockedReason", blockedReasonDesc);
+        data.emplace("FOBlockedReasonVal",
+                     std::to_string(std::to_underlying(blockedReason)));
+
+        auto sev = (requester == Requester::Tool) ? errors::Level::Informational
+                                                  : errors::Level::Warning;
+
+        co_await providers->getServices().logError(
+            errors::error_msg::failoverBlocked, sev, data);
+
         throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
     }
 
     if (redundancyInterface.role() == Role::Passive)
     {
+        co_await providers->getServices().logError(
+            errors::error_msg::failoverStarted, errors::Level::Informational,
+            data);
+
         ctx.spawn(doFailoverFromPassive(requester));
     }
     else
     {
-        // Shouldn't get here, would have failed in getFailoverBlockedReason
+        // Shouldn't get here, would have failed in validateFailoverRequest
         lg2::error("StartFailover on active BMC not supported yet");
         throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
     }

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -5,6 +5,7 @@
 #include "redundancy_interface.hpp"
 #include "role_determination.hpp"
 #include "role_handler.hpp"
+#include "types.hpp"
 
 #include <sdbusplus/async.hpp>
 #include <xyz/openbmc_project/Control/Failover/aserver.hpp>
@@ -125,6 +126,18 @@ class Manager :
      *        removes the persisted value.
      */
     sdbusplus::async::task<> postStartupClearFOInProgress();
+
+    /**
+     * @brief Checks if a failover can be started now.
+     *
+     * @param[in] options - The options passed to StartFailover
+     *
+     * @return std::string - The reason for the failover rejection
+     *                       or empty string if it can proceed.
+     *
+     */
+    sdbusplus::async::task<fo_blocked::Reason> validateFailoverRequest(
+        const FailoverOptions& options);
 
     /**
      * @brief The async context object

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -324,6 +324,8 @@ auto PassiveRoleHandler::getFailoverBlockedReason(
         .state = bmcState,
         .failoversNotAllowed = !redundancyInterface.failovers_allowed(),
         .forceOption = force,
+        .failoverInProgress = redundancyInterface.failover_in_progress() ||
+                              redundancyInterface.failover_imminent(),
 
         // If the active BMC were to completely die, its last known value of
         // RedundancyEnabled will still have been mirrored to the passive.

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -222,7 +222,6 @@ sdbusplus::async::task<> PassiveRoleHandler::startSync()
     {
         lg2::error("Full sync on passive BMC failed");
         co_await stopSync();
-        // TODO: create error log
     }
 }
 
@@ -270,7 +269,6 @@ sdbusplus::async::task<> PassiveRoleHandler::syncHealthCritical()
     if (providers.getSibling().alive())
     {
         lg2::error("Sync fail was not caused by a sibling BMC problem");
-        // TODO: Create error log
     }
     else
     {

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -4,6 +4,7 @@
 #include "redundancy.hpp"
 #include "services_impl.hpp"
 #include "sibling_reset_impl.hpp"
+#include "types.hpp"
 
 #include <CLI/CLI.hpp>
 #include <nlohmann/json.hpp>
@@ -393,8 +394,7 @@ sdbusplus::async::task<> modifyRedundancyOverride(
 sdbusplus::async::task<> startFailover(sdbusplus::async::context& ctx,
                                        bool force)
 {
-    using FailoverOptions = std::map<std::string, std::variant<bool>>;
-    FailoverOptions options;
+    rbmc::FailoverOptions options;
 
     try
     {

--- a/redundant-bmc/src/redundancy.cpp
+++ b/redundant-bmc/src/redundancy.cpp
@@ -176,6 +176,10 @@ Reason getFailoverBlockedReason(const Input& input)
                 return Reason::failoversNotAllowed;
             }
         }
+        else if (input.failoverInProgress)
+        {
+            return Reason::failoverAlreadyInProgress;
+        }
     }
     else
     {
@@ -235,6 +239,11 @@ std::string getFailoverBlockedDescription(Reason reason)
         case Reason::bmcNotPassive:
             desc = "This BMC is not passive"s;
             break;
+        case Reason::failoverAlreadyInProgress:
+            desc = "A failover is already in progress"s;
+            break;
+        case Reason::tooEarly:
+            desc = "It is too early in the BMC boot to start a failover"s;
     }
     return desc;
 }

--- a/redundant-bmc/src/redundancy.hpp
+++ b/redundant-bmc/src/redundancy.hpp
@@ -108,6 +108,7 @@ struct Input
     BMCState state;
     bool failoversNotAllowed;
     bool forceOption;
+    bool failoverInProgress;
     bool lastKnownRedundancyEnabled;
 };
 
@@ -121,7 +122,9 @@ enum class Reason
     failoversNotAllowed,
     siblingDeadButRedundancyNotEnabled,
     notAtReady,
-    bmcNotPassive
+    bmcNotPassive,
+    failoverAlreadyInProgress,
+    tooEarly
 };
 
 /**

--- a/redundant-bmc/src/redundancy_mgr.cpp
+++ b/redundant-bmc/src/redundancy_mgr.cpp
@@ -2,6 +2,9 @@
 
 #include "redundancy_mgr.hpp"
 
+#include "error_data.hpp"
+#include "errors.hpp"
+
 #include <persistent_data.hpp>
 #include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
@@ -25,21 +28,57 @@ RedundancyMgr::RedundancyMgr(sdbusplus::async::context& ctx,
     }
 }
 
-// NOLINTNEXTLINE
 void RedundancyMgr::determineAndSetRedundancy()
 {
+    auto firstTime = !redundancyDetermined;
+    auto oldEnabled = redundancyInterface.redundancy_enabled();
+    auto oldReasons = redundancyInterface.reasons_for_no_redundancy();
+
     if (!redundancyDetermined)
     {
         initSystemState();
     }
 
-    enableOrDisableRedundancy(getNoRedundancyReasons());
+    auto reasons = getNoRedundancyReasons();
+    enableOrDisableRedundancy(reasons);
     redundancyDetermined = true;
 
     determineAndSetFailoversAllowed();
 
     if (!redundancyInterface.redundancy_enabled())
     {
+        auto wasManuallyDisabled = std::ranges::contains(
+            oldReasons, ReasonForNoRedundancy::ManuallyDisabled);
+
+        // Log an error when redundancy isn't enabled if:
+        // 1. Redundancy was previously enabled.
+        // 2. This is the first time checking redundancy.
+        // 3. The manual override to disable redundancy is now off but
+        //    was previously on, meaning there is some other reason.
+        if (oldEnabled || firstTime || (!manualDisable && wasManuallyDisabled))
+        {
+            using namespace errors;
+            std::string error{error_msg::noRedundancy};
+            Level sev{Level::Error};
+
+            if (manualDisable)
+            {
+                error = error_msg::redundancyManuallyDisabled;
+                sev = Level::Informational;
+            }
+
+            AdditionalData data;
+            data.emplace("ReasonsCount", std::to_string(reasons.size()));
+            if (!reasons.empty())
+            {
+                auto val = std::to_underlying(*reasons.begin());
+                data.emplace("FirstReasonVal", std::to_string(val));
+            }
+            addDefaultData(redundancyInterface, providers, data);
+
+            ctx.spawn(providers.getServices().logError(error, sev, data));
+        }
+
         // Make sure syncs are disabled if redundancy is disabled.
         ctx.spawn(providers.getSyncInterface().disableBackgroundSync());
 

--- a/redundant-bmc/src/role_handler.hpp
+++ b/redundant-bmc/src/role_handler.hpp
@@ -4,8 +4,7 @@
 #include "providers.hpp"
 #include "redundancy.hpp"
 #include "redundancy_interface.hpp"
-
-using FailoverOptions = std::map<std::string, std::variant<bool>>;
+#include "types.hpp"
 
 namespace rbmc
 {

--- a/redundant-bmc/src/types.hpp
+++ b/redundant-bmc/src/types.hpp
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <variant>
+
+namespace rbmc
+{
+
+using FailoverOptions = std::map<std::string, std::variant<bool>>;
+
+} // namespace rbmc

--- a/redundant-bmc/test/error_data_test.cpp
+++ b/redundant-bmc/test/error_data_test.cpp
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright OpenBMC Authors
+
+#include "error_data.hpp"
+#include "types.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace rbmc::errors;
+using rbmc::FailoverOptions;
+
+TEST(ErrorDataTest, AddFailoverOptsToData_EmptyOptions)
+{
+    // Test with empty FailoverOptions
+    FailoverOptions options;
+    AdditionalData data;
+
+    addFailoverOptsToData(options, data);
+
+    EXPECT_TRUE(data.empty());
+}
+
+TEST(ErrorDataTest, AddFailoverOptsToData_TrueAndFalse)
+{
+    FailoverOptions options{{"option1", true}, {"option2", false}};
+    AdditionalData data;
+
+    addFailoverOptsToData(options, data);
+
+    ASSERT_EQ(data.size(), 2);
+    EXPECT_EQ(data["FOOpt:option1"], "true");
+    EXPECT_EQ(data["FOOpt:option2"], "false");
+}
+
+TEST(ErrorDataTest, AddFailoverOptsToData_PreserveExistingData)
+{
+    // Test that existing data in AdditionalData is preserved
+    AdditionalData data{{"ExistingKey1", "ExistingValue1"},
+                        {"ExistingKey2", "ExistingValue2"}};
+
+    FailoverOptions options{{"option1", false},
+                            {"xyz.openbmc_project.Option2", true}};
+
+    addFailoverOptsToData(options, data);
+
+    ASSERT_EQ(data.size(), 4);
+    EXPECT_EQ(data["ExistingKey1"], "ExistingValue1");
+    EXPECT_EQ(data["ExistingKey2"], "ExistingValue2");
+    EXPECT_EQ(data["FOOpt:option1"], "false");
+    EXPECT_EQ(data["FOOpt:xyz.openbmc_project.Option2"], "true");
+}
+
+TEST(ErrorDataTest, AddFailoverOptsToData_EmptyKeyString)
+{
+    // Test with empty key string (edge case)
+    FailoverOptions options{{"", true}};
+    AdditionalData data;
+
+    addFailoverOptsToData(options, data);
+
+    ASSERT_EQ(data.size(), 1);
+    EXPECT_EQ(data["FOOpt:"], "true");
+}

--- a/redundant-bmc/test/meson.build
+++ b/redundant-bmc/test/meson.build
@@ -4,9 +4,11 @@ test(
     'rbmc-tests',
     executable(
         'rbmc-tests',
+        'error_data_test.cpp',
         'persistent_data_test.cpp',
         'redundancy_test.cpp',
         'role_determination_test.cpp',
+        '../src/error_data.cpp',
         '../src/persistent_data.cpp',
         '../src/redundancy.cpp',
         '../src/role_determination.cpp',

--- a/redundant-bmc/test/redundancy_test.cpp
+++ b/redundant-bmc/test/redundancy_test.cpp
@@ -232,6 +232,7 @@ TEST(RedundancyTest, FailoverBlockedTest)
         .state = rbmc::BMCState::Ready,
         .failoversNotAllowed = false,
         .forceOption = false,
+        .failoverInProgress = false,
         .lastKnownRedundancyEnabled = true};
 
     EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(golden),
@@ -304,6 +305,14 @@ TEST(RedundancyTest, FailoverBlockedTest)
         input.lastKnownRedundancyEnabled = false;
         EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
                   rbmc::fo_blocked::Reason::siblingDeadButRedundancyNotEnabled);
+    }
+
+    // Failover in Progress
+    {
+        auto input = golden;
+        input.failoverInProgress = true;
+        EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
+                  rbmc::fo_blocked::Reason::failoverAlreadyInProgress);
     }
 }
 


### PR DESCRIPTION
Create PELs for:

- Failover block
- Failover started
- Cannot enable redundancy
