### PR TITLE
 RBMC: Fill in FailoversNotAllowedReason prop

### DIFF
--- a/redundant-bmc/src/error_data.cpp
+++ b/redundant-bmc/src/error_data.cpp
@@ -47,8 +47,12 @@ void addRedundancyData(const RedundancyInterface& iface, AdditionalData& data)
             });
     }
 
-    // TODO: FailoverNotAllowedReasons: Move from addFileData() when
-    //       it is on D-Bus.
+    if (iface.failovers_not_allowed_reason() !=
+        RedundancyInterface::FailoversNotAllowedReason::None)
+    {
+        data["FONotAllowedReason"] =
+            getPDIEnumString(iface.failovers_not_allowed_reason());
+    }
 
     // Only save these when they're interesting.
     if (iface.failover_in_progress())
@@ -163,18 +167,6 @@ void addFileData(AdditionalData& data)
             {
                 data["RedOffAtRuntime"] = boolToYesOrNo(true);
             }
-        }
-
-        auto notAllowedReasons = data::read<std::set<std::string>>(
-            data::key::failoversNotAllowedReasons);
-        if (notAllowedReasons.has_value() && !notAllowedReasons.value().empty())
-        {
-            // TODO: Move to addRedundancyData() when this moves to D-Bus.
-            data["FONotAllowedReasons"] = std::ranges::fold_left(
-                notAllowedReasons.value(), std::string{},
-                [](const auto& front, const auto& r) {
-                    return front.empty() ? r : front + ' ' + r;
-                });
         }
     }
     catch (const std::exception& e)

--- a/redundant-bmc/src/persistent_data.hpp
+++ b/redundant-bmc/src/persistent_data.hpp
@@ -26,7 +26,6 @@ constexpr auto roleReason = "RoleReason";
 constexpr auto noRedReasons = "NoRedundancyReasons";
 constexpr auto disableRed = "DisableRedundancy";
 constexpr auto redundancyOffAtRuntime = "RedundancyOffAtRuntime";
-constexpr auto failoversNotAllowedReasons = "FailoversNotAllowedReasons";
 constexpr auto failoverInProgress = "FailoverInProgress";
 } // namespace key
 

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -80,6 +80,21 @@ void printJSONParam(const std::string& name, const nlohmann::json& value)
     }
 }
 
+template <typename T>
+std::string getPDIEnumString(T value)
+    requires(std::is_enum_v<T>)
+{
+    try
+    {
+        auto v = sdbusplus::message::convert_to_string(value);
+        return v.substr(v.find_last_of('.') + 1);
+    }
+    catch (const std::exception& e)
+    {
+        return "BadEnum:" + std::to_string(std::to_underlying(value));
+    }
+}
+
 // NOLINTNEXTLINE
 sdbusplus::async::task<std::string> getBMCState(const rbmc::Services& services)
 {
@@ -88,8 +103,7 @@ sdbusplus::async::task<std::string> getBMCState(const rbmc::Services& services)
         // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
         auto bmcState = co_await services.getBMCState();
 
-        auto stateString = BMCState::convertBMCStateToString(bmcState);
-        co_return stateString.substr(stateString.find_last_of('.') + 1);
+        co_return getPDIEnumString(bmcState);
     }
     catch (const sdbusplus::exception_t& e)
     {
@@ -105,10 +119,7 @@ void addNoRedReasons(const rbmc::redundancy::ReasonsForNoRedundancy& reasons,
     if (!reasons.empty())
     {
         std::ranges::for_each(reasons, [&reasonList](const auto& r) {
-            auto shortName =
-                Redundancy::convertReasonForNoRedundancyToString(r);
-            shortName = shortName.substr(shortName.find_last_of('.') + 1);
-            reasonList.push_back(shortName);
+            reasonList.push_back(getPDIEnumString(r));
         });
     }
     else
@@ -172,9 +183,7 @@ sdbusplus::async::task<> getLocalBMCInfo(sdbusplus::async::context& ctx,
                          .path(path.str)
                          .properties();
 
-        auto role = Redundancy::convertRoleToString(props.role);
-        // Strip off the sdbusplus prefix to get the final part, e.g. 'Active'.
-        role = role.substr(role.find_last_of('.') + 1);
+        auto role = getPDIEnumString(props.role);
         output["Role"] = role;
 
         rbmc::ServicesImpl services{ctx};
@@ -247,9 +256,7 @@ sdbusplus::async::task<> getSiblingBMCInfo(sdbusplus::async::context& ctx,
                           .path(path.str)
                           .properties();
 
-        auto role = Redundancy::convertRoleToString(rProps.role);
-        role = role.substr(role.find_last_of('.') + 1);
-        output["Role"] = role;
+        output["Role"] = getPDIEnumString(rProps.role);
 
         if (!extended)
         {
@@ -266,12 +273,9 @@ sdbusplus::async::task<> getSiblingBMCInfo(sdbusplus::async::context& ctx,
                          .path(path.str)
                          .current_bmc_state();
 
-        auto bmcState = BMCState::convertBMCStateToString(state);
-        bmcState = bmcState.substr(bmcState.find_last_of('.') + 1);
-
         output["Redundancy Enabled"] = rProps.redundancy_enabled;
         output["Failovers Allowed"] = rProps.failovers_allowed;
-        output["BMC State"] = bmcState;
+        output["BMC State"] = getPDIEnumString(state);
         output["FW Version Hash"] = fwVersion;
         output["Provisioned"] = true; // TODO
     }

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -133,24 +133,15 @@ void addNoRedReasons(const rbmc::redundancy::ReasonsForNoRedundancy& reasons,
     output["Reasons for no BMC redundancy"] = std::move(reasonList);
 }
 
-void addFONotAllowedReasons(nlohmann::ordered_json& output)
+void addFONotAllowedReason(rbmc::FailoversNotAllowedReason reason,
+                           nlohmann::ordered_json& output)
 {
+    // The output looks better as an array even though there
+    // is only one value.
     nlohmann::json::array_t reasonList;
-    auto reasons =
-        data::read<std::set<std::string>>(data::key::failoversNotAllowedReasons)
-            .value_or(std::set<std::string>());
-    if (!reasons.empty())
-    {
-        std::ranges::for_each(reasons, [&reasonList](auto& reason) {
-            reasonList.push_back(reason);
-        });
-    }
-    else
-    {
-        reasonList.emplace_back("Unknown");
-    }
+    reasonList.emplace_back(getPDIEnumString(reason));
 
-    output["Reasons failovers are not allowed"] = std::move(reasonList);
+    output["Reason failovers are not allowed"] = std::move(reasonList);
 }
 
 void addLastFailoverDetails(const std::filesystem::path& dataPath,
@@ -225,7 +216,7 @@ sdbusplus::async::task<> getLocalBMCInfo(sdbusplus::async::context& ctx,
         if ((role == "Active") && props.redundancy_enabled &&
             !props.failovers_allowed)
         {
-            addFONotAllowedReasons(output);
+            addFONotAllowedReason(props.failovers_not_allowed_reason, output);
         }
 
         if ((role == "Active") && pos.has_value())

--- a/redundant-bmc/src/redundancy.cpp
+++ b/redundant-bmc/src/redundancy.cpp
@@ -83,37 +83,32 @@ ReasonsForNoRedundancy getNoRedundancyReasons(const Input& input)
 namespace fona
 {
 
-FailoversNotAllowedReasons getFailoversNotAllowedReasons(const Input& input)
+FailoversNotAllowedReason getFailoversNotAllowedReason(const Input& input)
 {
     using enum FailoversNotAllowedReason;
-    FailoversNotAllowedReasons reasons;
 
     if (!input.redundancyEnabled)
     {
-        reasons.insert(redundancyDisabled);
-        // No need to look for more reasons
-        return reasons;
+        return NoRedundancy;
     }
 
     if (input.failoverInProgress)
     {
-        reasons.insert(failoverInProgress);
-        // No need to look for more reasons
-        return reasons;
+        return FailoverInProgress;
     }
 
     if (!input.fullSyncComplete)
     {
-        reasons.insert(fullSyncNotComplete);
+        return FullSyncNotComplete;
     }
 
     if ((input.systemState != SystemState::off) &&
         (input.systemState != SystemState::runtime))
     {
-        reasons.insert(systemState);
+        return WrongSystemState;
     }
 
-    return reasons;
+    return None;
 }
 
 std::string getFailoversNotAllowedDescription(FailoversNotAllowedReason reason)
@@ -124,17 +119,20 @@ std::string getFailoversNotAllowedDescription(FailoversNotAllowedReason reason)
 
     switch (reason)
     {
-        case systemState:
+        case WrongSystemState:
             desc = "System state is not off or runtime"s;
             break;
-        case fullSyncNotComplete:
+        case FullSyncNotComplete:
             desc = "A full sync hasn't been completed"s;
             break;
-        case failoverInProgress:
+        case FailoverInProgress:
             desc = "A failover is in progress"s;
             break;
-        case redundancyDisabled:
+        case NoRedundancy:
             desc = "Redundancy is disabled"s;
+            break;
+        case None:
+            desc = "No reason"s;
             break;
     }
     return desc;

--- a/redundant-bmc/src/redundancy.hpp
+++ b/redundant-bmc/src/redundancy.hpp
@@ -14,6 +14,8 @@ using Role =
 
 using ReasonForNoRedundancy = sdbusplus::common::xyz::openbmc_project::state::
     bmc::Redundancy::ReasonForNoRedundancy;
+using FailoversNotAllowedReason = sdbusplus::common::xyz::openbmc_project::
+    state::bmc::Redundancy::FailoversNotAllowedReason;
 
 using BMCState = sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState;
 
@@ -66,24 +68,11 @@ struct Input
 };
 
 /**
- * @brief Reasons why failovers aren't allowed
- */
-enum class FailoversNotAllowedReason
-{
-    redundancyDisabled,
-    fullSyncNotComplete,
-    failoverInProgress,
-    systemState
-};
-
-using FailoversNotAllowedReasons = std::set<FailoversNotAllowedReason>;
-
-/**
- * @brief Returns the reasons that failovers aren't allowed
+ * @brief Returns the reason that failovers aren't allowed
  *
- * @return The reasons.  Empty if there are none.
+ * @return The reason.  None if there isn't any.
  */
-FailoversNotAllowedReasons getFailoversNotAllowedReasons(const Input& input);
+FailoversNotAllowedReason getFailoversNotAllowedReason(const Input& input);
 
 /**
  * @brief Return the string description of the reason

--- a/redundant-bmc/src/redundancy_mgr.cpp
+++ b/redundant-bmc/src/redundancy_mgr.cpp
@@ -13,17 +13,7 @@ RedundancyMgr::RedundancyMgr(sdbusplus::async::context& ctx,
                              Providers& providers, RedundancyInterface& iface) :
     ctx(ctx), providers(providers), redundancyInterface(iface),
     manualDisable(iface.disable_redundancy_override())
-{
-    try
-    {
-        data::remove(data::key::failoversNotAllowedReasons);
-    }
-    catch (const std::exception& e)
-    {
-        lg2::error("Failed removing failoversNotAllowedReasons: {ERROR}",
-                   "ERROR", e);
-    }
-}
+{}
 
 // NOLINTNEXTLINE
 void RedundancyMgr::determineAndSetRedundancy()
@@ -265,42 +255,24 @@ void RedundancyMgr::determineAndSetFailoversAllowed()
         .failoverInProgress = failoverInProgress,
         .systemState = systemState.value_or(SystemState::other)};
 
-    auto notAllowedReasons = fona::getFailoversNotAllowedReasons(input);
+    auto reason = fona::getFailoversNotAllowedReason(input);
 
-    // TODO: Put the reasons on D-Bus. For now, just save the
-    // descriptions in the normal spot for rbmctool.
+    redundancyInterface.failovers_not_allowed_reason(reason);
 
-    std::set<std::string> descs;
-    std::ranges::transform(
-        notAllowedReasons, std::inserter(descs, descs.begin()),
-        [](const auto& reason) {
-            auto desc = fona::getFailoversNotAllowedDescription(reason);
-            lg2::warning("Failovers not allowed because {REASON}", "REASON",
-                         desc);
-            return desc;
-        });
-
-    try
+    if (reason != FailoversNotAllowedReason::None)
     {
-        data::write(data::key::failoversNotAllowedReasons, descs);
-    }
-    catch (const std::exception& e)
-    {
-        lg2::error("Failed saving failovers not allowed descriptions");
-    }
+        lg2::warning("Failovers not allowed because {REASON}", "REASON",
+                     fona::getFailoversNotAllowedDescription(reason));
 
-    if (notAllowedReasons.empty())
+        redundancyInterface.failovers_allowed(false);
+    }
+    else
     {
         if (!redundancyInterface.failovers_allowed())
         {
             lg2::info("Changing failovers to allowed");
             redundancyInterface.failovers_allowed(true);
         }
-    }
-    else
-    {
-        // Already traced above.
-        redundancyInterface.failovers_allowed(false);
     }
 }
 

--- a/redundant-bmc/test/redundancy_test.cpp
+++ b/redundant-bmc/test/redundancy_test.cpp
@@ -158,23 +158,23 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
 TEST(RedundancyTest, FailoversNotAllowedTest)
 {
     namespace fona = rbmc::fona;
-    using enum fona::FailoversNotAllowedReason;
+    using enum rbmc::FailoversNotAllowedReason;
 
-    std::map<rbmc::SystemState, fona::FailoversNotAllowedReasons> testStates{
-        {rbmc::SystemState::off, {}},
-        {rbmc::SystemState::booting, {systemState}},
-        {rbmc::SystemState::runtime, {}},
-        {rbmc::SystemState::other, {systemState}}};
+    std::map<rbmc::SystemState, rbmc::FailoversNotAllowedReason> testStates{
+        {rbmc::SystemState::off, None},
+        {rbmc::SystemState::booting, WrongSystemState},
+        {rbmc::SystemState::runtime, None},
+        {rbmc::SystemState::other, WrongSystemState}};
 
-    for (const auto& [state, expectedReasons] : testStates)
+    for (const auto& [state, expectedReason] : testStates)
     {
         fona::Input input{.redundancyEnabled = true,
                           .fullSyncComplete = true,
                           .failoverInProgress = false,
                           .systemState = state};
 
-        auto reasons = fona::getFailoversNotAllowedReasons(input);
-        EXPECT_EQ(reasons, expectedReasons);
+        auto reason = fona::getFailoversNotAllowedReason(input);
+        EXPECT_EQ(reason, expectedReason);
     }
 
     // Redundancy disabled
@@ -183,10 +183,8 @@ TEST(RedundancyTest, FailoversNotAllowedTest)
                           .fullSyncComplete = true,
                           .failoverInProgress = false,
                           .systemState = rbmc::SystemState::off};
-        auto reasons = fona::getFailoversNotAllowedReasons(input);
-        ASSERT_EQ(reasons.size(), 1);
-        EXPECT_EQ(*reasons.begin(),
-                  fona::FailoversNotAllowedReason::redundancyDisabled);
+        auto reason = fona::getFailoversNotAllowedReason(input);
+        EXPECT_EQ(reason, NoRedundancy);
     }
 
     // Full sync not complete
@@ -195,10 +193,8 @@ TEST(RedundancyTest, FailoversNotAllowedTest)
                           .fullSyncComplete = false,
                           .failoverInProgress = false,
                           .systemState = rbmc::SystemState::off};
-        auto reasons = fona::getFailoversNotAllowedReasons(input);
-        ASSERT_EQ(reasons.size(), 1);
-        EXPECT_EQ(*reasons.begin(),
-                  fona::FailoversNotAllowedReason::fullSyncNotComplete);
+        auto reason = fona::getFailoversNotAllowedReason(input);
+        EXPECT_EQ(reason, FullSyncNotComplete);
     }
 
     // Failover in progress
@@ -207,19 +203,17 @@ TEST(RedundancyTest, FailoversNotAllowedTest)
                           .fullSyncComplete = true,
                           .failoverInProgress = true,
                           .systemState = rbmc::SystemState::off};
-        auto reasons = fona::getFailoversNotAllowedReasons(input);
-        ASSERT_EQ(reasons.size(), 1);
-        EXPECT_EQ(*reasons.begin(),
-                  fona::FailoversNotAllowedReason::failoverInProgress);
+        auto reason = fona::getFailoversNotAllowedReason(input);
+        EXPECT_EQ(reason, FailoverInProgress);
     }
 }
 
 TEST(RedundancyTest, GetFailoversNotAllowedDescTest)
 {
     namespace fona = rbmc::fona;
+    using enum rbmc::FailoversNotAllowedReason;
 
-    EXPECT_EQ(fona::getFailoversNotAllowedDescription(
-                  fona::FailoversNotAllowedReason::systemState),
+    EXPECT_EQ(fona::getFailoversNotAllowedDescription(WrongSystemState),
               "System state is not off or runtime");
 }
 


### PR DESCRIPTION
A property to hold the reason that failovers aren't allowed is now on
D-Bus, so fill it in.  It just holds a single value as opposed to
before, because in reality that is all that is useful anyway.

The other commit just simplified rbmc_tool.cpp a bit.