### PR TITLE
RBMC: Don't start already started targets

### DIFF
--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -527,15 +527,33 @@ sdbusplus::async::task<> ServicesImpl::startUnit(
     const std::string& unitName, std::chrono::seconds timeout) const
 {
     using namespace std::chrono_literals;
+
+    auto currentState = co_await getUnitState(unitName);
+    if (currentState == "active")
+    {
+        lg2::info("Unit {UNIT} is already active, not starting again", "UNIT",
+                  unitName);
+        co_return;
+    }
+
     constexpr auto systemd = sdbusplus::async::proxy()
                                  .service(service::systemd)
                                  .path(object_path::systemd)
                                  .interface(interface::systemdMgr);
 
-    lg2::info("Starting unit {UNIT}", "UNIT", unitName);
+    // Don't need to start the unit if activating, but still
+    // need to wait for it to complete.
+    if (currentState != "activating")
+    {
+        lg2::info("Starting unit {UNIT}", "UNIT", unitName);
 
-    co_await systemd.call<sdbusplus::message::object_path>(
-        ctx, "StartUnit", unitName, std::string{"replace"});
+        co_await systemd.call<sdbusplus::message::object_path>(
+            ctx, "StartUnit", unitName, std::string{"replace"});
+    }
+    else
+    {
+        lg2::info("Unit is already activating");
+    }
 
     std::string state;
     auto end = std::chrono::steady_clock::now() + timeout;


### PR DESCRIPTION
Starting a unit that is already active will still run all of the services that depend on it which isn't desired, so before starting the active or passive targets check if they are already active and don't do anything if they are.

The only case this comes into play is if this service is restarted after the target has already been started.

Tested:
- First time: service still starts
- Already running: see:

```
Unit obmc-bmc-active.target is already active, not starting again
```

Change-Id: Ie5002d21e31d481f6486ab7eda005a1c8a6277fd