### PR TITLE
RBMC: Keep track of in-progress waits

### DIFF
--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -4,6 +4,7 @@
 #include "redundancy_mgr.hpp"
 #include "role_handler.hpp"
 #include "timer.hpp"
+#include "wait_tracker.hpp"
 
 namespace rbmc
 {
@@ -32,7 +33,7 @@ class ActiveRoleHandler : public RoleHandler
                       RedundancyInterface& iface) :
         RoleHandler(ctx, providers, iface), redMgr(ctx, providers, iface),
         siblingHealthTimer(
-            ctx,
+            ctx, Wait::siblingHealth,
             std::bind_front(&ActiveRoleHandler::siblingHealthCritical, this))
     {}
 

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -6,6 +6,7 @@
 #include "errors.hpp"
 #include "passive_role_handler.hpp"
 #include "persistent_data.hpp"
+#include "wait_tracker.hpp"
 
 #include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
@@ -49,6 +50,8 @@ Manager::Manager(sdbusplus::async::context& ctx,
         lg2::error("Failed trying to obtain previous role error: {ERROR}",
                    "ERROR", e);
     }
+
+    removeAllTrackedWaits();
 
     // emit the Failover interfaces added signal
     emit_added();

--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -30,6 +30,7 @@ executable(
     'sibling_impl.cpp',
     'sibling_reset_impl.cpp',
     'sync_interface_impl.cpp',
+    'wait_tracker.cpp',
     dependencies: rbmc_deps,
     install: true,
     install_dir: execinstalldir,
@@ -41,6 +42,7 @@ executable(
     'rbmc_tool.cpp',
     'services_impl.cpp',
     'sibling_reset_impl.cpp',
+    'wait_tracker.cpp',
     dependencies: [rbmc_deps, CLI11],
     install: true,
 )

--- a/redundant-bmc/src/persistent_data.cpp
+++ b/redundant-bmc/src/persistent_data.cpp
@@ -71,8 +71,9 @@ static std::string makeTimestampString(const time_t& timestamp)
 
 } // namespace util
 
-void remove(std::string_view name, const std::filesystem::path& path)
+void remove(std::string_view name)
 {
+    auto path = dataFile();
     auto json = util::readFile(path);
     if (!json)
     {

--- a/redundant-bmc/src/persistent_data.hpp
+++ b/redundant-bmc/src/persistent_data.hpp
@@ -10,8 +10,34 @@
 namespace data
 {
 
-const std::filesystem::path dataFile{
-    "/var/lib/phosphor-state-manager/redundant-bmc/data.json"};
+// Default path for persistent data directory
+inline std::filesystem::path dataDirPath{
+    "/var/lib/phosphor-state-manager/redundant-bmc"};
+
+constexpr auto dataFileName = "data.json";
+
+/**
+ * @brief Get the full path to the data file
+ *
+ * @return The full path combining dataDirPath and dataFileName
+ */
+inline std::filesystem::path dataFile()
+{
+    return dataDirPath / dataFileName;
+}
+
+/**
+ * @brief Set the persistent data directory path
+ *
+ * This should be called early in initialization to set the directory
+ * where persistent data files will be stored.
+ *
+ * @param[in] dirPath - The directory path for persistent data
+ */
+inline void setDataDirectory(const std::filesystem::path& dirPath)
+{
+    dataDirPath = dirPath;
+}
 
 using FailoverLogs = std::vector<std::pair<std::string, std::string>>;
 
@@ -62,9 +88,9 @@ void writeFile(const nlohmann::json& json, const std::filesystem::path& path);
  * @param[in] value - The value to save
  */
 template <typename T>
-void write(std::string_view name, const T& value,
-           const std::filesystem::path& path = dataFile)
+void write(std::string_view name, const T& value)
 {
+    auto path = dataFile();
     auto json = util::readFile(path).value_or(nlohmann::json::object());
     if constexpr (std::is_enum_v<T>)
     {
@@ -85,16 +111,14 @@ void write(std::string_view name, const T& value,
  *
  * @tparam T - The data type
  * @param[in] name - The key the value is saved under
- * @param[in] path - The path to the file
  *
  * @return optional<T> - The value, or std::nullopt if the file or
  *                       key isn't present.
  */
 template <typename T>
-std::optional<T> read(std::string_view name,
-                      const std::filesystem::path& path = dataFile)
+std::optional<T> read(std::string_view name)
 {
-    auto json = util::readFile(path);
+    auto json = util::readFile(dataFile());
     if (!json)
     {
         return std::nullopt;
@@ -121,11 +145,8 @@ std::optional<T> read(std::string_view name,
  * @brief Remove an entry from the file
  *
  * @param[in] name - The key for the entry to remove
- *
- * @param[in] path - The path to the file
  */
-void remove(std::string_view name,
-            const std::filesystem::path& path = dataFile);
+void remove(std::string_view name);
 
 /**
  * @brief Log the requester and timestamp of a failover.

--- a/redundant-bmc/src/persistent_data.hpp
+++ b/redundant-bmc/src/persistent_data.hpp
@@ -53,6 +53,7 @@ constexpr auto noRedReasons = "NoRedundancyReasons";
 constexpr auto disableRed = "DisableRedundancy";
 constexpr auto redundancyOffAtRuntime = "RedundancyOffAtRuntime";
 constexpr auto failoverInProgress = "FailoverInProgress";
+constexpr auto trackedWaits = "TrackedWaits";
 } // namespace key
 
 namespace util

--- a/redundant-bmc/src/rbmc_manager_main.cpp
+++ b/redundant-bmc/src/rbmc_manager_main.cpp
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include "manager.hpp"
+#include "persistent_data.hpp"
 #include "providers_impl.hpp"
 
 #include <sdbusplus/async/context.hpp>
@@ -14,6 +15,8 @@ int main()
 
     std::unique_ptr<rbmc::Providers> providers =
         std::make_unique<rbmc::ProvidersImpl>(ctx);
+
+    data::setDataDirectory(providers->getServices().getPersistentDataPath());
 
     rbmc::Manager manager{ctx, std::move(providers)};
 

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -5,6 +5,7 @@
 #include "services_impl.hpp"
 #include "sibling_reset_impl.hpp"
 #include "types.hpp"
+#include "wait_tracker.hpp"
 
 #include <CLI/CLI.hpp>
 #include <nlohmann/json.hpp>
@@ -159,6 +160,17 @@ void addLastFailoverDetails(const std::filesystem::path& dataPath,
     }
 }
 
+void addTrackedWaits(nlohmann::ordered_json& output)
+{
+    auto waits = rbmc::getTrackedWaits();
+    if (waits.empty())
+    {
+        return;
+    }
+
+    output["Current Waits"] = std::move(waits);
+}
+
 // NOLINTNEXTLINE
 sdbusplus::async::task<> getLocalBMCInfo(sdbusplus::async::context& ctx,
                                          bool extended,
@@ -219,6 +231,8 @@ sdbusplus::async::task<> getLocalBMCInfo(sdbusplus::async::context& ctx,
         {
             addFONotAllowedReason(props.failovers_not_allowed_reason, output);
         }
+
+        addTrackedWaits(output);
 
         if ((role == "Active") && pos.has_value())
         {

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 #include "services_impl.hpp"
 
+#include "wait_tracker.hpp"
+
 #include <openssl/evp.h>
 
 #include <phosphor-logging/lg2.hpp>
@@ -540,6 +542,8 @@ sdbusplus::async::task<> ServicesImpl::startUnit(
     std::string state;
     auto end = std::chrono::steady_clock::now() + timeout;
 
+    ScopeWaitTracker wait{Wait::startUnit};
+
     while ((state != "active") && (state != "failed"))
     {
         if (std::chrono::steady_clock::now() > end)
@@ -650,6 +654,9 @@ auto ServicesImpl::getBMCState() const -> sdbusplus::async::task<
 sdbusplus::async::task<> ServicesImpl::doFailoverImminentDelay() const
 {
     lg2::info("Delaying for 10s for failover imminent notification");
+
+    ScopeWaitTracker wait{Wait::failoverImminent};
+
     // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
     co_await sdbusplus::async::sleep_for(ctx, std::chrono::seconds{10});
 }
@@ -674,6 +681,8 @@ sdbusplus::async::task<> ServicesImpl::waitForSystemInventoryPath()
     using namespace std::chrono_literals;
     auto end = std::chrono::steady_clock::now() + 3min;
     bool traced = false;
+
+    ScopeWaitTracker wait{Wait::systemInventoryPath};
 
     while (std::chrono::steady_clock::now() < end)
     {
@@ -718,6 +727,8 @@ sdbusplus::async::task<bool> ServicesImpl::checkSystemInventoryStatus()
 
     using namespace std::chrono_literals;
     auto end = std::chrono::steady_clock::now() + 3min;
+
+    ScopeWaitTracker wait{Wait::systemInventoryStatus};
 
     while (std::chrono::steady_clock::now() < end)
     {

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 #include "sibling_impl.hpp"
 
+#include "wait_tracker.hpp"
+
 #include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/ObjectMapper/client.hpp>
 #include <xyz/openbmc_project/Software/Version/common.hpp>
@@ -396,6 +398,8 @@ sdbusplus::async::task<> SiblingImpl::waitForSiblingUp()
     std::chrono::minutes timeout{6};
     auto waiting = false;
 
+    ScopeWaitTracker wait{Wait::siblingAlive};
+
     while (!alive() && ((std::chrono::steady_clock::now() - start) < timeout))
     {
         if (!waiting)
@@ -430,6 +434,8 @@ sdbusplus::async::task<> SiblingImpl::waitForSiblingRole()
 
     auto start = std::chrono::steady_clock::now();
 
+    ScopeWaitTracker wait{Wait::siblingRole};
+
     while (noRole() && ((std::chrono::steady_clock::now() - start) < timeout))
     {
         if (!waiting)
@@ -461,6 +467,8 @@ sdbusplus::async::task<> SiblingImpl::waitForBMCSteadyState() const
     auto steadyState = [](BMCState state) {
         return (state == BMCState::Ready) || (state == BMCState::Quiesced);
     };
+
+    ScopeWaitTracker wait{Wait::siblingBMCSteadyState};
 
     while (!steadyState(bmcState.state) &&
            ((std::chrono::steady_clock::now() - start) < timeout))

--- a/redundant-bmc/src/sync_interface_impl.cpp
+++ b/redundant-bmc/src/sync_interface_impl.cpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#include "wait_tracker.hpp"
+
 #include <phosphor-logging/lg2.hpp>
 #include <sync_interface_impl.hpp>
 #include <xyz/openbmc_project/ObjectMapper/client.hpp>
@@ -51,6 +53,8 @@ sdbusplus::async::task<bool> SyncInterfaceImpl::doFullSync()
                                           SyncBMCData::interface));
 
         status = co_await sync.full_sync_status();
+
+        ScopeWaitTracker wait{Wait::fullSync};
 
         while ((status == SyncStatus::FullSyncInProgress) &&
                !ctx.stop_requested())

--- a/redundant-bmc/src/timer.hpp
+++ b/redundant-bmc/src/timer.hpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "wait_tracker.hpp"
+
 #include <sdbusplus/async.hpp>
 
 namespace rbmc
@@ -20,10 +22,12 @@ class Timer :
      * @brief Constructor
      *
      * @param[in] ctx - The async context object
+     * @param[in] wait - The wait type for this timer.
      * @param[in] callback - Function to call on expiration
      */
-    Timer(sdbusplus::async::context& ctx, std::function<void()>&& callback) :
-        context_ref(ctx), callback(std::move(callback))
+    Timer(sdbusplus::async::context& ctx, Wait wait,
+          std::function<void()>&& callback) :
+        context_ref(ctx), wait(wait), callback(std::move(callback))
     {}
 
     /**
@@ -34,6 +38,7 @@ class Timer :
                        [[maybe_unused]] uint64_t usec, void* userdata)
     {
         Timer* t = static_cast<Timer*>(userdata);
+        removeTrackedWait(t->wait);
         t->callback();
         t->source.reset();
         return 0;
@@ -46,6 +51,7 @@ class Timer :
      */
     void start(const std::chrono::microseconds& timeout)
     {
+        addTrackedWait(wait);
         source.reset();
 
         auto s = get_event_loop(ctx).add_oneshot_timer(Timer::handler, this,
@@ -58,6 +64,7 @@ class Timer :
      */
     void stop()
     {
+        removeTrackedWait(wait);
         source.reset();
     }
 
@@ -72,6 +79,11 @@ class Timer :
       private:
         sdbusplus::event::source source;
     };
+
+    /**
+     * The wait type for this timer.
+     */
+    Wait wait;
 
     /**
      * @brief Function to run on timeout

--- a/redundant-bmc/src/wait_tracker.cpp
+++ b/redundant-bmc/src/wait_tracker.cpp
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "wait_tracker.hpp"
+
+#include "persistent_data.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+#include <algorithm>
+
+namespace rbmc
+{
+
+std::string waitToString(Wait wait)
+{
+    switch (wait)
+    {
+        case Wait::startUnit:
+            return "StartUnit";
+        case Wait::systemInventoryPath:
+            return "SystemInventoryPath";
+        case Wait::systemInventoryStatus:
+            return "SystemInventoryStatus";
+        case Wait::peerConnection:
+            return "PeerConnection";
+        case Wait::siblingAlive:
+            return "SiblingAlive";
+        case Wait::siblingRole:
+            return "SiblingRole";
+        case Wait::siblingBMCSteadyState:
+            return "SiblingBMCSteadyState";
+        case Wait::siblingHealth:
+            return "SiblingHealth";
+        case Wait::fullSync:
+            return "FullSync";
+        case Wait::failoverImminent:
+            return "FailoverImminent";
+    }
+    return "Unknown";
+}
+
+std::vector<std::string> getTrackedWaits()
+{
+    try
+    {
+        using U = std::underlying_type_t<Wait>;
+        auto waits = data::read<std::vector<U>>(data::key::trackedWaits)
+                         .value_or(std::vector<U>{});
+
+        std::vector<std::string> result;
+        result.reserve(waits.size());
+        for (auto w : waits)
+        {
+            result.push_back(waitToString(static_cast<Wait>(w)));
+        }
+        return result;
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Error reading tracked waits: {ERROR}", "ERROR", e);
+    }
+    return {};
+}
+
+void addTrackedWait(Wait wait)
+{
+    try
+    {
+        using U = std::underlying_type_t<Wait>;
+        auto waits = data::read<std::vector<U>>(data::key::trackedWaits)
+                         .value_or(std::vector<U>{});
+
+        if (!std::ranges::contains(waits, std::to_underlying(wait)))
+        {
+            waits.push_back(std::to_underlying(wait));
+            data::write(data::key::trackedWaits, waits);
+        }
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Error adding tracked wait: {ERROR}", "ERROR", e);
+    }
+}
+
+void removeTrackedWait(Wait wait)
+{
+    try
+    {
+        using U = std::underlying_type_t<Wait>;
+        auto waits = data::read<std::vector<U>>(data::key::trackedWaits)
+                         .value_or(std::vector<U>{});
+
+        if (std::erase(waits, std::to_underlying(wait)) == 0)
+        {
+            return;
+        }
+
+        if (waits.empty())
+        {
+            data::remove(data::key::trackedWaits);
+        }
+        else
+        {
+            data::write(data::key::trackedWaits, waits);
+        }
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Error removing tracked wait: {ERROR}", "ERROR", e);
+    }
+}
+
+void removeAllTrackedWaits()
+{
+    try
+    {
+        data::remove(data::key::trackedWaits);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Error removing all tracked waits: {ERROR}", "ERROR", e);
+    }
+}
+
+} // namespace rbmc

--- a/redundant-bmc/src/wait_tracker.hpp
+++ b/redundant-bmc/src/wait_tracker.hpp
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace rbmc
+{
+
+/**
+ * These APIs are used for saving what the code is currently waiting for
+ * so that things like rbmctool can display it.
+ */
+
+enum class Wait
+{
+    startUnit,
+    systemInventoryPath,
+    systemInventoryStatus,
+    peerConnection,
+    siblingAlive,
+    siblingRole,
+    siblingBMCSteadyState,
+    siblingHealth,
+    fullSync,
+    failoverImminent
+};
+
+/**
+ * @brief Convert a Wait enum value to its string name.
+ *
+ * @param[in] wait - The Wait enum value
+ * @return The string name with the first letter uppercased, e.g. "StartUnit"
+ */
+std::string waitToString(Wait wait);
+
+/**
+ * @brief Returns the currently tracked waits as a vector of strings.
+ *
+ * e.g. "StartUnit", "SiblingAlive".
+ *
+ * @return vector of tracked wait names, empty if none are tracked.
+ */
+std::vector<std::string> getTrackedWaits();
+
+/**
+ * @brief Add a wait to the tracked waits list.
+ *
+ * If the wait is already in the list, it will not be added again.
+ *
+ * @param[in] wait - The wait to add
+ */
+void addTrackedWait(Wait wait);
+
+/**
+ * @brief Remove a wait from the tracked waits list.
+ *
+ * If the wait is not in the list, nothing happens.
+ *
+ * @param[in] wait - The wait to remove
+ */
+void removeTrackedWait(Wait wait);
+
+/**
+ * @brief Remove all tracked waits.
+ *
+ * Clears the entire tracked waits list from persistent storage.
+ * If there are no tracked waits, nothing happens.
+ */
+void removeAllTrackedWaits();
+
+/**
+ * @class ScopeWaitTracker
+ *
+ * RAII class that adds a wait on construction and removes it on destruction.
+ */
+class ScopeWaitTracker
+{
+  public:
+    ScopeWaitTracker(const ScopeWaitTracker&) = delete;
+    ScopeWaitTracker& operator=(const ScopeWaitTracker&) = delete;
+    ScopeWaitTracker(ScopeWaitTracker&&) = delete;
+    ScopeWaitTracker& operator=(ScopeWaitTracker&&) = delete;
+
+    ScopeWaitTracker(Wait w) : wait(w)
+    {
+        addTrackedWait(wait);
+    }
+
+    ~ScopeWaitTracker()
+    {
+        removeTrackedWait(wait);
+    }
+
+  private:
+    Wait wait;
+};
+
+} // namespace rbmc

--- a/redundant-bmc/test/meson.build
+++ b/redundant-bmc/test/meson.build
@@ -8,10 +8,12 @@ test(
         'persistent_data_test.cpp',
         'redundancy_test.cpp',
         'role_determination_test.cpp',
+        'wait_tracker_test.cpp',
         '../src/error_data.cpp',
         '../src/persistent_data.cpp',
         '../src/redundancy.cpp',
         '../src/role_determination.cpp',
+        '../src/wait_tracker.cpp',
         dependencies: [
             gtest,
             nlohmann_json_dep,

--- a/redundant-bmc/test/meson.build
+++ b/redundant-bmc/test/meson.build
@@ -19,6 +19,6 @@ test(
             phosphordbusinterfaces,
             phosphorlogging,
         ],
-        include_directories: '../src',
+        include_directories: ['../src', '.'],
     ),
 )

--- a/redundant-bmc/test/persistent_data_test.cpp
+++ b/redundant-bmc/test/persistent_data_test.cpp
@@ -1,4 +1,5 @@
 #include "persistent_data.hpp"
+#include "persistent_data_test_fixture.hpp"
 #include "role_determination.hpp"
 
 #include <fstream>
@@ -6,85 +7,62 @@
 #include <gtest/gtest.h>
 
 using namespace rbmc;
+using namespace rbmc::test;
 using namespace role_determination;
 
-class PersistentDataTest : public ::testing::Test
-{
-  protected:
-    static void SetUpTestCase()
-    {
-        char d[] = "/tmp/datatestXXXXXX";
-        dataDir = mkdtemp(d);
-        saveFile = dataDir / "save.json";
-    }
-
-    static void TearDownTestCase()
-    {
-        std::filesystem::remove_all(dataDir);
-    }
-
-    static std::filesystem::path saveFile;
-    static std::filesystem::path dataDir;
-};
-
-std::filesystem::path PersistentDataTest::saveFile;
-std::filesystem::path PersistentDataTest::dataDir;
+class PersistentDataTest : public PersistentDataTestFixture
+{};
 
 TEST_F(PersistentDataTest, WriteAndReadTest)
 {
     // Write
-    data::write("Role", Role::Active, saveFile);
-    data::write("Bool", true, saveFile);
-    data::write("String", std::string{"String"}, saveFile);
-    data::write("Uint32", uint32_t{0xAABBCCDD}, saveFile);
+    data::write("Role", Role::Active);
+    data::write("Bool", true);
+    data::write("String", std::string{"String"});
+    data::write("Uint32", uint32_t{0xAABBCCDD});
 
     // Read back
-    EXPECT_EQ(data::read<Role>("Role", saveFile), Role::Active);
-    EXPECT_EQ(data::read<bool>("Bool", saveFile), true);
-    EXPECT_EQ(data::read<std::string>("String", saveFile),
-              std::string{"String"});
-    EXPECT_EQ(data::read<uint32_t>("Uint32", saveFile), 0xAABBCCDD);
+    EXPECT_EQ(data::read<Role>("Role"), Role::Active);
+    EXPECT_EQ(data::read<bool>("Bool"), true);
+    EXPECT_EQ(data::read<std::string>("String"), std::string{"String"});
+    EXPECT_EQ(data::read<uint32_t>("Uint32"), 0xAABBCCDD);
 
     // Write new values
-    data::write("Role", Role::Passive, saveFile);
-    data::write("Bool", false, saveFile);
-    data::write("String", std::string{"New"}, saveFile);
-    data::write("Uint32", uint32_t{0x12345678}, saveFile);
+    data::write("Role", Role::Passive);
+    data::write("Bool", false);
+    data::write("String", std::string{"New"});
+    data::write("Uint32", uint32_t{0x12345678});
 
     // Read back the new values
-    EXPECT_EQ(data::read<Role>("Role", saveFile), Role::Passive);
-    EXPECT_EQ(data::read<bool>("Bool", saveFile), false);
-    EXPECT_EQ(data::read<std::string>("String", saveFile), std::string{"New"});
-    EXPECT_EQ(data::read<uint32_t>("Uint32", saveFile), 0x12345678);
+    EXPECT_EQ(data::read<Role>("Role"), Role::Passive);
+    EXPECT_EQ(data::read<bool>("Bool"), false);
+    EXPECT_EQ(data::read<std::string>("String"), std::string{"New"});
+    EXPECT_EQ(data::read<uint32_t>("Uint32"), 0x12345678);
 
     // Some different types - write
-    data::write("EmptyString", std::string{}, saveFile);
-    data::write("VectorOfStrings", std::vector<std::string>{"a", "b"},
-                saveFile);
-    data::write("EmptyVector", std::vector<std::string>{}, saveFile);
-    data::write("Map", std::map<int, std::string>{{1, "one"}, {2, "two"}},
-                saveFile);
-    data::write("EmptyMap", std::map<int, std::string>{}, saveFile);
+    data::write("EmptyString", std::string{});
+    data::write("VectorOfStrings", std::vector<std::string>{"a", "b"});
+    data::write("EmptyVector", std::vector<std::string>{});
+    data::write("Map", std::map<int, std::string>{{1, "one"}, {2, "two"}});
+    data::write("EmptyMap", std::map<int, std::string>{});
 
     // Some different types - read back
-    EXPECT_EQ(data::read<std::string>("EmptyString", saveFile), std::string{});
-    EXPECT_EQ(data::read<std::vector<std::string>>("VectorOfStrings", saveFile),
+    EXPECT_EQ(data::read<std::string>("EmptyString"), std::string{});
+    EXPECT_EQ(data::read<std::vector<std::string>>("VectorOfStrings"),
               (std::vector<std::string>{"a", "b"}));
-    EXPECT_EQ(data::read<std::vector<std::string>>("EmptyVector", saveFile),
+    EXPECT_EQ(data::read<std::vector<std::string>>("EmptyVector"),
               (std::vector<std::string>{}));
 
-    EXPECT_EQ((data::read<std::map<int, std::string>>("Map", saveFile)),
+    EXPECT_EQ((data::read<std::map<int, std::string>>("Map")),
               (std::map<int, std::string>{{1, "one"}, {2, "two"}}));
-    EXPECT_EQ((data::read<std::map<int, std::string>>("EmptyMap", saveFile)),
+    EXPECT_EQ((data::read<std::map<int, std::string>>("EmptyMap")),
               (std::map<int, std::string>{}));
 
     // Key doesn't exist
-    EXPECT_EQ(data::read<Role>("Blah", saveFile), std::nullopt);
-
-    // File doesn't exist
-    EXPECT_EQ(data::read<Role>("Role", "/blah/blah"), std::nullopt);
+    EXPECT_EQ(data::read<Role>("Blah"), std::nullopt);
 
     // Invalid JSON
+    auto saveFile = data::dataFile();
     std::filesystem::remove(saveFile);
     std::ofstream file{saveFile};
     const char* data = R"(
@@ -96,30 +74,30 @@ TEST_F(PersistentDataTest, WriteAndReadTest)
     file << data;
     file.close();
 
-    EXPECT_EQ(data::read<Role>("Role", saveFile), std::nullopt);
+    EXPECT_EQ(data::read<Role>("Role"), std::nullopt);
 }
 
 TEST_F(PersistentDataTest, RemoveTest)
 {
     // Write three
-    data::write("Role", Role::Active, saveFile);
-    data::write("Bool", true, saveFile);
-    data::write("String", std::string{"String"}, saveFile);
+    data::write("Role", Role::Active);
+    data::write("Bool", true);
+    data::write("String", std::string{"String"});
 
     // Remove the last one
-    data::remove("String", saveFile);
-    EXPECT_EQ(data::read<std::string>("String", saveFile), std::nullopt);
+    data::remove("String");
+    EXPECT_EQ(data::read<std::string>("String"), std::nullopt);
 
     // Make sure other ones still there
-    EXPECT_EQ(data::read<Role>("Role", saveFile), Role::Active);
-    EXPECT_EQ(data::read<bool>("Bool", saveFile), true);
+    EXPECT_EQ(data::read<Role>("Role"), Role::Active);
+    EXPECT_EQ(data::read<bool>("Bool"), true);
 
     // now remove remaining ones
-    data::remove("Role", saveFile);
-    EXPECT_EQ(data::read<Role>("Role", saveFile), std::nullopt);
+    data::remove("Role");
+    EXPECT_EQ(data::read<Role>("Role"), std::nullopt);
 
-    data::remove("Bool", saveFile);
-    EXPECT_EQ(data::read<bool>("Bool", saveFile), std::nullopt);
+    data::remove("Bool");
+    EXPECT_EQ(data::read<bool>("Bool"), std::nullopt);
 
     // Not found
     data::remove("Blah");

--- a/redundant-bmc/test/persistent_data_test_fixture.hpp
+++ b/redundant-bmc/test/persistent_data_test_fixture.hpp
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "persistent_data.hpp"
+
+#include <filesystem>
+
+#include <gtest/gtest.h>
+
+namespace rbmc::test
+{
+
+/**
+ * @class PersistentDataTestFixture
+ *
+ * Test fixture to manage the directory used to save
+ * persistent data in testcases.
+ *
+ * Tests that need persistent data functionality should
+ * inherit from this.
+ */
+class PersistentDataTestFixture : public ::testing::Test
+{
+  protected:
+    PersistentDataTestFixture()
+    {
+        char tempDir[] = "/tmp/rbmc_data_test_XXXXXX";
+        dataDir = mkdtemp(tempDir);
+
+        // Set the data directory for the data namespace
+        data::setDataDirectory(dataDir);
+    }
+
+    ~PersistentDataTestFixture() override
+    {
+        if (!dataDir.empty())
+        {
+            std::filesystem::remove_all(dataDir);
+        }
+    }
+
+    std::filesystem::path dataDir;
+};
+
+} // namespace rbmc::test

--- a/redundant-bmc/test/wait_tracker_test.cpp
+++ b/redundant-bmc/test/wait_tracker_test.cpp
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "persistent_data_test_fixture.hpp"
+#include "wait_tracker.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace rbmc;
+using namespace rbmc::test;
+
+class WaitTrackerTest : public PersistentDataTestFixture
+{};
+
+// Helper to read the raw wait list from persistent data
+static std::vector<std::underlying_type_t<Wait>> readWaits()
+{
+    using U = std::underlying_type_t<Wait>;
+    return data::read<std::vector<U>>(data::key::trackedWaits)
+        .value_or(std::vector<U>{});
+}
+
+TEST_F(WaitTrackerTest, AddSingleWait)
+{
+    addTrackedWait(Wait::startUnit);
+
+    auto waits = readWaits();
+    ASSERT_EQ(waits.size(), 1);
+    EXPECT_EQ(waits[0], std::to_underlying(Wait::startUnit));
+}
+
+TEST_F(WaitTrackerTest, AddMultipleWaits)
+{
+    addTrackedWait(Wait::startUnit);
+    addTrackedWait(Wait::siblingAlive);
+    addTrackedWait(Wait::fullSync);
+
+    auto waits = readWaits();
+    ASSERT_EQ(waits.size(), 3);
+    EXPECT_TRUE(
+        std::ranges::contains(waits, std::to_underlying(Wait::startUnit)));
+    EXPECT_TRUE(
+        std::ranges::contains(waits, std::to_underlying(Wait::siblingAlive)));
+    EXPECT_TRUE(
+        std::ranges::contains(waits, std::to_underlying(Wait::fullSync)));
+}
+
+TEST_F(WaitTrackerTest, AddDuplicateWait)
+{
+    addTrackedWait(Wait::peerConnection);
+    addTrackedWait(Wait::peerConnection);
+
+    auto waits = readWaits();
+    EXPECT_EQ(waits.size(), 1);
+}
+
+TEST_F(WaitTrackerTest, RemoveWait)
+{
+    addTrackedWait(Wait::siblingRole);
+    addTrackedWait(Wait::siblingBMCSteadyState);
+
+    removeTrackedWait(Wait::siblingRole);
+
+    auto waits = readWaits();
+    ASSERT_EQ(waits.size(), 1);
+    EXPECT_EQ(waits[0], std::to_underlying(Wait::siblingBMCSteadyState));
+}
+
+TEST_F(WaitTrackerTest, RemoveLastWait)
+{
+    addTrackedWait(Wait::systemInventoryPath);
+    removeTrackedWait(Wait::systemInventoryPath);
+
+    // Key should be gone entirely, not an empty array
+    EXPECT_EQ(data::read<std::vector<std::underlying_type_t<Wait>>>(
+                  data::key::trackedWaits),
+              std::nullopt);
+}
+
+TEST_F(WaitTrackerTest, RemoveNonExistentWait)
+{
+    EXPECT_NO_THROW(removeTrackedWait(Wait::fullSync));
+
+    addTrackedWait(Wait::startUnit);
+    EXPECT_NO_THROW(removeTrackedWait(Wait::fullSync));
+
+    auto waits = readWaits();
+    EXPECT_EQ(waits.size(), 1);
+}
+
+TEST_F(WaitTrackerTest, ScopeWaitTrackerAddsOnConstruct)
+{
+    {
+        ScopeWaitTracker swt{Wait::siblingAlive};
+
+        auto waits = readWaits();
+        ASSERT_EQ(waits.size(), 1);
+        EXPECT_EQ(waits[0], std::to_underlying(Wait::siblingAlive));
+    }
+}
+
+TEST_F(WaitTrackerTest, ScopeWaitTrackerRemovesOnDestruct)
+{
+    {
+        ScopeWaitTracker swt{Wait::siblingAlive};
+    }
+
+    // After going out of scope, the key should be gone
+    EXPECT_EQ(data::read<std::vector<std::underlying_type_t<Wait>>>(
+                  data::key::trackedWaits),
+              std::nullopt);
+}
+
+TEST_F(WaitTrackerTest, ScopeWaitTrackerMultipleScopes)
+{
+    {
+        ScopeWaitTracker outer{Wait::peerConnection};
+
+        auto waits = readWaits();
+        ASSERT_EQ(waits.size(), 1);
+
+        {
+            ScopeWaitTracker inner{Wait::fullSync};
+
+            waits = readWaits();
+            ASSERT_EQ(waits.size(), 2);
+            EXPECT_TRUE(std::ranges::contains(
+                waits, std::to_underlying(Wait::peerConnection)));
+            EXPECT_TRUE(std::ranges::contains(
+                waits, std::to_underlying(Wait::fullSync)));
+        }
+
+        // inner gone, outer still present
+        waits = readWaits();
+        ASSERT_EQ(waits.size(), 1);
+        EXPECT_EQ(waits[0], std::to_underlying(Wait::peerConnection));
+    }
+
+    // Both gone
+    EXPECT_EQ(data::read<std::vector<std::underlying_type_t<Wait>>>(
+                  data::key::trackedWaits),
+              std::nullopt);
+}
+
+TEST_F(WaitTrackerTest, GetTrackedWaitsAsStrings)
+{
+    // No waits - should return empty vector
+    EXPECT_TRUE(getTrackedWaits().empty());
+
+    addTrackedWait(Wait::startUnit);
+    addTrackedWait(Wait::siblingAlive);
+    addTrackedWait(Wait::fullSync);
+
+    auto waits = getTrackedWaits();
+    ASSERT_EQ(waits.size(), 3);
+    EXPECT_TRUE(std::ranges::contains(waits, "StartUnit"));
+    EXPECT_TRUE(std::ranges::contains(waits, "SiblingAlive"));
+    EXPECT_TRUE(std::ranges::contains(waits, "FullSync"));
+
+    // Remove one and verify it's gone from the string list
+    removeTrackedWait(Wait::siblingAlive);
+    waits = getTrackedWaits();
+    ASSERT_EQ(waits.size(), 2);
+    EXPECT_FALSE(std::ranges::contains(waits, "SiblingAlive"));
+    EXPECT_TRUE(std::ranges::contains(waits, "StartUnit"));
+    EXPECT_TRUE(std::ranges::contains(waits, "FullSync"));
+}
+
+TEST_F(WaitTrackerTest, RemoveAllTrackedWaits)
+{
+    // Add several waits
+    addTrackedWait(Wait::startUnit);
+    addTrackedWait(Wait::siblingAlive);
+    addTrackedWait(Wait::fullSync);
+
+    ASSERT_EQ(readWaits().size(), 3);
+
+    // Remove all - key should be gone entirely
+    removeAllTrackedWaits();
+
+    EXPECT_EQ(data::read<std::vector<std::underlying_type_t<Wait>>>(
+                  data::key::trackedWaits),
+              std::nullopt);
+}
+
+TEST_F(WaitTrackerTest, RemoveAllTrackedWaitsWhenEmpty)
+{
+    // Should not crash when there are no tracked waits
+    EXPECT_NO_THROW(removeAllTrackedWaits());
+
+    EXPECT_EQ(data::read<std::vector<std::underlying_type_t<Wait>>>(
+                  data::key::trackedWaits),
+              std::nullopt);
+}


### PR DESCRIPTION
Introduce wait tracker APIs so that in all the places the code is waiting for something to happen what is being waited on can be displayed in rbmctool.

  - Added new wait tracker APIs to monitor what the code is currently waiting on during various state transitions
  - Wait states are persisted to the data file so rbmctool can read them
  - Call the new APIs in all of the relevant places.
  - Create a persistent_data test fixture to make handling the data file easier in unit tests.