### PR TITLE
RBMC: Add try/catch around passive BMC full sync

### DIFF
--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -210,7 +210,24 @@ sdbusplus::async::task<> PassiveRoleHandler::startSync()
         co_return;
     }
 
-    if (co_await providers.getSyncInterface().doFullSync())
+    bool syncSucceeded = false;
+
+    try
+    {
+        syncSucceeded = co_await providers.getSyncInterface().doFullSync();
+        if (!syncSucceeded)
+        {
+            lg2::error("Full sync on passive BMC failed");
+        }
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Full sync on passive BMC failed with exception: {ERROR}",
+                   "ERROR", e);
+        syncSucceeded = false;
+    }
+
+    if (syncSucceeded)
     {
         fullSyncDone = true;
 
@@ -220,7 +237,6 @@ sdbusplus::async::task<> PassiveRoleHandler::startSync()
     }
     else
     {
-        lg2::error("Full sync on passive BMC failed");
         co_await stopSync();
     }
 }


### PR DESCRIPTION
There was a try/catch missing around the full sync that caused a crash when the full sync threw an exception.

Change-Id: I35ace17265237be73890ef74498fc649a03791d7