### PR TITLE
RBMC: Start using PeerConnected property to know inter-BMC network status

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -82,6 +82,10 @@ will wait up to ten minutes total for the passive BMC to get to a steady state
 (assuming the passive BMC is alive), which would either be `Ready` or
 `Quiesced`.
 
+There is also a ten minute wait for the network connection between the BMCs.
+This is in parallel with the steady state wait so if one is complete first it
+will still wait for the other.
+
 After the passive BMC reaches steady state, it will then check the following
 items to see if redundancy can be enabled:
 
@@ -130,6 +134,21 @@ wasn't running.
 Note that redundancy cannot be enabled at runtime if the system wasn't booted
 with redundancy enabled. A concurrent maintenance operation would be necessary
 in that case.
+
+### Passive BMC loses network connection
+
+A loss of the network connection between the BMCs will start a five minute timer
+similar to how it was done for a heartbeat loss. At five minutes, redundancy
+will be disabled and an event log will be created. If it comes back before then,
+it will go through the code to calculate redundancy followed by a full sync to
+sync over any files that might have changed when the network was down.
+
+The heartbeat timer will take precedence over this one. So if the heartbeat
+isn't currently active when the network loss occurs, the new timer won't be
+started since the overall loss of the passive BMC is already being handled.
+
+In addition, if the network loss timer is already running when the heartbeat
+loss is noticed, it will be canceled when the heartbeat loss timer is started.
 
 ## Interacting with Data Sync on the Active BMC
 

--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -94,6 +94,7 @@ items to see if redundancy can be enabled:
    so.
 1. The sibling BMC has been provisioned.
 1. The firmware versions are the same on the BMCs.
+1. The network between the BMCs is connected.
 1. If attempting to enable any time at runtime, redundancy must have been
    enabled when runtime was first reached.
 

--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -50,11 +50,13 @@ sdbusplus::async::task<> ActiveRoleHandler::start()
 
     if (sibling.alive())
     {
-        // Make sure the sibling had time to get its role assigned, and
-        // also wait for it to hit steady state as redundancy can only
-        // be enabled if the sibling BMC is at the Ready state.
+        // Before trying to enable redundancy, wait for:
+        // 1. Sibling to have its role assigned.
+        // 2. Sibling to hit steady state (Ready needed for redundancy)
+        // 3. The network to connect to the sibling BMC.
         co_await sdbusplus::async::execution::when_all(
-            sibling.waitForSiblingRole(), sibling.waitForBMCSteadyState());
+            sibling.waitForSiblingRole(), sibling.waitForBMCSteadyState(),
+            services.waitForPeerConnection());
     }
 
     co_await redMgr.determineRedundancyAndSync();
@@ -109,8 +111,10 @@ sdbusplus::async::task<> ActiveRoleHandler::siblingHealthy()
     stopSiblingWatches();
 
     auto& sibling = providers.getSibling();
+    auto& services = providers.getServices();
     co_await sdbusplus::async::execution::when_all(
-        sibling.waitForSiblingRole(), sibling.waitForBMCSteadyState());
+        sibling.waitForSiblingRole(), sibling.waitForBMCSteadyState(),
+        services.waitForPeerConnection());
 
     lg2::info("Attempting to enable redundancy now that sibling is back");
     providers.getSyncInterface().clearFullSyncComplete();
@@ -214,18 +218,24 @@ sdbusplus::async::task<> ActiveRoleHandler::failoverStartActiveTarget()
 // NOLINTNEXTLINE
 sdbusplus::async::task<> ActiveRoleHandler::failoverWaitForSibling()
 {
+    auto& sibling = providers.getSibling();
+    auto& services = providers.getServices();
+
     // Wait a bit to ensure the sibling reset is detected before we
     // start waiting for it to come back. After the active target
     // has real code in it that runs longer than a few seconds,
     // this could be removed.
-    co_await providers.getSibling().pauseForHeartbeatChange();
+    co_await sibling.pauseForHeartbeatChange();
 
     // Wait for the sibling heartbeat to come back
-    co_await providers.getSibling().waitForSiblingUp();
+    co_await sibling.waitForSiblingUp();
 
-    // Wait for the sibling to get to a steady state so redundancy can
-    // be determined.
-    co_await providers.getSibling().waitForBMCSteadyState();
+    // If heartbeat came back, wait for steady state and the network.
+    if (sibling.alive())
+    {
+        co_await sdbusplus::async::execution::when_all(
+            sibling.waitForBMCSteadyState(), services.waitForPeerConnection());
+    }
 }
 
 // NOLINTNEXTLINE

--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -93,6 +93,9 @@ void ActiveRoleHandler::siblingHealthChange(bool alive)
                 "Disabling redundancy in {TIME} minutes if sibling doesn't come back",
                 "TIME", siblingHealthTimeout.count());
             siblingHealthTimer.start(siblingHealthTimeout);
+
+            // Background sync won't work without a healthy sibling
+            ctx.spawn(providers.getSyncInterface().disableBackgroundSync());
         }
     }
 }

--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -65,7 +65,7 @@ sdbusplus::async::task<> ActiveRoleHandler::start()
 
     startSyncHealthWatch();
 
-    co_return;
+    startPeerConnectedWatch();
 }
 
 void ActiveRoleHandler::siblingStateChange(BMCState state)
@@ -81,6 +81,7 @@ void ActiveRoleHandler::siblingHealthChange(bool alive)
 {
     if (alive)
     {
+        lg2::info("Sibling BMC health changed to good");
         siblingHealthTimer.stop();
         ctx.spawn(siblingHealthy());
     }
@@ -92,6 +93,14 @@ void ActiveRoleHandler::siblingHealthChange(bool alive)
             lg2::warning(
                 "Disabling redundancy in {TIME} minutes if sibling doesn't come back",
                 "TIME", siblingHealthTimeout.count());
+
+            // Just use the sibling health timer if neither indicator is good.
+            if (peerConnectionTimer.isRunning())
+            {
+                lg2::info("Stopping peer connection timer");
+                peerConnectionTimer.stop();
+            }
+
             siblingHealthTimer.start(siblingHealthTimeout);
 
             // Background sync won't work without a healthy sibling
@@ -106,15 +115,18 @@ void ActiveRoleHandler::siblingHealthCritical()
     redMgr.determineAndSetRedundancy();
 }
 
-// NOLINTNEXTLINE
 sdbusplus::async::task<> ActiveRoleHandler::siblingHealthy()
 {
-    lg2::info("Passive BMC health changed to good");
-
     stopSiblingWatches();
+    stopPeerConnectedWatch();
 
     auto& sibling = providers.getSibling();
     auto& services = providers.getServices();
+
+    // Before trying to enable redundancy, wait for:
+    // 1. Sibling to have its role assigned.
+    // 2. Sibling to hit steady state (Ready needed for redundancy)
+    // 3. Peer connection to be established.
     co_await sdbusplus::async::execution::when_all(
         sibling.waitForSiblingRole(), sibling.waitForBMCSteadyState(),
         services.waitForPeerConnection());
@@ -124,8 +136,54 @@ sdbusplus::async::task<> ActiveRoleHandler::siblingHealthy()
     co_await redMgr.determineRedundancyAndSync();
 
     startSiblingWatches();
+    startPeerConnectedWatch();
 
     co_return;
+}
+
+void ActiveRoleHandler::peerConnectionChange(bool connected)
+{
+    lg2::info("PeerConnected changed to {C}", "C", connected);
+
+    if (connected)
+    {
+        peerConnectionTimer.stop();
+
+        // If sibling is already alive, attempt to re-enable redundancy.
+        if (providers.getSibling().alive())
+        {
+            ctx.spawn(siblingHealthy());
+        }
+    }
+    else
+    {
+        if (!redundancyInterface.redundancy_enabled())
+        {
+            return;
+        }
+
+        // Always disable background sync when network is down
+        ctx.spawn(providers.getSyncInterface().disableBackgroundSync());
+
+        // If sibling is alive, this is only a network issue at this
+        // point so start the timer to disabling redundancy. Otherwise,
+        // this problem is already being handled by the sibling
+        // health timer code.
+        if (providers.getSibling().alive())
+        {
+            lg2::warning(
+                "Disabling redundancy in {TIME} minutes if peer connection doesn't come back",
+                "TIME", siblingHealthTimeout.count());
+            peerConnectionTimer.start(siblingHealthTimeout);
+        }
+    }
+}
+
+void ActiveRoleHandler::peerConnectionCritical()
+{
+    lg2::error("Peer connection timer expired, disabling redundancy");
+    // Disables redundancy because peerConnected is false
+    redMgr.determineAndSetRedundancy();
 }
 
 void ActiveRoleHandler::syncHealthPropertyChanged(
@@ -155,15 +213,18 @@ sdbusplus::async::task<> ActiveRoleHandler::syncHealthCritical()
 
     // A passive BMC reboot should not result in redundancy being
     // disabled, so wait a bit for the passive BMC's heartbeat
-    // to change.  If it's still running, then this is a valid
-    // sync fail so disable redundancy.  If it isn't running then
-    // then the code that deals with the sibling heartbeat will
-    // deal with it.
-    // TODO: Also do network failure detection.
+    // to change to see if that is the cause.
+    // After that:
+    // - If heartbeat (alive) and peer connection are OK, then
+    //   disable redundancy due to a sync fail.
+    //   If heartbeat or peer connection are bad then then the code
+    //   that deals with those will handle everything.
+
     lg2::info("Waiting to see if sibling heartbeat stops");
     co_await providers.getSibling().pauseForHeartbeatChange();
 
-    if (providers.getSibling().alive())
+    if (providers.getSibling().alive() &&
+        providers.getServices().getPeerConnected())
     {
         lg2::error("Disabling redundancy due to critical sync health");
 
@@ -172,11 +233,12 @@ sdbusplus::async::task<> ActiveRoleHandler::syncHealthCritical()
     }
     else
     {
+        // The siblingHealthTimer/peerConnectionTimer will handle this.
         lg2::warning(
-            "Sync health is critical, but there is also a sibling heartbeat loss");
+            "Sync fail caused by sibling alive = {ALIVE} or peer connected = {CONN}",
+            "ALIVE", providers.getSibling().alive(), "CONN",
+            providers.getServices().getPeerConnected());
     }
-
-    co_return;
 }
 
 // NOLINTNEXTLINE
@@ -257,6 +319,7 @@ sdbusplus::async::task<> ActiveRoleHandler::failoverDetermineRedundancy()
 
     startSiblingWatches();
     startSyncHealthWatch();
+    startPeerConnectedWatch();
 }
 
 void ActiveRoleHandler::siblingFailoverImminent(bool imminent)

--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -33,7 +33,10 @@ class ActiveRoleHandler : public RoleHandler
         RoleHandler(ctx, providers, iface), redMgr(ctx, providers, iface),
         siblingHealthTimer(
             ctx,
-            std::bind_front(&ActiveRoleHandler::siblingHealthCritical, this))
+            std::bind_front(&ActiveRoleHandler::siblingHealthCritical, this)),
+        peerConnectionTimer(
+            ctx,
+            std::bind_front(&ActiveRoleHandler::peerConnectionCritical, this))
     {}
 
     /**
@@ -42,7 +45,9 @@ class ActiveRoleHandler : public RoleHandler
     ~ActiveRoleHandler() override
     {
         stopSiblingWatches();
+        peerConnectionTimer.stop();
         providers.getSyncInterface().stopSyncHealthWatch(Role::Active);
+        stopPeerConnectedWatch();
     }
 
     /**
@@ -138,6 +143,14 @@ class ActiveRoleHandler : public RoleHandler
         providers.getSibling().clearCallbacks(Role::Active);
     }
 
+    /**
+     * @brief Stops the peer connected property callbacks/watches
+     */
+    inline void stopPeerConnectedWatch()
+    {
+        providers.getServices().removePeerConnectedCallback(Role::Active);
+    }
+
     using BMCState =
         sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState;
 
@@ -187,6 +200,32 @@ class ActiveRoleHandler : public RoleHandler
     }
 
     /**
+     * @brief Starts watching the peer connection property
+     */
+    void startPeerConnectedWatch()
+    {
+        providers.getServices().addPeerConnectedCallback(
+            Role::Active,
+            std::bind_front(&ActiveRoleHandler::peerConnectionChange, this));
+    }
+
+    /**
+     * @brief Called when the peer connection property changes
+     *
+     * Manages the peer connection timer and attempts recovery when
+     * the connection is restored.
+     *
+     * @param[in] connected - The new value.
+     */
+    void peerConnectionChange(bool connected);
+
+    /**
+     * @brief Called when the peer connection stays bad
+     *        long enough to explicitly disable redundancy.
+     */
+    void peerConnectionCritical();
+
+    /**
      * @brief Called when the sync health property changes
      *
      * Spawns syncHealthCritical() on critical health.
@@ -222,6 +261,13 @@ class ActiveRoleHandler : public RoleHandler
      * Upon expiration redundancy will be disabled.
      */
     Timer siblingHealthTimer;
+
+    /**
+     * @brief Timer used when the peer connection changes to bad
+     *
+     * Upon expiration redundancy will be disabled.
+     */
+    Timer peerConnectionTimer;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -101,6 +101,8 @@ sdbusplus::async::task<> PassiveRoleHandler::start()
 
     setupSiblingHealthWatch();
 
+    setupPeerConnectedWatch();
+
     try
     {
         // This is only valid on the active BMC
@@ -192,7 +194,8 @@ sdbusplus::async::task<> PassiveRoleHandler::tryFullSync()
     if (providers.getSibling().alive() &&
         providers.getSibling().getRedundancyEnabled().value_or(false) &&
         (providers.getSibling().getRole().value_or(Role::Unknown) ==
-         Role::Active))
+         Role::Active) &&
+        providers.getServices().getPeerConnected())
     {
         co_await startSync();
     }
@@ -348,6 +351,15 @@ auto PassiveRoleHandler::getFailoverBlockedReason(
         .lastKnownRedundancyEnabled = redundancyInterface.redundancy_enabled()};
 
     co_return fo_blocked::getFailoverBlockedReason(input);
+}
+
+void PassiveRoleHandler::peerConnectedChange([[maybe_unused]] bool connected)
+{
+    // If connected and all other conditions succeed for a full sync,
+    // will start one, otherwise will stop background syncing.
+    // If the active BMC just came back from a reboot, most likely
+    // redundancy won't be enabled yet though.
+    ctx.spawn(tryFullSync());
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/passive_role_handler.hpp
+++ b/redundant-bmc/src/passive_role_handler.hpp
@@ -39,6 +39,7 @@ class PassiveRoleHandler : public RoleHandler
     {
         providers.getSibling().clearCallbacks(Role::Passive);
         providers.getSyncInterface().stopSyncHealthWatch(Role::Passive);
+        providers.getServices().removePeerConnectedCallback(Role::Passive);
     }
 
     /**
@@ -107,7 +108,18 @@ class PassiveRoleHandler : public RoleHandler
     inline void setupSiblingHealthWatch()
     {
         providers.getSibling().addHealthCallback(
-            Role::Passive, [this](bool hb) { siblingHealthChange(hb); });
+            Role::Passive,
+            std::bind_front(&PassiveRoleHandler::siblingHealthChange, this));
+    }
+
+    /**
+     * @brief Setup watching the PeerConnected property
+     */
+    inline void setupPeerConnectedWatch()
+    {
+        providers.getServices().addPeerConnectedCallback(
+            Role::Passive,
+            std::bind_front(&PassiveRoleHandler::peerConnectedChange, this));
     }
 
     /**
@@ -151,6 +163,13 @@ class PassiveRoleHandler : public RoleHandler
      *        to stop background sync if it was running.
      */
     sdbusplus::async::task<> syncHealthCritical();
+
+    /**
+     * @brief Called when the PeerConnected property changes.
+     *
+     * Tries to either start or stop a sync.
+     */
+    void peerConnectedChange(bool connected);
 
     /**
      * @brief Tracks if a full sync has already been done since

--- a/redundant-bmc/src/redundancy.cpp
+++ b/redundant-bmc/src/redundancy.cpp
@@ -13,9 +13,6 @@ ReasonsForNoRedundancy getNoRedundancyReasons(const Input& input)
     using enum ReasonForNoRedundancy;
     ReasonsForNoRedundancy reasons;
 
-    // TODO:
-    // - Network health
-
     if (input.role != Role::Active)
     {
         reasons.insert(BMCNotActive);
@@ -56,6 +53,11 @@ ReasonsForNoRedundancy getNoRedundancyReasons(const Input& input)
             if (!input.codeVersionsMatch)
             {
                 reasons.insert(CodeVersionMismatch);
+            }
+
+            if (!input.peerConnected)
+            {
+                reasons.insert(NetworkError);
             }
 
             if (input.siblingState != BMCState::Ready)

--- a/redundant-bmc/src/redundancy.hpp
+++ b/redundant-bmc/src/redundancy.hpp
@@ -38,6 +38,7 @@ struct Input
     bool manualDisable;
     bool redundancyOffAtRuntimeStart;
     bool syncFailed;
+    bool peerConnected;
 };
 
 using ReasonsForNoRedundancy = std::set<ReasonForNoRedundancy>;

--- a/redundant-bmc/src/redundancy_mgr.cpp
+++ b/redundant-bmc/src/redundancy_mgr.cpp
@@ -137,7 +137,8 @@ redundancy::ReasonsForNoRedundancy RedundancyMgr::getNoRedundancyReasons()
             services.getFWVersion() == sibling.getFWVersion().value_or(""),
         .manualDisable = manualDisable,
         .redundancyOffAtRuntimeStart = isRedundancyOffAtRuntime(),
-        .syncFailed = syncFailed};
+        .syncFailed = syncFailed,
+        .peerConnected = services.getPeerConnected()};
 
     return redundancy::getNoRedundancyReasons(input);
 }

--- a/redundant-bmc/src/redundancy_mgr.cpp
+++ b/redundant-bmc/src/redundancy_mgr.cpp
@@ -203,7 +203,7 @@ void RedundancyMgr::initSystemState()
     auto& services = providers.getServices();
 
     services.addSystemStateCallback(
-        std::bind_front(&RedundancyMgr::systemStateChange, this));
+        Role::Active, std::bind_front(&RedundancyMgr::systemStateChange, this));
 
     try
     {

--- a/redundant-bmc/src/redundancy_mgr.hpp
+++ b/redundant-bmc/src/redundancy_mgr.hpp
@@ -36,7 +36,7 @@ class RedundancyMgr
      */
     ~RedundancyMgr()
     {
-        providers.getServices().clearSystemStateCallbacks();
+        providers.getServices().removeSystemStateCallback(Role::Active);
     }
 
     /**

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -3,12 +3,17 @@
 #include "errors.hpp"
 
 #include <sdbusplus/async.hpp>
+#include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
 #include <xyz/openbmc_project/State/BMC/common.hpp>
 
 #include <filesystem>
+#include <map>
 
 namespace rbmc
 {
+
+using Role =
+    sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy::Role;
 
 enum class SystemState
 {
@@ -165,19 +170,22 @@ class Services
     /**
      * @brief Add a function that gets called when the system state changes.
      *
+     * @param[in] role - The role to register with
      * @param[in] callback - The function to call
      */
-    void addSystemStateCallback(SystemStateCallback&& callback)
+    void addSystemStateCallback(Role role, SystemStateCallback&& callback)
     {
-        systemStateCBs.push_back(std::move(callback));
+        systemStateCBs.emplace(role, std::move(callback));
     }
 
     /**
-     * @brief Clears all system state change callbacks.
+     * @brief Remove a specific system state change callback by role.
+     *
+     * @param[in] role - The role of the callback to remove
      */
-    void clearSystemStateCallbacks()
+    void removeSystemStateCallback(Role role)
     {
-        systemStateCBs.clear();
+        systemStateCBs.erase(role);
     }
 
     /**
@@ -203,7 +211,7 @@ class Services
     /**
      * @brief The functions to call when the system state changes
      */
-    std::vector<SystemStateCallback> systemStateCBs;
+    std::map<Role, SystemStateCallback> systemStateCBs;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -45,6 +45,7 @@ class Services
     Services& operator=(Services&&) = delete;
 
     using SystemStateCallback = std::function<void(SystemState)>;
+    using PeerConnectedCallback = std::function<void(bool)>;
 
     /**
      * @brief Sets up the D-Bus matches
@@ -115,6 +116,18 @@ class Services
      * @return The system state
      */
     virtual SystemState getSystemState() const = 0;
+
+    /**
+     * @brief Returns if the peer network is connected
+     *
+     * @return true if PeerConnected status is Connected, false otherwise
+     */
+    virtual bool getPeerConnected() const = 0;
+
+    /**
+     * @brief Waits for the PeerConnected property to reach Connected
+     */
+    virtual sdbusplus::async::task<> waitForPeerConnection() = 0;
 
     /**
      * @brief Execute the 'failover imminent' delay to the other BMC
@@ -189,6 +202,28 @@ class Services
     }
 
     /**
+     * @brief Add a function that gets called when the peer connected status
+     *        changes.
+     *
+     * @param[in] role - The role to register with
+     * @param[in] callback - The function to call
+     */
+    void addPeerConnectedCallback(Role role, PeerConnectedCallback&& callback)
+    {
+        peerConnectedCBs.emplace(role, std::move(callback));
+    }
+
+    /**
+     * @brief Remove a specific peer connected change callback by role.
+     *
+     * @param[in] role - The role of the callback to remove
+     */
+    void removePeerConnectedCallback(Role role)
+    {
+        peerConnectedCBs.erase(role);
+    }
+
+    /**
      * @brief On the system inventory object, check that its Progress
      *        Status property is 'Completed'.
      *
@@ -212,6 +247,11 @@ class Services
      * @brief The functions to call when the system state changes
      */
     std::map<Role, SystemStateCallback> systemStateCBs;
+
+    /**
+     * @brief The functions to call when the peer connected status changes
+     */
+    std::map<Role, PeerConnectedCallback> peerConnectedCBs;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -389,8 +389,8 @@ void ServicesImpl::updateSystemState()
                        "NEW_STATE", getSystemStateName(newState));
         }
         systemState = newState;
-        std::ranges::for_each(systemStateCBs, [newState](const auto& callback) {
-            callback(newState);
+        std::ranges::for_each(systemStateCBs, [newState](const auto& entry) {
+            entry.second(newState);
         });
     }
 }

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -10,6 +10,7 @@
 #include <xyz/openbmc_project/Inventory/Item/System/common.hpp>
 #include <xyz/openbmc_project/Logging/Create/client.hpp>
 #include <xyz/openbmc_project/ObjectMapper/client.hpp>
+#include <xyz/openbmc_project/Provisioning/Provisioning/client.hpp>
 #include <xyz/openbmc_project/State/BMC/client.hpp>
 #include <xyz/openbmc_project/State/Boot/Progress/client.hpp>
 #include <xyz/openbmc_project/State/Host/client.hpp>
@@ -29,6 +30,10 @@ using SystemInv =
 using InvProgress = sdbusplus::client::xyz::openbmc_project::common::Progress<>;
 using SidebandBus =
     sdbusplus::client::xyz::openbmc_project::control::SideBandBus<>;
+using Provisioning =
+    sdbusplus::client::xyz::openbmc_project::provisioning::Provisioning<>;
+using PeerConnectionStatus = sdbusplus::common::xyz::openbmc_project::
+    provisioning::Provisioning::PeerConnectionStatus;
 
 using HostProperties =
     std::variant<std::string, HostState::HostState, HostState::RestartCause,
@@ -194,8 +199,11 @@ sdbusplus::async::task<> ServicesImpl::init()
     ctx.spawn(watchHostInterfacesAdded());
     ctx.spawn(watchHostStatePropertiesChanged());
     ctx.spawn(watchBootProgressPropertiesChanged());
+    ctx.spawn(watchProvisioningInterfacesAdded());
+    ctx.spawn(watchProvisioningPropertiesChanged());
     co_await readHostState();
     co_await readBootProgress();
+    co_await readProvisioningProperties();
     updateSystemState();
 
     co_await waitForSystemInventoryPath();
@@ -317,6 +325,29 @@ sdbusplus::async::task<> ServicesImpl::readBootProgress()
     co_return;
 }
 
+sdbusplus::async::task<> ServicesImpl::readProvisioningProperties()
+{
+    try
+    {
+        auto service = co_await util::getService(
+            ctx, Provisioning::instance_path, Provisioning::interface);
+        auto props = co_await Provisioning(ctx)
+                         .service(service)
+                         .path(Provisioning::instance_path)
+                         .properties();
+
+        provisioned = props.provisioned;
+        peerConnected = props.peer_connected == PeerConnectionStatus::Connected;
+
+        lg2::debug("Initial Provisioned = {PROV} and PeerConnected = {STATUS}",
+                   "PROV", props.provisioned, "STATUS", props.peer_connected);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        // Not on D-Bus yet
+    }
+}
+
 // NOLINTNEXTLINE
 sdbusplus::async::task<> ServicesImpl::watchBootProgressPropertiesChanged()
 {
@@ -341,6 +372,72 @@ sdbusplus::async::task<> ServicesImpl::watchBootProgressPropertiesChanged()
     }
 
     co_return;
+}
+
+void ServicesImpl::loadProvisioningProps(const ProvisioningPropMap& propertyMap)
+{
+    auto it = propertyMap.find("PeerConnected");
+    if (it != propertyMap.end())
+    {
+        auto prevConnected = peerConnected;
+
+        auto rawStatus =
+            std::get<Provisioning::PeerConnectionStatus>(it->second);
+
+        lg2::info("The new PeerConnected value is {STATUS}", "STATUS",
+                  rawStatus);
+
+        peerConnected = rawStatus == PeerConnectionStatus::Connected;
+
+        if (prevConnected != peerConnected)
+        {
+            std::ranges::for_each(peerConnectedCBs, [this](const auto& entry) {
+                entry.second(peerConnected);
+            });
+        }
+    }
+
+    it = propertyMap.find("Provisioned");
+    if (it != propertyMap.end())
+    {
+        provisioned = std::get<bool>(it->second);
+
+        lg2::info("The new Provisioned value is {PROV}", "PROV", provisioned);
+    }
+}
+
+sdbusplus::async::task<> ServicesImpl::watchProvisioningInterfacesAdded()
+{
+    sdbusplus::async::match match(
+        ctx, rules::interfacesAddedAtPath(Provisioning::instance_path));
+
+    while (!ctx.stop_requested())
+    {
+        auto [_, interfaces] =
+            co_await match.next<sdbusplus::message::object_path,
+                                ProvisioningInterfaceMap>();
+
+        auto it = interfaces.find(Provisioning::interface);
+        if (it != interfaces.end())
+        {
+            lg2::info("Provisioning interface added");
+            loadProvisioningProps(it->second);
+        }
+    }
+}
+
+sdbusplus::async::task<> ServicesImpl::watchProvisioningPropertiesChanged()
+{
+    sdbusplus::async::match match(
+        ctx, rules::propertiesChanged(Provisioning::instance_path,
+                                      Provisioning::interface));
+
+    while (!ctx.stop_requested())
+    {
+        auto [_, properties] =
+            co_await match.next<std::string, ProvisioningPropMap>();
+        loadProvisioningProps(properties);
+    }
 }
 
 void ServicesImpl::updateSystemState()
@@ -584,7 +681,8 @@ sdbusplus::async::task<> ServicesImpl::startUnit(
 
 bool ServicesImpl::getProvisioned() const
 {
-    // TODO: Eventually get this from somewhere.
+    // TODO: Return the actual value.
+    // return provisioned;
     return true;
 }
 
@@ -828,6 +926,44 @@ sdbusplus::async::task<> ServicesImpl::logError(
         lg2::error("Failed to create event log {MSG}: {ERROR}", "MSG", error,
                    "ERROR", e);
     }
+}
+
+sdbusplus::async::task<> ServicesImpl::waitForPeerConnection()
+{
+    using namespace std::chrono_literals;
+    std::chrono::minutes timeout{10};
+
+    lg2::info("waitForPeerConnection initial peerConnected value = {STATUS}",
+              "STATUS", peerConnected);
+
+    if (peerConnected)
+    {
+        co_return;
+    }
+
+    auto end = std::chrono::steady_clock::now() + timeout;
+    bool tracedWait = false;
+
+    while (std::chrono::steady_clock::now() < end)
+    {
+        if (peerConnected)
+        {
+            lg2::info("Peer now connected");
+            co_return;
+        }
+
+        if (!tracedWait)
+        {
+            tracedWait = true;
+            lg2::info("Waiting up to {MIN} minutes for peer connection", "MIN",
+                      timeout.count());
+        }
+
+        co_await sdbusplus::async::sleep_for(ctx, 500ms);
+    }
+
+    lg2::error("Timed out waiting for peer connection after {MIN} minutes",
+               "MIN", timeout.count());
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -3,6 +3,7 @@
 
 #include "services.hpp"
 
+#include <xyz/openbmc_project/Provisioning/Provisioning/common.hpp>
 #include <xyz/openbmc_project/State/Boot/Progress/common.hpp>
 #include <xyz/openbmc_project/State/Host/common.hpp>
 
@@ -30,6 +31,12 @@ class ServicesImpl : public Services
     ServicesImpl& operator=(const ServicesImpl&) = delete;
     ServicesImpl(ServicesImpl&&) = delete;
     ServicesImpl& operator=(ServicesImpl&&) = delete;
+
+    using ProvisioningCommon =
+        sdbusplus::common::xyz::openbmc_project::provisioning::Provisioning;
+    using ProvisioningPropMap =
+        std::unordered_map<std::string, ProvisioningCommon::PropertiesVariant>;
+    using ProvisioningInterfaceMap = std::map<std::string, ProvisioningPropMap>;
 
     /**
      * @brief Constructor
@@ -97,6 +104,21 @@ class ServicesImpl : public Services
      * @return The system state
      */
     SystemState getSystemState() const override;
+
+    /**
+     * @brief Returns if the peer is connected
+     *
+     * @return true if PeerConnected status is Connected, false otherwise
+     */
+    bool getPeerConnected() const override
+    {
+        return peerConnected;
+    }
+
+    /**
+     * @brief Waits for the PeerConnected property to reach Connected
+     */
+    sdbusplus::async::task<> waitForPeerConnection() override;
 
     /**
      * @brief Reads the BMC state
@@ -204,6 +226,23 @@ class ServicesImpl : public Services
     sdbusplus::async::task<> watchBootProgressPropertiesChanged();
 
     /**
+     * @brief Starts the InterfacesAdded watch for the Provisioning interface
+     */
+    sdbusplus::async::task<> watchProvisioningInterfacesAdded();
+
+    /**
+     * @brief Starts the PropertiesChanged watch for the Provisioning interface
+     */
+    sdbusplus::async::task<> watchProvisioningPropertiesChanged();
+
+    /**
+     * @brief Reads the Provisioning interface properties
+     */
+    sdbusplus::async::task<> readProvisioningProperties();
+
+    void loadProvisioningProps(const ProvisioningPropMap& propertyMap);
+
+    /**
      * @brief Called when either the host state or boot progress property
      *        changes value to calculate the system state.
      */
@@ -238,6 +277,16 @@ class ServicesImpl : public Services
      * @brief The current system state value
      */
     std::optional<SystemState> systemState;
+
+    /**
+     * @brief Tracks peer connection state
+     */
+    bool peerConnected{false};
+
+    /**
+     * @brief The provisioned status value
+     */
+    bool provisioned;
 
     /**
      * @brief D-Bus path for the Item.System object

--- a/redundant-bmc/src/timer.hpp
+++ b/redundant-bmc/src/timer.hpp
@@ -61,6 +61,16 @@ class Timer :
         source.reset();
     }
 
+    /**
+     * @brief Check if the timer is currently running
+     *
+     * @return true if timer is running, false otherwise
+     */
+    bool isRunning() const
+    {
+        return source != nullptr;
+    }
+
   private:
     /**
      * @brief RAII wrapper for sdbusplus::source

--- a/redundant-bmc/test/redundancy_test.cpp
+++ b/redundant-bmc/test/redundancy_test.cpp
@@ -21,7 +21,8 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
         .codeVersionsMatch = true,
         .manualDisable = false,
         .redundancyOffAtRuntimeStart = false,
-        .syncFailed = false};
+        .syncFailed = false,
+        .peerConnected = true};
 
     // Nothing stopping redundancy
     {
@@ -127,6 +128,16 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
         auto reasons = getNoRedundancyReasons(input);
         ASSERT_EQ(reasons.size(), 1);
         EXPECT_EQ(*reasons.begin(), RedundancyOffAtRuntimeStart);
+    }
+
+    // Network failure
+    {
+        auto input = golden;
+        input.peerConnected = false;
+
+        auto reasons = getNoRedundancyReasons(input);
+        ASSERT_EQ(reasons.size(), 1);
+        EXPECT_EQ(*reasons.begin(), NetworkError);
     }
 
     // Sync failed


### PR DESCRIPTION
This PR adds code to start watching the PeerConnected property that says if the network connection is good between the BMCs. 

It will wait up to 10 minutes for the property to go to Connected continuing on and trying to enable redundancy.  At that point if it isn't connected, redundancy will be disabled with the reason of 'NetworkError'.

It can handle the connection being lost and regained at steady-state.