### PR TITLE
RBMC: Sync handling improvements

### DIFF
--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -123,6 +123,12 @@ sdbusplus::async::task<> ActiveRoleHandler::siblingHealthy()
     auto& sibling = providers.getSibling();
     auto& services = providers.getServices();
 
+    // As redundancy could be enabled here if passive
+    // wasn't gone long, hold off failovers until the
+    // full sync is done.
+    providers.getSyncInterface().clearFullSyncComplete();
+    redMgr.determineAndSetFailoversAllowed();
+
     // Before trying to enable redundancy, wait for:
     // 1. Sibling to have its role assigned.
     // 2. Sibling to hit steady state (Ready needed for redundancy)
@@ -132,7 +138,6 @@ sdbusplus::async::task<> ActiveRoleHandler::siblingHealthy()
         services.waitForPeerConnection());
 
     lg2::info("Attempting to enable redundancy now that sibling is back");
-    providers.getSyncInterface().clearFullSyncComplete();
     co_await redMgr.determineRedundancyAndSync();
 
     startSiblingWatches();

--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -61,11 +61,7 @@ sdbusplus::async::task<> ActiveRoleHandler::start()
 
     co_await redMgr.determineRedundancyAndSync();
 
-    startSiblingWatches();
-
-    startSyncHealthWatch();
-
-    startPeerConnectedWatch();
+    startAllWatches();
 }
 
 void ActiveRoleHandler::siblingStateChange(BMCState state)
@@ -117,8 +113,7 @@ void ActiveRoleHandler::siblingHealthCritical()
 
 sdbusplus::async::task<> ActiveRoleHandler::siblingHealthy()
 {
-    stopSiblingWatches();
-    stopPeerConnectedWatch();
+    stopAllWatches();
 
     auto& sibling = providers.getSibling();
     auto& services = providers.getServices();
@@ -140,10 +135,7 @@ sdbusplus::async::task<> ActiveRoleHandler::siblingHealthy()
     lg2::info("Attempting to enable redundancy now that sibling is back");
     co_await redMgr.determineRedundancyAndSync();
 
-    startSiblingWatches();
-    startPeerConnectedWatch();
-
-    co_return;
+    startAllWatches();
 }
 
 void ActiveRoleHandler::peerConnectionChange(bool connected)
@@ -322,9 +314,7 @@ sdbusplus::async::task<> ActiveRoleHandler::failoverDetermineRedundancy()
     // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
     co_await redMgr.determineRedundancyAndSync();
 
-    startSiblingWatches();
-    startSyncHealthWatch();
-    startPeerConnectedWatch();
+    startAllWatches();
 }
 
 void ActiveRoleHandler::siblingFailoverImminent(bool imminent)

--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -44,10 +44,7 @@ class ActiveRoleHandler : public RoleHandler
      */
     ~ActiveRoleHandler() override
     {
-        stopSiblingWatches();
-        peerConnectionTimer.stop();
-        providers.getSyncInterface().stopSyncHealthWatch(Role::Active);
-        stopPeerConnectedWatch();
+        stopAllWatches();
     }
 
     /**
@@ -116,38 +113,48 @@ class ActiveRoleHandler : public RoleHandler
 
   private:
     /**
-     * @brief Starts the Sibling property watches/callbacks
+     * @brief Starts all property watches/callbacks
      */
-    inline void startSiblingWatches()
+    inline void startAllWatches()
     {
+        // Start sibling watches
         auto& sibling = providers.getSibling();
         sibling.addBMCStateCallback(
             Role::Active,
             std::bind_front(&ActiveRoleHandler::siblingStateChange, this));
-
         sibling.addHealthCallback(
             Role::Active,
             std::bind_front(&ActiveRoleHandler::siblingHealthChange, this));
-
         sibling.addFailoverImminentCallback(
             Role::Active,
             std::bind_front(&ActiveRoleHandler::siblingFailoverImminent, this));
+
+        // Start sync health watch
+        providers.getSyncInterface().watchSyncHealth(
+            Role::Active,
+            std::bind_front(&ActiveRoleHandler::syncHealthPropertyChanged,
+                            this));
+
+        // Start peer connected watch
+        providers.getServices().addPeerConnectedCallback(
+            Role::Active,
+            std::bind_front(&ActiveRoleHandler::peerConnectionChange, this));
     }
 
     /**
-     * @brief Stops the sibling property callbacks/watches
+     * @brief Stops all property watches/callbacks
      */
-    inline void stopSiblingWatches()
+    inline void stopAllWatches()
     {
+        // Stop sibling watches
         siblingHealthTimer.stop();
         providers.getSibling().clearCallbacks(Role::Active);
-    }
 
-    /**
-     * @brief Stops the peer connected property callbacks/watches
-     */
-    inline void stopPeerConnectedWatch()
-    {
+        // Stop sync health watch
+        providers.getSyncInterface().stopSyncHealthWatch(Role::Active);
+
+        // Stop peer connected watch
+        peerConnectionTimer.stop();
         providers.getServices().removePeerConnectedCallback(Role::Active);
     }
 
@@ -187,27 +194,6 @@ class ActiveRoleHandler : public RoleHandler
      *        long enough to explicitly disable redundancy.
      */
     void siblingHealthCritical();
-
-    /**
-     * @brief Starts watching the data sync health status property
-     */
-    void startSyncHealthWatch()
-    {
-        providers.getSyncInterface().watchSyncHealth(
-            Role::Active,
-            std::bind_front(&ActiveRoleHandler::syncHealthPropertyChanged,
-                            this));
-    }
-
-    /**
-     * @brief Starts watching the peer connection property
-     */
-    void startPeerConnectedWatch()
-    {
-        providers.getServices().addPeerConnectedCallback(
-            Role::Active,
-            std::bind_front(&ActiveRoleHandler::peerConnectionChange, this));
-    }
 
     /**
      * @brief Called when the peer connection property changes


### PR DESCRIPTION
1. Combine all of ActiveRoleHandler's start/stop watch calls into single stop and start all watches functions.  This also fixes a situation where the sync health handler got called while a full sync was running and failed.  It doesn't need to be called as the code running the full sync already handles the fail.
2. As soon as the passive BMC health comes back after it was offline, clear the full sync complete flag to turn off failovers allowed while the code is waiting for the passive to come all the way back until the full sync is done.

The 2nd one is because now with the PeerConnected check, the code can be waiting for a lot longer before it even gets to the full sync again, so it should be obvious this isn't failovers allowed steady state.