### PR TITLE
RBMC: Ignore PeerConnected property flapping

### DIFF
--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -389,7 +389,11 @@ void ServicesImpl::loadProvisioningProps(const ProvisioningPropMap& propertyMap)
 
         peerConnected = rawStatus == PeerConnectionStatus::Connected;
 
-        if (prevConnected != peerConnected)
+        // Ignore the intermediate states when doing callbacks to deal
+        // with Connected->InProgress->Connected flapping.
+        if (prevConnected != peerConnected &&
+            (rawStatus == PeerConnectionStatus::Connected ||
+             rawStatus == PeerConnectionStatus::NotConnected))
         {
             std::ranges::for_each(peerConnectedCBs, [this](const auto& entry) {
                 entry.second(peerConnected);


### PR DESCRIPTION
In simulation it was seen that the PeerConnected property can go from Connected to InProgress back to Connected again.

There is no need to execute the callbacks in that case since it never went to NotConnected, so fix the code to handle this.

Change-Id: Ie24997b1cc2e72cfe72ed76bc298cbd2e3bde2ad