### PR TITLE
RBMC: Hold off BMC ready until after redundancy

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -23,10 +23,17 @@ first in this case would ensure BMC 0 remains passive.
 
 ### Holding off BMC Ready
 
-A service file linked into multi-user.target that polls for the active and
-passive systemd targets to complete will prevent the system from reaching the
-BMC ready state before the role has been determined. On the active BMC this
-would also wait for all of the active applications to be started.
+The phosphor-wait-for-active-passive-target.service prevents the BMC from
+reaching the Ready state until the initial role determination and redundancy
+work is complete. This service runs a script that:
+
+1. Polls the Role D-Bus property until it becomes Active or Passive (max 20
+   minutes)
+2. Waits for the corresponding systemd target (obmc-bmc-active.target or
+   obmc-bmc-passive.target) to complete (max 60 minutes)
+3. On the active BMC only, waits for the /run/openbmc/bmc_redundancy_determined
+   marker file to be created, indicating redundancy determination is complete
+   (max 15 minutes)
 
 ## Role Determination Rules
 

--- a/redundant-bmc/src/redundancy_mgr.cpp
+++ b/redundant-bmc/src/redundancy_mgr.cpp
@@ -110,6 +110,8 @@ sdbusplus::async::task<> RedundancyMgr::determineRedundancyAndSync()
             determineAndSetFailoversAllowed();
         }
     }
+
+    providers.getServices().setRedundancyDetermined();
 }
 
 void RedundancyMgr::handleBackgroundSyncFailed()

--- a/redundant-bmc/src/scripts/wait-for-active-passive-target.sh
+++ b/redundant-bmc/src/scripts/wait-for-active-passive-target.sh
@@ -2,6 +2,8 @@
 
 # Wait for the Role property to get set to Active or Passive and
 # then wait for the corresponding obmc-bmc-<role>.target to start.
+# On the active BMC, then wait up to an additional 15 minutes for
+# the file /run/openbmc/bmc_redundancy_determined to be present.
 
 retries=600 # Wait max 20 minutes for role to be set
 passive=0
@@ -46,11 +48,37 @@ do
     if echo "$state" | grep -q -e '\"active\"' -e '\"failed\"' ;
     then
         echo "Done waiting for $target"
-        exit 0
+        break
     fi
     retries="$((retries - 1))"
     sleep 2
 done
 
-echo "Timed out waiting for $target to start"
-exit 1
+if [ "$retries" -eq 0 ];
+then
+    echo "Timed out waiting for $target to start"
+    exit 1
+fi
+
+# If this is the active BMC, wait for redundancy to be determined
+if [ "$passive" -eq 0 ];
+then
+    echo "Active BMC target started, now waiting for redundancy to be determined"
+
+    retries=450 # Wait max 15 minutes for redundancy determined file
+    while [ "$retries" -ne 0 ]
+    do
+        if [ -f /run/openbmc/bmc_redundancy_determined ];
+        then
+            echo "Redundancy determined file found"
+            exit 0
+        fi
+        retries="$((retries - 1))"
+        sleep 2
+    done
+
+    echo "Timed out waiting for redundancy to be determined"
+    exit 1
+fi
+
+exit 0

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -242,6 +242,14 @@ class Services
      */
     virtual sdbusplus::async::task<> acquireFullHardwareAccess() = 0;
 
+    /**
+     * @brief Creates the redundancy determined marker file
+     *
+     * Creates /run/openbmc/bmc_redundancy_determined to indicate
+     * that redundancy determination is complete.
+     */
+    virtual void setRedundancyDetermined() = 0;
+
   protected:
     /**
      * @brief The functions to call when the system state changes

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -966,4 +966,35 @@ sdbusplus::async::task<> ServicesImpl::waitForPeerConnection()
                "MIN", timeout.count());
 }
 
+void ServicesImpl::setRedundancyDetermined()
+{
+    namespace fs = std::filesystem;
+
+    const fs::path runDir = "/run/openbmc";
+    const fs::path markerFile = runDir / "bmc_redundancy_determined";
+
+    try
+    {
+        if (!fs::exists(runDir))
+        {
+            fs::create_directories(runDir);
+        }
+
+        std::ofstream file(markerFile);
+        if (!file)
+        {
+            lg2::error(
+                "Failed to create redundancy determined marker file {FILE}",
+                "FILE", markerFile.string());
+            return;
+        }
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error(
+            "Exception creating redundancy determined marker file: {ERROR}",
+            "ERROR", e);
+    }
+}
+
 } // namespace rbmc

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -180,6 +180,14 @@ class ServicesImpl : public Services
         std::string error, errors::Level severity,
         errors::AdditionalData data) const override;
 
+    /**
+     * @brief Creates the redundancy determined marker file
+     *
+     * Creates /run/openbmc/bmc_redundancy_determined to indicate
+     * that redundancy determination is complete.
+     */
+    void setRedundancyDetermined() override;
+
   private:
     /**
      * @brief Returns the D-Bus object path for the unit in the


### PR DESCRIPTION
There can now be up to a ten minute wait after the active target has started to wait for the PeerConnected property before redundancy will even be checked.  Since the BMC is at the Ready state someone may try to power on in that window, causing issues down the line.

To prevent that, on the active BMC the Ready state will now be held off until after redundancy has been determined, and if enabled then also after the full sync is complete.

Previously, the wait-for-active-passive-target.sh script would hold off BMC Ready until after the active target was started, and now it will also wait up to another 15 minutes for the file
/run/openbmc/bmc_redundancy_determined to exist.

The ActiveRoleHandler will then write that file after the redundancy work is done. It will remain until the BMC is rebooted.

It will also be written on the new active BMC after a failover, though at this point there are no users of that.

Tested:

File is written:
```
$ ls /run/openbmc/
active-bmc                 bmc_position               bmc_redundancy_determined
```

BMC Ready is held off relevant traces:

```
wait-for-active-passive-target.sh[853]: BMC role determined, now waiting for obmc-bmc-active.target to start

phosphor-rbmc-state-manager[846]: Waiting up to 10 minutes for peer connection

phosphor-rbmc-state-manager[846]: Peer now connected

phosphor-rbmc-state-manager[846]: Full sync completed with status xyz.openbmc_project.Control.SyncBMCData.FullSyncStatus.FullSyncCompleted

wait-for-active-passive-target.sh[853]: Redundancy determined file found

phosphor-bmc-state-manager[740]: BMC_READY
```

Change-Id: Iba27171a47d85d3c9ef2c5daadf67d4b5ae9f134