### PR TITLE
RBMC: Change ReasonsForNoRedundancy to a vector

### DIFF
--- a/redundant-bmc/src/redundancy.cpp
+++ b/redundant-bmc/src/redundancy.cpp
@@ -15,66 +15,66 @@ ReasonsForNoRedundancy getNoRedundancyReasons(const Input& input)
 
     if (input.role != Role::Active)
     {
-        reasons.insert(BMCNotActive);
+        reasons.push_back(BMCNotActive);
     }
 
     if (input.manualDisable)
     {
-        reasons.insert(ManuallyDisabled);
+        reasons.push_back(ManuallyDisabled);
     }
 
     if (!input.siblingPresent)
     {
-        reasons.insert(SiblingMissing);
+        reasons.push_back(SiblingMissing);
     }
     else
     {
         if (!input.siblingAlive)
         {
-            reasons.insert(SiblingNotAlive);
+            reasons.push_back(SiblingNotAlive);
         }
         else
         {
             if (!input.siblingProvisioned)
             {
-                reasons.insert(SiblingNotProvisioned);
+                reasons.push_back(SiblingNotProvisioned);
             }
 
             if (input.siblingRole != Role::Passive)
             {
-                reasons.insert(SiblingNotPassive);
+                reasons.push_back(SiblingNotPassive);
             }
 
             if (input.siblingCannotBeActive)
             {
-                reasons.insert(SiblingCannotBeActive);
+                reasons.push_back(SiblingCannotBeActive);
             }
 
             if (!input.codeVersionsMatch)
             {
-                reasons.insert(CodeVersionMismatch);
+                reasons.push_back(CodeVersionMismatch);
             }
 
             if (!input.peerConnected)
             {
-                reasons.insert(NetworkError);
+                reasons.push_back(NetworkError);
             }
 
             if (input.siblingState != BMCState::Ready)
             {
-                reasons.insert(SiblingNotAtReady);
+                reasons.push_back(SiblingNotAtReady);
             }
 
             if (input.syncFailed)
             {
-                reasons.insert(DataSyncFailed);
+                reasons.push_back(DataSyncFailed);
             }
         }
     }
 
     if (input.redundancyOffAtRuntimeStart)
     {
-        reasons.insert(RedundancyOffAtRuntimeStart);
+        reasons.push_back(RedundancyOffAtRuntimeStart);
     }
 
     return reasons;

--- a/redundant-bmc/src/redundancy.hpp
+++ b/redundant-bmc/src/redundancy.hpp
@@ -41,7 +41,7 @@ struct Input
     bool peerConnected;
 };
 
-using ReasonsForNoRedundancy = std::set<ReasonForNoRedundancy>;
+using ReasonsForNoRedundancy = std::vector<ReasonForNoRedundancy>;
 
 /**
  * @brief Returns the reasons that redundancy can't be enabled.

--- a/redundant-bmc/src/redundancy_interface.cpp
+++ b/redundant-bmc/src/redundancy_interface.cpp
@@ -110,7 +110,7 @@ bool RedundancyInterface::set_property(
 
 bool RedundancyInterface::set_property(
     [[maybe_unused]] reasons_for_no_redundancy_t type,
-    const std::set<ReasonForNoRedundancy>& reasons)
+    const std::vector<ReasonForNoRedundancy>& reasons)
 {
     if (reasons == reasons_for_no_redundancy_)
     {
@@ -118,12 +118,12 @@ bool RedundancyInterface::set_property(
     }
 
     // Use the last segment of the string name to trace and save for debug
-    std::set<std::string> names;
+    std::vector<std::string> names;
     std::ranges::for_each(reasons, [&names](const auto& reason) {
         auto shortName = convertReasonForNoRedundancyToString(reason);
         shortName = shortName.substr(shortName.find_last_of('.') + 1);
         lg2::info("No redundancy because: {DESC}", "DESC", shortName);
-        names.insert(shortName);
+        names.push_back(shortName);
     });
 
     try

--- a/redundant-bmc/src/redundancy_interface.hpp
+++ b/redundant-bmc/src/redundancy_interface.hpp
@@ -65,7 +65,7 @@ class RedundancyInterface :
      * @return If the property value changed
      */
     bool set_property(reasons_for_no_redundancy_t type,
-                      const std::set<ReasonForNoRedundancy>& reasons);
+                      const std::vector<ReasonForNoRedundancy>& reasons);
 
   private:
     /**

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -166,7 +166,7 @@ void SiblingImpl::loadRedundancyProps(
     if (it != propertyMap.end())
     {
         const auto& reasons =
-            std::get<std::set<ReasonForNoRedundancy>>(it->second);
+            std::get<std::vector<ReasonForNoRedundancy>>(it->second);
         redundancy.hasReasonForNoRedundancy = !reasons.empty();
     }
 }

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -2,7 +2,7 @@
 #pragma once
 #include "sibling.hpp"
 
-#include <set>
+#include <vector>
 
 namespace rbmc
 {
@@ -19,7 +19,7 @@ class SiblingImpl : public Sibling
   public:
     using PropertyVariant =
         std::variant<std::string, bool, Role, size_t, BMCState,
-                     std::set<ReasonForNoRedundancy>>;
+                     std::vector<ReasonForNoRedundancy>>;
     using PropertyMap = std::unordered_map<std::string, PropertyVariant>;
     using InterfaceMap = std::map<std::string, PropertyMap>;
     using ManagedObjects =


### PR DESCRIPTION
The property is changing to a D-Bus array from a set so that the most important reasons can be listed first instead of just having it be sorted alphabetically.

The code is already adding the reasons in priority order, and with the property change they can now be read that way.

Tested:
Everything still works, can see multiple reasons:

```
Reasons for no BMC redundancy:
    ManuallyDisabled
    SiblingCannotBeActive
```

Change-Id: I6940d8fc089980deeed61b9555a071fec6ae0bf3