### PR TITLE
RBMC: Use barriers to synchronize init

### DIFF
--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -193,14 +193,18 @@ sdbusplus::async::task<int> runAsyncCmd(sdbusplus::async::context& ctx,
 
 } // namespace util
 
-// NOLINTNEXTLINE
 sdbusplus::async::task<> ServicesImpl::init()
 {
-    ctx.spawn(watchHostInterfacesAdded());
-    ctx.spawn(watchHostStatePropertiesChanged());
-    ctx.spawn(watchBootProgressPropertiesChanged());
-    ctx.spawn(watchProvisioningInterfacesAdded());
-    ctx.spawn(watchProvisioningPropertiesChanged());
+    auto barrier = std::make_shared<sdbusplus::async::barrier>(6);
+
+    ctx.spawn(watchHostInterfacesAdded(barrier));
+    ctx.spawn(watchHostStatePropertiesChanged(barrier));
+    ctx.spawn(watchBootProgressPropertiesChanged(barrier));
+    ctx.spawn(watchProvisioningInterfacesAdded(barrier));
+    ctx.spawn(watchProvisioningPropertiesChanged(barrier));
+
+    co_await barrier->wait();
+
     co_await readHostState();
     co_await readBootProgress();
     co_await readProvisioningProperties();
@@ -231,11 +235,13 @@ sdbusplus::async::task<> ServicesImpl::readHostState()
     co_return;
 }
 
-// NOLINTNEXTLINE
-sdbusplus::async::task<> ServicesImpl::watchHostInterfacesAdded()
+sdbusplus::async::task<> ServicesImpl::watchHostInterfacesAdded(
+    std::shared_ptr<sdbusplus::async::barrier> barrier)
 {
     sdbusplus::async::match match(
         ctx, rules::interfacesAddedAtPath(object_path::hostState));
+
+    co_await barrier->wait();
 
     while (!ctx.stop_requested())
     {
@@ -276,12 +282,14 @@ sdbusplus::async::task<> ServicesImpl::watchHostInterfacesAdded()
     co_return;
 }
 
-// NOLINTNEXTLINE
-sdbusplus::async::task<> ServicesImpl::watchHostStatePropertiesChanged()
+sdbusplus::async::task<> ServicesImpl::watchHostStatePropertiesChanged(
+    std::shared_ptr<sdbusplus::async::barrier> barrier)
 {
     sdbusplus::async::match match(
         ctx,
         rules::propertiesChanged(object_path::hostState, HostState::interface));
+
+    co_await barrier->wait();
 
     while (!ctx.stop_requested())
     {
@@ -348,12 +356,14 @@ sdbusplus::async::task<> ServicesImpl::readProvisioningProperties()
     }
 }
 
-// NOLINTNEXTLINE
-sdbusplus::async::task<> ServicesImpl::watchBootProgressPropertiesChanged()
+sdbusplus::async::task<> ServicesImpl::watchBootProgressPropertiesChanged(
+    std::shared_ptr<sdbusplus::async::barrier> barrier)
 {
     sdbusplus::async::match match(
         ctx, rules::propertiesChanged(object_path::hostState,
                                       BootProgress::interface));
+
+    co_await barrier->wait();
 
     while (!ctx.stop_requested())
     {
@@ -410,10 +420,13 @@ void ServicesImpl::loadProvisioningProps(const ProvisioningPropMap& propertyMap)
     }
 }
 
-sdbusplus::async::task<> ServicesImpl::watchProvisioningInterfacesAdded()
+sdbusplus::async::task<> ServicesImpl::watchProvisioningInterfacesAdded(
+    std::shared_ptr<sdbusplus::async::barrier> barrier)
 {
     sdbusplus::async::match match(
         ctx, rules::interfacesAddedAtPath(Provisioning::instance_path));
+
+    co_await barrier->wait();
 
     while (!ctx.stop_requested())
     {
@@ -430,11 +443,14 @@ sdbusplus::async::task<> ServicesImpl::watchProvisioningInterfacesAdded()
     }
 }
 
-sdbusplus::async::task<> ServicesImpl::watchProvisioningPropertiesChanged()
+sdbusplus::async::task<> ServicesImpl::watchProvisioningPropertiesChanged(
+    std::shared_ptr<sdbusplus::async::barrier> barrier)
 {
     sdbusplus::async::match match(
         ctx, rules::propertiesChanged(Provisioning::instance_path,
                                       Provisioning::interface));
+
+    co_await barrier->wait();
 
     while (!ctx.stop_requested())
     {

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -3,6 +3,7 @@
 
 #include "services.hpp"
 
+#include <sdbusplus/async/barrier.hpp>
 #include <xyz/openbmc_project/Provisioning/Provisioning/common.hpp>
 #include <xyz/openbmc_project/State/Boot/Progress/common.hpp>
 #include <xyz/openbmc_project/State/Host/common.hpp>
@@ -202,13 +203,19 @@ class ServicesImpl : public Services
 
     /**
      * @brief Starts the InterfacesAdded watch for the host state
+     *
+     * @param[in] barrier - Initialization barrier
      */
-    sdbusplus::async::task<> watchHostInterfacesAdded();
+    sdbusplus::async::task<> watchHostInterfacesAdded(
+        std::shared_ptr<sdbusplus::async::barrier> barrier);
 
     /**
      * @brief Starts the PropertiesChanged watch for the host state
+     *
+     * @param[in] barrier - Initialization barrier
      */
-    sdbusplus::async::task<> watchHostStatePropertiesChanged();
+    sdbusplus::async::task<> watchHostStatePropertiesChanged(
+        std::shared_ptr<sdbusplus::async::barrier> barrier);
 
     /**
      * @brief Reads the CurrentHostState property
@@ -222,18 +229,27 @@ class ServicesImpl : public Services
 
     /**
      * @brief Starts the PropertiesChanged watch for the BootProgress property
+     *
+     * @param[in] barrier - Initialization barrier
      */
-    sdbusplus::async::task<> watchBootProgressPropertiesChanged();
+    sdbusplus::async::task<> watchBootProgressPropertiesChanged(
+        std::shared_ptr<sdbusplus::async::barrier> barrier);
 
     /**
      * @brief Starts the InterfacesAdded watch for the Provisioning interface
+     *
+     * @param[in] barrier - Initialization barrier
      */
-    sdbusplus::async::task<> watchProvisioningInterfacesAdded();
+    sdbusplus::async::task<> watchProvisioningInterfacesAdded(
+        std::shared_ptr<sdbusplus::async::barrier> barrier);
 
     /**
      * @brief Starts the PropertiesChanged watch for the Provisioning interface
+     *
+     * @param[in] barrier - Initialization barrier
      */
-    sdbusplus::async::task<> watchProvisioningPropertiesChanged();
+    sdbusplus::async::task<> watchProvisioningPropertiesChanged(
+        std::shared_ptr<sdbusplus::async::barrier> barrier);
 
     /**
      * @brief Reads the Provisioning interface properties

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -34,11 +34,15 @@ sdbusplus::async::task<> SiblingImpl::init()
         co_return;
     }
 
+    auto barrier = std::make_shared<sdbusplus::async::barrier>(4);
+
     // Start the D-Bus watches for the signals that don't
     // need a service name.
-    ctx.spawn(watchInterfaceAdded());
-    ctx.spawn(watchInterfaceRemoved());
-    ctx.spawn(watchPropertyChanged());
+    ctx.spawn(watchInterfaceAdded(barrier));
+    ctx.spawn(watchInterfaceRemoved(barrier));
+    ctx.spawn(watchPropertyChanged(barrier));
+
+    co_await barrier->wait();
 
     serviceName = co_await lookupServiceName();
 
@@ -205,12 +209,15 @@ void SiblingImpl::loadAvailabilityProps(
     }
 }
 
-// NOLINTNEXTLINE
-sdbusplus::async::task<> SiblingImpl::watchInterfaceAdded()
+sdbusplus::async::task<> SiblingImpl::watchInterfaceAdded(
+    std::shared_ptr<sdbusplus::async::barrier> barrier)
 {
     namespace rules = sdbusplus::bus::match::rules;
     sdbusplus::async::match match(ctx,
                                   rules::interfacesAddedAtPath(objectPath));
+
+    co_await barrier->wait();
+
     while (!ctx.stop_requested())
     {
         auto [_, interfaces] =
@@ -250,12 +257,14 @@ sdbusplus::async::task<> SiblingImpl::watchInterfaceAdded()
     }
 }
 
-// NOLINTNEXTLINE
-sdbusplus::async::task<> SiblingImpl::watchInterfaceRemoved()
+sdbusplus::async::task<> SiblingImpl::watchInterfaceRemoved(
+    std::shared_ptr<sdbusplus::async::barrier> barrier)
 {
     namespace rules = sdbusplus::bus::match::rules;
     sdbusplus::async::match match(ctx,
                                   rules::interfacesRemovedAtPath(objectPath));
+
+    co_await barrier->wait();
 
     while (!ctx.stop_requested())
     {
@@ -293,12 +302,14 @@ sdbusplus::async::task<> SiblingImpl::watchInterfaceRemoved()
     }
 }
 
-// NOLINTNEXTLINE
-sdbusplus::async::task<> SiblingImpl::watchPropertyChanged()
+sdbusplus::async::task<> SiblingImpl::watchPropertyChanged(
+    std::shared_ptr<sdbusplus::async::barrier> barrier)
 {
     sdbusplus::async::match match(
         ctx, std::format("type='signal',member='PropertiesChanged',path='{}'",
                          objectPath));
+
+    co_await barrier->wait();
 
     while (!ctx.stop_requested())
     {

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -2,6 +2,8 @@
 #pragma once
 #include "sibling.hpp"
 
+#include <sdbusplus/async/barrier.hpp>
+
 #include <vector>
 
 namespace rbmc
@@ -247,13 +249,19 @@ class SiblingImpl : public Sibling
   private:
     /**
      * @brief Starts a Sibling InterfacesAdded watch
+     *
+     * @param[in] barrier - Initialization barrier
      */
-    sdbusplus::async::task<> watchInterfaceAdded();
+    sdbusplus::async::task<> watchInterfaceAdded(
+        std::shared_ptr<sdbusplus::async::barrier> barrier);
 
     /**
      * @brief Starts a Sibling InterfacesRemoved watch
+     *
+     * @param[in] barrier - Initialization barrier
      */
-    sdbusplus::async::task<> watchInterfaceRemoved();
+    sdbusplus::async::task<> watchInterfaceRemoved(
+        std::shared_ptr<sdbusplus::async::barrier> barrier);
 
     /**
      * @brief Starts a Sibling NameOwnerChanged watch
@@ -262,8 +270,11 @@ class SiblingImpl : public Sibling
 
     /**
      * @brief Starts a PropertyChanged watch for all interfaces
+     *
+     * @param[in] barrier - Initialization barrier
      */
-    sdbusplus::async::task<> watchPropertyChanged();
+    sdbusplus::async::task<> watchPropertyChanged(
+        std::shared_ptr<sdbusplus::async::barrier> barrier);
 
     /**
      * @brief Sets initial values for all properties


### PR DESCRIPTION
Use the new sdbusplus::async::barrier in the Services and Sibling init functions to ensure that all the IA & PC match objects have been created before the code attempts to read initial values.

Because the match functions were spawned, there was nothing to guarantee they would have created the matches before the initial value was read, leaving a window where if the value changes after the read and before the match was created, it would have been missed.

Tested:
Everything still works.

Change-Id: Ia9687fe26245a36d5e480531115654abb0cd0777