### PR TITLE
RBMC: Add PeerConnected to rbmctool output

### DIFF
--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -202,22 +202,27 @@ sdbusplus::async::task<> getLocalBMCInfo(sdbusplus::async::context& ctx,
         output["Failovers Allowed"] = props.failovers_allowed;
         output["Failover In Progress"] = props.failover_in_progress;
         output["FW Version Hash"] = services.getFWVersion();
-        output["Provisioned"] = services.getProvisioned();
 
         try
         {
-            auto peerConnected = co_await Provisioning(ctx)
-                                     .service(provService)
-                                     .path(Provisioning::instance_path)
-                                     .peer_connected();
-
-            if (peerConnected != PeerConnectionStatus::Connected)
+            auto provProps = co_await Provisioning(ctx)
+                                 .service(provService)
+                                 .path(Provisioning::instance_path)
+                                 .properties();
+            if (!provProps.provisioned)
             {
-                output["Peer Connected"] = getPDIEnumString(peerConnected);
+                output["Paired"] = provProps.provisioned;
+            }
+
+            if (provProps.peer_connected != PeerConnectionStatus::Connected)
+            {
+                output["Peer Connected"] =
+                    getPDIEnumString(provProps.peer_connected);
             }
         }
         catch (const std::exception& e)
         {
+            output["Paired"] = e.what();
             output["PeerConnected"] = e.what();
         }
 
@@ -293,7 +298,7 @@ sdbusplus::async::task<> getSiblingBMCInfo(sdbusplus::async::context& ctx,
         output["Failovers Allowed"] = rProps.failovers_allowed;
         output["BMC State"] = getPDIEnumString(state);
         output["FW Version Hash"] = fwVersion;
-        output["Provisioned"] = true; // TODO
+        output["Paired"] = true; // TODO
     }
     catch (const std::exception& e)
     {

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -8,7 +8,9 @@
 
 #include <CLI/CLI.hpp>
 #include <nlohmann/json.hpp>
+#include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Control/Failover/client.hpp>
+#include <xyz/openbmc_project/Provisioning/Provisioning/client.hpp>
 #include <xyz/openbmc_project/Software/Version/client.hpp>
 #include <xyz/openbmc_project/State/BMC/Redundancy/client.hpp>
 #include <xyz/openbmc_project/State/BMC/client.hpp>
@@ -22,9 +24,14 @@ using BMCState = sdbusplus::client::xyz::openbmc_project::state::BMC<>;
 using Role = Redundancy::Role;
 using Failover = sdbusplus::client::xyz::openbmc_project::control::Failover<>;
 using Version = sdbusplus::client::xyz::openbmc_project::software::Version<>;
+using Provisioning =
+    sdbusplus::client::xyz::openbmc_project::provisioning::Provisioning<>;
+using PeerConnectionStatus = sdbusplus::common::xyz::openbmc_project::
+    provisioning::Provisioning::PeerConnectionStatus;
 
 constexpr auto siblingService =
     "xyz.openbmc_project.State.BMC.Redundancy.Sibling";
+constexpr auto provService = "xyz.openbmc_project.Provisioning";
 
 template <typename T>
 void printParam(std::string key, const T& value)
@@ -196,6 +203,23 @@ sdbusplus::async::task<> getLocalBMCInfo(sdbusplus::async::context& ctx,
         output["Failover In Progress"] = props.failover_in_progress;
         output["FW Version Hash"] = services.getFWVersion();
         output["Provisioned"] = services.getProvisioned();
+
+        try
+        {
+            auto peerConnected = co_await Provisioning(ctx)
+                                     .service(provService)
+                                     .path(Provisioning::instance_path)
+                                     .peer_connected();
+
+            if (peerConnected != PeerConnectionStatus::Connected)
+            {
+                output["Peer Connected"] = getPDIEnumString(peerConnected);
+            }
+        }
+        catch (const std::exception& e)
+        {
+            output["PeerConnected"] = e.what();
+        }
 
         if (role != "Unknown")
         {


### PR DESCRIPTION
Since the RBMC code uses PeerConnected to enable redundancy, and will wait on it to change to connected, display the value in the rbmctool output.

Only display it if it isn't Connected, as normal operation is for it to be connected assuming the sibling BMC is present.

Also read the real value for the provisioned property, and only display that when it is false. Change the field name to 'Paired' since that is the correct name.