### PR TITLE
RBMC Pairing monitoring enhancements

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -41,7 +41,6 @@ The current rules for role determination are:
 
 1. If the sibling BMC doesn't have a heartbeat, choose active. It could be the
    sibling isn't even present.
-1. If the sibling isn't provisioned, choose active.
 1. If the sibling is already passive, choose active.
 1. If the sibling is already active, choose passive.
 1. If there was previously a failover in progress, choose active. See

--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -57,6 +57,15 @@ sdbusplus::async::task<> ActiveRoleHandler::start()
         co_await sdbusplus::async::execution::when_all(
             sibling.waitForSiblingRole(), sibling.waitForBMCSteadyState(),
             services.waitForPeerConnection());
+
+        // If PeerConnected == true and sibling provisioned == false
+        // a small delay will be needed to let the new provisioned
+        // value propagate to this BMC.
+        if (services.getPeerConnected() &&
+            !sibling.getProvisioned().value_or(true))
+        {
+            co_await sibling.pauseForDataPropagation();
+        }
     }
 
     co_await redMgr.determineRedundancyAndSync();
@@ -131,6 +140,13 @@ sdbusplus::async::task<> ActiveRoleHandler::siblingHealthy()
     co_await sdbusplus::async::execution::when_all(
         sibling.waitForSiblingRole(), sibling.waitForBMCSteadyState(),
         services.waitForPeerConnection());
+
+    // Just like in start(), a delay may be needed to let
+    // the sibling provisioned value propagate.
+    if (services.getPeerConnected() && !sibling.getProvisioned().value_or(true))
+    {
+        co_await sibling.pauseForDataPropagation();
+    }
 
     lg2::info("Attempting to enable redundancy now that sibling is back");
     co_await redMgr.determineRedundancyAndSync();

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -105,6 +105,11 @@ sdbusplus::async::task<> Manager::startup()
     co_await postStartupClearFOInProgress();
 
     spawnRoleHandler();
+
+    if (!services.getProvisioned())
+    {
+        setupProvisionedWatch();
+    }
 }
 
 // NOLINTNEXTLINE
@@ -453,6 +458,61 @@ sdbusplus::async::task<> Manager::doFailoverFromPassive(Requester requester)
     redundancyInterface.failover_in_progress(false);
 
     co_await active->failoverDetermineRedundancy();
+}
+
+void Manager::setupProvisionedWatch()
+{
+    providers->getServices().addProvisionedCallback(
+        Role::Passive,
+        std::bind_front(&Manager::provisionedChangeHandler, this));
+}
+
+void Manager::provisionedChangeHandler(bool provisioned)
+{
+    ctx.spawn(handleProvisionedChange(provisioned));
+}
+
+sdbusplus::async::task<> Manager::handleProvisionedChange(bool provisioned)
+{
+    if (!provisioned)
+    {
+        co_return;
+    }
+
+    // Doublecheck the BMC is passive.  It should be.
+    if (redundancyInterface.role() != Role::Passive)
+    {
+        lg2::warning(
+            "Provisioned just changed to true but BMC not already passive?");
+        providers->getServices().removeProvisionedCallback(Role::Passive);
+        co_return;
+    }
+
+    // If being passive isn't still required, clear the
+    // reasons_for_no_redundancy property which will let the other BMC
+    // know this BMC can be active again.
+
+    auto passiveRoleInfo = co_await determinePassiveRoleIfRequired();
+
+    if (!passiveRoleInfo.has_value())
+    {
+        lg2::info("This BMC is no longer required to be passive");
+
+        // Note: Leave chosePassiveDueToError so the next reboot still sees it.
+
+        redundancyInterface.reasons_for_no_redundancy({});
+
+        // No need for future callbacks.
+        providers->getServices().removeProvisionedCallback(Role::Passive);
+    }
+    else
+    {
+        lg2::warning(
+            "After provisioned property change to true, BMC still required to be passive: {REASON}",
+            "REASON",
+            role_determination::getRoleReasonDescription(
+                passiveRoleInfo->reason));
+    }
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -189,7 +189,6 @@ sdbusplus::async::task<role_determination::RoleInfo> Manager::determineRole()
         // Note:  If these returned nullopts, the algorithm wouldn't use
         //        them anyway because there would be no heartbeat.
         auto siblingRole = sibling.getRole().value_or(Role::Unknown);
-        auto siblingProvisioned = sibling.getProvisioned().value_or(false);
         auto siblingFailoverInProgress =
             sibling.getFailoverInProgress().value_or(false);
 
@@ -207,7 +206,6 @@ sdbusplus::async::task<role_determination::RoleInfo> Manager::determineRole()
             .previousRole = previousRole,
             .siblingRole = siblingRole,
             .siblingAlive = sibling.alive(),
-            .siblingProvisioned = siblingProvisioned,
             .failoverInProgress = redundancyInterface.failover_in_progress(),
             .siblingFailoverInProgress = siblingFailoverInProgress};
 

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -140,6 +140,25 @@ class Manager :
         const FailoverOptions& options);
 
     /**
+     * @brief Setup watch for provisioning changes
+     */
+    void setupProvisionedWatch();
+
+    /**
+     * @brief Handler for provisioned property changes
+     *
+     * @param[in] provisioned - The new provisioned value
+     */
+    void provisionedChangeHandler(bool provisioned);
+
+    /**
+     * @brief Async handler spawned by provisionedChangeHandler
+     *
+     * @param[in] provisioned - The new provisioned value
+     */
+    sdbusplus::async::task<> handleProvisionedChange(bool provisioned);
+
+    /**
      * @brief The async context object
      */
     sdbusplus::async::context& ctx;

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -294,11 +294,19 @@ sdbusplus::async::task<> getSiblingBMCInfo(sdbusplus::async::context& ctx,
                          .path(path.str)
                          .current_bmc_state();
 
+        auto provProps = co_await Provisioning(ctx)
+                             .service(siblingService)
+                             .path(path.str)
+                             .properties();
+
         output["Redundancy Enabled"] = rProps.redundancy_enabled;
         output["Failovers Allowed"] = rProps.failovers_allowed;
         output["BMC State"] = getPDIEnumString(state);
         output["FW Version Hash"] = fwVersion;
-        output["Paired"] = true; // TODO
+        if (!provProps.provisioned)
+        {
+            output["Paired"] = provProps.provisioned;
+        }
     }
     catch (const std::exception& e)
     {

--- a/redundant-bmc/src/role_determination.cpp
+++ b/redundant-bmc/src/role_determination.cpp
@@ -21,11 +21,6 @@ RoleInfo determineRole(const Input& input)
         result = {Role::Active, RoleReason::siblingNotAlive};
     }
 
-    else if (!input.siblingProvisioned)
-    {
-        result = {Role::Active, RoleReason::siblingNotProvisioned};
-    }
-
     else if (input.siblingRole == Role::Passive)
     {
         result = {Role::Active, RoleReason::siblingPassive};
@@ -81,9 +76,6 @@ std::string getRoleReasonDescription(RoleReason reason)
             break;
         case RoleReason::siblingNotAlive:
             desc = "Sibling not alive"s;
-            break;
-        case RoleReason::siblingNotProvisioned:
-            desc = "Sibling is not provisioned"s;
             break;
         case RoleReason::siblingPassive:
             desc = "Sibling is already passive"s;

--- a/redundant-bmc/src/role_determination.hpp
+++ b/redundant-bmc/src/role_determination.hpp
@@ -21,7 +21,6 @@ struct Input
     Role previousRole;
     Role siblingRole;
     bool siblingAlive;
-    bool siblingProvisioned;
     bool failoverInProgress;
     bool siblingFailoverInProgress;
 };
@@ -33,7 +32,6 @@ enum class RoleReason
 {
     unknown,
     siblingNotAlive,
-    siblingNotProvisioned,
     siblingPassive,
     siblingActive,
     resumePrevious,

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -46,6 +46,7 @@ class Services
 
     using SystemStateCallback = std::function<void(SystemState)>;
     using PeerConnectedCallback = std::function<void(bool)>;
+    using ProvisionedCallback = std::function<void(bool)>;
 
     /**
      * @brief Sets up the D-Bus matches
@@ -224,6 +225,28 @@ class Services
     }
 
     /**
+     * @brief Add a function that gets called when the provisioned status
+     *        changes.
+     *
+     * @param[in] role - The role to register with
+     * @param[in] callback - The function to call
+     */
+    void addProvisionedCallback(Role role, ProvisionedCallback&& callback)
+    {
+        provisionedCBs.emplace(role, std::move(callback));
+    }
+
+    /**
+     * @brief Remove a specific provisioned change callback by role.
+     *
+     * @param[in] role - The role of the callback to remove
+     */
+    void removeProvisionedCallback(Role role)
+    {
+        provisionedCBs.erase(role);
+    }
+
+    /**
      * @brief On the system inventory object, check that its Progress
      *        Status property is 'Completed'.
      *
@@ -260,6 +283,11 @@ class Services
      * @brief The functions to call when the peer connected status changes
      */
     std::map<Role, PeerConnectedCallback> peerConnectedCBs;
+
+    /**
+     * @brief The functions to call when the provisioned status changes
+     */
+    std::map<Role, ProvisionedCallback> provisionedCBs;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -414,9 +414,18 @@ void ServicesImpl::loadProvisioningProps(const ProvisioningPropMap& propertyMap)
     it = propertyMap.find("Provisioned");
     if (it != propertyMap.end())
     {
+        auto prevProvisioned = provisioned;
         provisioned = std::get<bool>(it->second);
 
         lg2::info("The new Provisioned value is {PROV}", "PROV", provisioned);
+
+        // Invoke callbacks if value changed
+        if (prevProvisioned != provisioned)
+        {
+            std::ranges::for_each(provisionedCBs, [this](const auto& entry) {
+                entry.second(provisioned);
+            });
+        }
     }
 }
 

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -157,6 +157,11 @@ class Sibling
     virtual sdbusplus::async::task<> pauseForHeartbeatChange() const = 0;
 
     /**
+     * @brief Pause to allow time for data from the sibling BMC to propagate.
+     */
+    virtual sdbusplus::async::task<> pauseForDataPropagation() const = 0;
+
+    /**
      * @brief Returns the D-Bus service name for the sibling service.
      *
      * Returns an empty string if it isn't on D-Bus.

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -3,6 +3,7 @@
 
 #include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/ObjectMapper/client.hpp>
+#include <xyz/openbmc_project/Provisioning/Provisioning/common.hpp>
 #include <xyz/openbmc_project/Software/Version/common.hpp>
 #include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
 #include <xyz/openbmc_project/State/BMC/common.hpp>
@@ -19,6 +20,8 @@ using VersionIntf = sdbusplus::common::xyz::openbmc_project::software::Version;
 using BMCStateIntf = sdbusplus::common::xyz::openbmc_project::state::BMC;
 using AvailIntf =
     sdbusplus::common::xyz::openbmc_project::state::decorator::Availability;
+using ProvisioningIntf =
+    sdbusplus::common::xyz::openbmc_project::provisioning::Provisioning;
 
 SiblingImpl::SiblingImpl(sdbusplus::async::context& ctx) :
     ctx(ctx), objectPath(std::string{RedIntf::namespace_path::value} + '/' +
@@ -209,6 +212,18 @@ void SiblingImpl::loadAvailabilityProps(
     }
 }
 
+void SiblingImpl::loadProvisioningProps(
+    const SiblingImpl::PropertyMap& propertyMap)
+{
+    provisioning.present = true;
+
+    auto it = propertyMap.find("Provisioned");
+    if (it != propertyMap.end())
+    {
+        provisioning.provisioned = std::get<bool>(it->second);
+    }
+}
+
 sdbusplus::async::task<> SiblingImpl::watchInterfaceAdded(
     std::shared_ptr<sdbusplus::async::barrier> barrier)
 {
@@ -289,6 +304,10 @@ sdbusplus::async::task<> SiblingImpl::watchInterfaceRemoved(
         if (std::ranges::contains(interfaces, AvailIntf::interface))
         {
             availability.present = false;
+        }
+        if (std::ranges::contains(interfaces, ProvisioningIntf::interface))
+        {
+            provisioning.present = false;
         }
 
         // If alive before and all interfaces are now gone invoke the callbacks
@@ -396,6 +415,10 @@ void SiblingImpl::loadFromPropertyMap(const std::string& interface,
     else if (interface == AvailIntf::interface)
     {
         loadAvailabilityProps(propertyMap);
+    }
+    else if (interface == ProvisioningIntf::interface)
+    {
+        loadProvisioningProps(propertyMap);
     }
 }
 

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -501,4 +501,11 @@ sdbusplus::async::task<> SiblingImpl::pauseForHeartbeatChange() const
     co_return co_await sdbusplus::async::sleep_for(ctx, 5s);
 }
 
+sdbusplus::async::task<> SiblingImpl::pauseForDataPropagation() const
+{
+    using namespace std::chrono_literals;
+    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
+    co_return co_await sdbusplus::async::sleep_for(ctx, 4s);
+}
+
 } // namespace rbmc

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -237,6 +237,11 @@ class SiblingImpl : public Sibling
     sdbusplus::async::task<> pauseForHeartbeatChange() const override;
 
     /**
+     * @brief Pause to allow time for data from the sibling BMC to propagate.
+     */
+    sdbusplus::async::task<> pauseForDataPropagation() const override;
+
+    /**
      * @brief Returns the D-Bus service name for the sibling service.
      *
      * Returns an empty string if it isn't on D-Bus.

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -132,8 +132,7 @@ class SiblingImpl : public Sibling
     {
         if (alive())
         {
-            // TBD which interface to use.
-            return true;
+            return provisioning.provisioned;
         }
 
         return std::nullopt;
@@ -316,6 +315,14 @@ class SiblingImpl : public Sibling
     void loadAvailabilityProps(const PropertyMap& propertyMap);
 
     /**
+     * @brief Sets Provisioning data members with whatever is in the property
+     * map
+     *
+     * @param[in] propertyMap - The property name -> value map
+     */
+    void loadProvisioningProps(const PropertyMap& propertyMap);
+
+    /**
      * @brief Sets data members with whatever is in the property map
      *
      * @param[in] interface - The interface name
@@ -333,6 +340,7 @@ class SiblingImpl : public Sibling
         bmcState.present = false;
         version.present = false;
         availability.present = false;
+        provisioning.present = false;
     }
 
     /**
@@ -407,6 +415,17 @@ class SiblingImpl : public Sibling
      * @brief Availability presence and value
      */
     Availability availability;
+
+    struct Provisioning
+    {
+        bool present = false;
+        bool provisioned = false;
+    };
+
+    /**
+     * @brief Provisioning presence and value
+     */
+    Provisioning provisioning;
 
     /**
      * @brief The D-Bus object path for the sibling.

--- a/redundant-bmc/test/role_determination_test.cpp
+++ b/redundant-bmc/test/role_determination_test.cpp
@@ -17,7 +17,6 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
                     .previousRole = Unknown,
                     .siblingRole = Unknown,
                     .siblingAlive = true,
-                    .siblingProvisioned = true,
                     .failoverInProgress = false,
                     .siblingFailoverInProgress = false};
 
@@ -32,7 +31,6 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
                     .previousRole = Unknown,
                     .siblingRole = Unknown,
                     .siblingAlive = true,
-                    .siblingProvisioned = true,
                     .failoverInProgress = false,
                     .siblingFailoverInProgress = false};
         RoleInfo info{Passive, positionNonzero};
@@ -47,7 +45,6 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
                     .previousRole = Unknown,
                     .siblingRole = Unknown,
                     .siblingAlive = false,
-                    .siblingProvisioned = true,
                     .failoverInProgress = false,
                     .siblingFailoverInProgress = false};
 
@@ -56,29 +53,12 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
         EXPECT_EQ(getRoleReasonDescription(info.reason), "Sibling not alive");
     }
 
-    // Sibling not provisioned
-    {
-        Input input{.bmcPosition = 1,
-                    .previousRole = Unknown,
-                    .siblingRole = Unknown,
-                    .siblingAlive = true,
-                    .siblingProvisioned = false,
-                    .failoverInProgress = false,
-                    .siblingFailoverInProgress = false};
-
-        RoleInfo info{Active, siblingNotProvisioned};
-        EXPECT_EQ(determineRole(input), info);
-        EXPECT_EQ(getRoleReasonDescription(info.reason),
-                  "Sibling is not provisioned");
-    }
-
     // Sibling already active, this pos = 0
     {
         Input input{.bmcPosition = 0,
                     .previousRole = Unknown,
                     .siblingRole = Active,
                     .siblingAlive = true,
-                    .siblingProvisioned = true,
                     .failoverInProgress = false,
                     .siblingFailoverInProgress = false};
 
@@ -94,7 +74,6 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
                     .previousRole = Unknown,
                     .siblingRole = Passive,
                     .siblingAlive = true,
-                    .siblingProvisioned = true,
                     .failoverInProgress = false,
                     .siblingFailoverInProgress = false};
 
@@ -110,7 +89,6 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
                     .previousRole = Passive,
                     .siblingRole = Unknown,
                     .siblingAlive = true,
-                    .siblingProvisioned = true,
                     .failoverInProgress = false,
                     .siblingFailoverInProgress = false};
 
@@ -127,7 +105,6 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
                     .previousRole = Active,
                     .siblingRole = Unknown,
                     .siblingAlive = true,
-                    .siblingProvisioned = true,
                     .failoverInProgress = false,
                     .siblingFailoverInProgress = false};
 
@@ -145,7 +122,6 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
                     .previousRole = Active,
                     .siblingRole = Unknown,
                     .siblingAlive = true,
-                    .siblingProvisioned = true,
                     .failoverInProgress = true,
                     .siblingFailoverInProgress = false};
 
@@ -164,7 +140,6 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
                     .previousRole = Active,
                     .siblingRole = Unknown,
                     .siblingAlive = true,
-                    .siblingProvisioned = true,
                     .failoverInProgress = false,
                     .siblingFailoverInProgress = true};
 


### PR DESCRIPTION
1. Don't use the sibling pairing value in role determination since it will aleady be passive anyway.
2. When a BMC is paired, clear the 'cannot be active' indication so that it can become active in the future without a reboot.
3. The sibling pairing result is now available in the sibling daemon so get it from there.

The self pairing value is still hardcoded to true because in simulation there is no pairing done yet.