### PR TITLE
RBMC: Put back in sibling BMC state callback

### DIFF
--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -190,10 +190,19 @@ void SiblingImpl::loadStateProps(const SiblingImpl::PropertyMap& propertyMap)
 {
     bmcState.present = true;
 
+    auto old = bmcState.state;
     auto it = propertyMap.find("CurrentBMCState");
     if (it != propertyMap.end())
     {
         bmcState.state = std::get<BMCState>(it->second);
+    }
+
+    if (bmcState.state != old)
+    {
+        for (const auto& callback : std::ranges::views::values(bmcStateCBs))
+        {
+            callback(bmcState.state);
+        }
     }
 }
 


### PR DESCRIPTION
When the SiblingImpl code moved to using unique interfaces for the properties instead of just one big 'Sibling' one, executing the callback when the BMC state property changed was dropped.  Add it back.

Tested:
```
phosphor-rbmc-state-manager[1397]: Sibling property CurrentBMCState changed
phosphor-rbmc-state-manager[1397]: Sibling BMC went to Quiesce, disabling redundancy
```

Change-Id: If05ee1c15c537d8d5d62b98eb4afe670656d4889