### PR TITLE
Add config file to the RBMC manager and use it to read the sibling present GPIO

### DIFF
--- a/meson.options
+++ b/meson.options
@@ -153,3 +153,10 @@ option(
     value: 'enabled',
     description: 'Enable redundant BMC state management',
 )
+
+option(
+    'rbmc-config-file',
+    type: 'string',
+    value: 'default.json',
+    description: 'Redundant BMC config file to install (relative to redundant-bmc/config_files/)',
+)

--- a/redundant-bmc/config_files/README.md
+++ b/redundant-bmc/config_files/README.md
@@ -1,0 +1,58 @@
+# Redundant BMC Configuration Files
+
+This directory contains the platform-specific redundant BMC configuration files.
+
+A config file is required, and the one to use is specified with the
+`rbmc-config-file` meson option.
+
+It is then installed into
+`/usr/share/phosphor-state-manager/redundant-bmc/config.json`.
+
+## Config File Format
+
+```json
+{
+  "sibling_bmc_reset_gpio": {
+    "name": "sibling-bmc-reset-n",
+    "polarity": "low"
+  },
+  "bmc_configs": [
+    {
+      "bmc_pos": 0,
+      "sibling_bmc_present_gpio": {
+        "name": "chassis2-present",
+        "polarity": "low"
+      }
+    },
+    {
+      "bmc_pos": 1,
+      "sibling_bmc_present_gpio": {
+        "name": "chassis1-present",
+        "polarity": "high"
+      }
+    }
+  ]
+}
+```
+
+## Fields
+
+### Top Level
+
+- **sibling_bmc_reset_gpio** (object, required): GPIO configuration for
+  resetting the sibling BMC.
+- **bmc_configs** (array, conditionally required): Array of BMC configuration
+  objects. Required when there is a `sibling_bmc_reset_gpio`, optional when
+  false.
+
+### BMC Config Object
+
+- **bmc_pos** (number, required): Position/index of this BMC (0 or 1).
+- **sibling_bmc_present_gpio** (object, required): GPIO configuration for
+  detecting sibling BMC presence.
+
+### GPIO Config Object (optional)
+
+- **name** (string, required): Name of the GPIO line.
+- **polarity** (string, required): Either "low" or "high" - indicates the active
+  state of the GPIO.

--- a/redundant-bmc/config_files/default.json
+++ b/redundant-bmc/config_files/default.json
@@ -1,0 +1,6 @@
+{
+    "sibling_bmc_reset_gpio": {
+        "name": "sibling-bmc-reset-n",
+        "polarity": "low"
+    }
+}

--- a/redundant-bmc/config_files/huygens.json
+++ b/redundant-bmc/config_files/huygens.json
@@ -1,0 +1,22 @@
+{
+    "sibling_bmc_reset_gpio": {
+        "name": "sibling-bmc-reset-n",
+        "polarity": "low"
+    },
+    "bmc_configs": [
+        {
+            "bmc_pos": 0,
+            "sibling_bmc_present_gpio": {
+                "name": "presence-chassis2",
+                "polarity": "low"
+            }
+        },
+        {
+            "bmc_pos": 1,
+            "sibling_bmc_present_gpio": {
+                "name": "presence-chassis1",
+                "polarity": "low"
+            }
+        }
+    ]
+}

--- a/redundant-bmc/config_files/rbmc-prototype.json
+++ b/redundant-bmc/config_files/rbmc-prototype.json
@@ -1,0 +1,6 @@
+{
+    "sibling_bmc_reset_gpio": {
+        "name": "sibling-bmc-reset-n",
+        "polarity": "low"
+    }
+}

--- a/redundant-bmc/config_files/skiboards.json
+++ b/redundant-bmc/config_files/skiboards.json
@@ -1,0 +1,6 @@
+{
+    "sibling_bmc_reset_gpio": {
+        "name": "sibling-bmc-reset",
+        "polarity": "high"
+    }
+}

--- a/redundant-bmc/meson.build
+++ b/redundant-bmc/meson.build
@@ -1,6 +1,39 @@
 # SPDX-License-Identifier: Apache-2.0
+
+fs = import('fs')
+
 subdir('src')
 
 if get_option('tests').allowed()
     subdir('test')
 endif
+
+rbmc_config_file = get_option('rbmc-config-file')
+if rbmc_config_file == ''
+    error(
+        'Redundant BMC config file must be specified.\n' + 'Check redundant-bmc/config_files/ for available configs.\n' + 'Specify with: -Drbmc-config-file=<filename>',
+    )
+endif
+
+config_source = join_paths(
+    meson.current_source_dir(),
+    'config_files',
+    rbmc_config_file,
+)
+
+# Validate that the specified config file exists
+if not fs.is_file(config_source)
+    error(
+        'Redundant BMC config file not found: @0@\n'.format(config_source) + 'Check redundant-bmc/config_files/ for available configs.\n',
+    )
+endif
+
+install_data(
+    config_source,
+    install_dir: join_paths(
+        get_option('datadir'),
+        'phosphor-state-manager',
+        'redundant-bmc',
+    ),
+    rename: 'config.json',
+)

--- a/redundant-bmc/src/config_data.hpp
+++ b/redundant-bmc/src/config_data.hpp
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "types.hpp"
+
+#include <map>
+#include <optional>
+#include <string>
+
+namespace rbmc
+{
+
+/**
+ * @struct GPIOConfig
+ *
+ * Configuration for a GPIO line
+ */
+struct GPIOConfig
+{
+    /**
+     * @brief The GPIO line name (e.g., "chassis2-present")
+     */
+    std::string name;
+
+    /**
+     * @brief The polarity of the GPIO line
+     *
+     * Low means active when the GPIO reads low
+     * High means active when the GPIO reads high
+     */
+    GPIOPolarity polarity;
+};
+
+/**
+ * @struct BMCConfig
+ *
+ * Configuration for a single BMC
+ */
+struct BMCConfig
+{
+    /**
+     * @brief The BMC position
+     */
+    size_t bmcPos;
+
+    /**
+     * @brief GPIO configuration for detecting sibling BMC presence
+     */
+    GPIOConfig siblingBMCPresentGPIO;
+};
+
+/**
+ * @struct RedundantBMCConfig
+ *
+ * Top-level configuration for redundant BMC functionality
+ */
+struct RedundantBMCConfig
+{
+    /**
+     * @brief GPIO configuration for resetting the sibling BMC
+     */
+    GPIOConfig siblingBMCResetGPIO;
+
+    /**
+     * @brief Configuration for each BMC in the redundant system.
+     *        Map key is the BMC position (0-based)
+     */
+    std::map<size_t, BMCConfig> bmcConfigs;
+};
+
+} // namespace rbmc

--- a/redundant-bmc/src/config_parser.cpp
+++ b/redundant-bmc/src/config_parser.cpp
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "config_parser.hpp"
+
+#include <nlohmann/json.hpp>
+#include <phosphor-logging/lg2.hpp>
+
+#include <fstream>
+#include <stdexcept>
+
+namespace rbmc::config_parser
+{
+
+namespace
+{
+/**
+ * @brief Parse GPIO polarity string to enum
+ *
+ * @param[in] polarity - The polarity string to parse
+ *
+ * @return GpioPolarity enum value
+ * @throws std::runtime_error if polarity is not "low" or "high"
+ */
+GPIOPolarity parsePolarity(const std::string& polarity)
+{
+    if (polarity == "low")
+    {
+        return GPIOPolarity::low;
+    }
+    else if (polarity == "high")
+    {
+        return GPIOPolarity::high;
+    }
+    else
+    {
+        throw std::runtime_error("Invalid GPIO polarity '" + polarity +
+                                 "'. Must be 'low' or 'high'");
+    }
+}
+
+/**
+ * @brief Parse a GPIO configuration from JSON
+ *
+ * @param[in] gpioJSON - The JSON object containing GPIO config
+ * @param[in] fieldName - The name of the GPIO field (for error messages)
+ *
+ * @return GPIOConfig object
+ * @throws std::runtime_error if required fields are missing or invalid
+ */
+GPIOConfig parseGPIOConfig(const nlohmann::json& gpioJSON,
+                           const std::string& fieldName)
+{
+    auto nameIt = gpioJSON.find("name");
+    if (nameIt == gpioJSON.end())
+    {
+        throw std::runtime_error(
+            fieldName + " config missing required 'name' field");
+    }
+
+    auto polarityIt = gpioJSON.find("polarity");
+    if (polarityIt == gpioJSON.end())
+    {
+        throw std::runtime_error(
+            fieldName + " config missing required 'polarity' field");
+    }
+
+    GPIOConfig config;
+    config.name = nameIt->get<std::string>();
+    config.polarity = parsePolarity(polarityIt->get<std::string>());
+    return config;
+}
+
+/**
+ * @brief Parse a single BMC configuration from JSON
+ *
+ * @param[in] bmcJSON - The JSON object containing BMC config
+ *
+ * @return BMCConfig object
+ * @throws std::runtime_error if required fields are missing or invalid
+ */
+BMCConfig parseBMCConfig(const nlohmann::json& bmcJSON)
+{
+    BMCConfig config;
+
+    auto bmcPosIt = bmcJSON.find("bmc_pos");
+    if (bmcPosIt == bmcJSON.end())
+    {
+        throw std::runtime_error("BMC config missing required 'bmc_pos' field");
+    }
+    config.bmcPos = bmcPosIt->get<size_t>();
+
+    auto gpioIt = bmcJSON.find("sibling_bmc_present_gpio");
+    if (gpioIt == bmcJSON.end())
+    {
+        throw std::runtime_error(
+            "BMC config missing required 'sibling_bmc_present_gpio' field");
+    }
+    config.siblingBMCPresentGPIO =
+        parseGPIOConfig(*gpioIt, "sibling_bmc_present_gpio");
+
+    return config;
+}
+
+/**
+ * @brief Parse BMC configurations array from JSON
+ *
+ * @param[in] jsonData - The root JSON object
+ *
+ * @return Map of BMC position to BMCConfig
+ * @throws std::runtime_error if array is invalid or configs are malformed
+ */
+std::map<size_t, BMCConfig> parseBMCConfigs(const nlohmann::json& jsonData)
+{
+    std::map<size_t, BMCConfig> configs;
+
+    auto bmcConfigsIt = jsonData.find("bmc_configs");
+    if (bmcConfigsIt == jsonData.end())
+    {
+        return configs;
+    }
+
+    const auto& bmcConfigsJSON = *bmcConfigsIt;
+    if (!bmcConfigsJSON.is_array())
+    {
+        throw std::runtime_error("'bmc_configs' must be an array");
+    }
+
+    for (const auto& bmcJSON : bmcConfigsJSON)
+    {
+        auto bmcConfig = parseBMCConfig(bmcJSON);
+        auto [it, inserted] =
+            configs.emplace(bmcConfig.bmcPos, std::move(bmcConfig));
+        if (!inserted)
+        {
+            throw std::runtime_error(
+                "Duplicate bmc_pos " + std::to_string(it->first) +
+                " found in bmc_configs array");
+        }
+    }
+
+    return configs;
+}
+
+} // anonymous namespace
+
+RedundantBMCConfig parse(const std::filesystem::path& path)
+{
+    if (!std::filesystem::exists(path))
+    {
+        throw std::runtime_error("Config file not found: " + path.string());
+    }
+
+    try
+    {
+        std::ifstream file(path);
+        if (!file.is_open())
+        {
+            throw std::runtime_error(
+                "Failed to open config file: " + path.string());
+        }
+
+        nlohmann::json jsonData;
+        file >> jsonData;
+
+        RedundantBMCConfig config;
+
+        auto resetGpioIt = jsonData.find("sibling_bmc_reset_gpio");
+        if (resetGpioIt == jsonData.end())
+        {
+            throw std::runtime_error(
+                "Config file missing required 'sibling_bmc_reset_gpio' field");
+        }
+
+        config.siblingBMCResetGPIO =
+            parseGPIOConfig(*resetGpioIt, "sibling_bmc_reset_gpio");
+
+        config.bmcConfigs = parseBMCConfigs(jsonData);
+
+        return config;
+    }
+    catch (const nlohmann::json::exception& e)
+    {
+        throw std::runtime_error("JSON parsing error in config file " +
+                                 path.string() + ": " + e.what());
+    }
+}
+
+} // namespace rbmc::config_parser

--- a/redundant-bmc/src/config_parser.cpp
+++ b/redundant-bmc/src/config_parser.cpp
@@ -185,4 +185,11 @@ RedundantBMCConfig parse(const std::filesystem::path& path)
     }
 }
 
+RedundantBMCConfig readConfig()
+{
+    constexpr auto configPath =
+        "/usr/share/phosphor-state-manager/redundant-bmc/config.json";
+    return parse(configPath);
+}
+
 } // namespace rbmc::config_parser

--- a/redundant-bmc/src/config_parser.hpp
+++ b/redundant-bmc/src/config_parser.hpp
@@ -20,4 +20,13 @@ namespace rbmc::config_parser
  */
 RedundantBMCConfig parse(const std::filesystem::path& path);
 
+/**
+ * @brief Reads the config from file.
+ *
+ * Uses /usr/share/phosphor-state-manager/redundant-bmc/config.json
+ *
+ * @return The parsed configuration
+ */
+RedundantBMCConfig readConfig();
+
 } // namespace rbmc::config_parser

--- a/redundant-bmc/src/config_parser.hpp
+++ b/redundant-bmc/src/config_parser.hpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "config_data.hpp"
+
+#include <filesystem>
+
+namespace rbmc::config_parser
+{
+
+/**
+ * @brief Parse the redundant BMC configuration file from JSON format
+ *
+ * @param[in] path - Path to the JSON file
+ *
+ * @return The parsed configuration
+ *
+ * @throws std::runtime_error if the file doesn't exist or cannot be parsed
+ * @throws nlohmann::json::exception if JSON parsing fails
+ */
+RedundantBMCConfig parse(const std::filesystem::path& path);
+
+} // namespace rbmc::config_parser

--- a/redundant-bmc/src/gpio.cpp
+++ b/redundant-bmc/src/gpio.cpp
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "gpio.hpp"
+
+#include <gpiod.hpp>
+#include <phosphor-logging/lg2.hpp>
+
+#include <chrono>
+#include <thread>
+
+namespace rbmc
+{
+
+namespace
+{
+
+class GPIOLineGuard
+{
+  public:
+    explicit GPIOLineGuard(gpiod::line& line) : line(line) {}
+
+    ~GPIOLineGuard()
+    {
+        if (line.is_requested())
+        {
+            try
+            {
+                line.release();
+            }
+            catch (...)
+            {}
+        }
+    }
+
+    GPIOLineGuard(const GPIOLineGuard&) = delete;
+    GPIOLineGuard& operator=(const GPIOLineGuard&) = delete;
+    GPIOLineGuard(GPIOLineGuard&&) = delete;
+    GPIOLineGuard& operator=(GPIOLineGuard&&) = delete;
+
+  private:
+    gpiod::line& line;
+};
+
+} // anonymous namespace
+
+std::optional<bool> readGPIO(const std::string& gpioName, GPIOPolarity polarity)
+{
+    constexpr int maxRetries = 3;
+    constexpr std::chrono::milliseconds retryDelay{5};
+
+    auto line = gpiod::find_line(gpioName);
+    if (!line)
+    {
+        lg2::warning("GPIO line {NAME} not found", "NAME", gpioName);
+        return std::nullopt;
+    }
+
+    const bool activeHigh = (polarity == GPIOPolarity::high);
+
+    // Retry in case of contention with other GPIO readers
+    for (int attempt = 1; attempt <= maxRetries; ++attempt)
+    {
+        try
+        {
+            line.request(
+                {"RBMC manager", gpiod::line_request::DIRECTION_INPUT,
+                 activeHigh ? 0 : gpiod::line_request::FLAG_ACTIVE_LOW});
+
+            GPIOLineGuard guard(line);
+
+            return line.get_value() != 0;
+        }
+        catch (const std::exception& e)
+        {
+            if (attempt < maxRetries)
+            {
+                lg2::info(
+                    "GPIO {NAME} request failed (attempt {ATTEMPT}/{MAX}): {ERROR}",
+                    "NAME", gpioName, "ATTEMPT", attempt, "MAX", maxRetries,
+                    "ERROR", e);
+                std::this_thread::sleep_for(retryDelay);
+            }
+            else
+            {
+                lg2::warning(
+                    "Error reading GPIO {NAME} after {MAX} attempts: {ERROR}",
+                    "NAME", gpioName, "MAX", maxRetries, "ERROR", e);
+            }
+        }
+    }
+
+    return std::nullopt;
+}
+
+} // namespace rbmc

--- a/redundant-bmc/src/gpio.hpp
+++ b/redundant-bmc/src/gpio.hpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "types.hpp"
+
+#include <optional>
+#include <string>
+
+namespace rbmc
+{
+
+/**
+ * @brief Read a GPIO
+ *
+ * @param[in] gpioName - The GPIO line name
+ * @param[in] polarity - The GPIO polarity
+ * @return true if GPIO reads high (after polarity adjustment),
+ *         false if GPIO reads low,
+ *         nullopt if GPIO line not found or read failed after retries
+ */
+std::optional<bool> readGPIO(const std::string& gpioName,
+                             GPIOPolarity polarity);
+
+} // namespace rbmc

--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -19,6 +19,7 @@ executable(
     'active_role_handler.cpp',
     'config_parser.cpp',
     'error_data.cpp',
+    'gpio.cpp',
     'manager.cpp',
     'passive_role_handler.cpp',
     'persistent_data.cpp',

--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -17,6 +17,7 @@ rbmc_deps = [
 executable(
     'phosphor-rbmc-state-manager',
     'active_role_handler.cpp',
+    'config_parser.cpp',
     'error_data.cpp',
     'manager.cpp',
     'passive_role_handler.cpp',

--- a/redundant-bmc/src/providers.hpp
+++ b/redundant-bmc/src/providers.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "config_data.hpp"
 #include "services.hpp"
 #include "sibling.hpp"
 #include "sibling_reset.hpp"
@@ -44,6 +45,13 @@ class Providers
      * @brief Returns the SiblingReset provider
      */
     virtual SiblingReset& getSiblingReset() = 0;
+
+    /**
+     * @brief Returns the config file data structures.
+     *
+     * @return The configuration
+     */
+    virtual const RedundantBMCConfig& getConfig() const = 0;
 };
 
 }; // namespace rbmc

--- a/redundant-bmc/src/providers_impl.hpp
+++ b/redundant-bmc/src/providers_impl.hpp
@@ -34,8 +34,8 @@ class ProvidersImpl : public Providers
      * @param[in] ctx - The async context object
      */
     explicit ProvidersImpl(sdbusplus::async::context& ctx) :
-        config(config_parser::readConfig()), services(ctx), sibling(ctx),
-        syncInterface(ctx), siblingReset(ctx)
+        config(config_parser::readConfig()), services(ctx),
+        sibling(ctx, config, services), syncInterface(ctx), siblingReset(ctx)
     {}
 
     /**

--- a/redundant-bmc/src/providers_impl.hpp
+++ b/redundant-bmc/src/providers_impl.hpp
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "config_parser.hpp"
 #include "providers.hpp"
 #include "services_impl.hpp"
 #include "sibling_impl.hpp"
 #include "sibling_reset_impl.hpp"
 #include "sync_interface_impl.hpp"
+
+#include <phosphor-logging/lg2.hpp>
 
 namespace rbmc
 {
@@ -31,7 +34,8 @@ class ProvidersImpl : public Providers
      * @param[in] ctx - The async context object
      */
     explicit ProvidersImpl(sdbusplus::async::context& ctx) :
-        services(ctx), sibling(ctx), syncInterface(ctx), siblingReset(ctx)
+        config(config_parser::readConfig()), services(ctx), sibling(ctx),
+        syncInterface(ctx), siblingReset(ctx)
     {}
 
     /**
@@ -66,7 +70,20 @@ class ProvidersImpl : public Providers
         return siblingReset;
     }
 
+    /**
+     * @brief Returns the config file data structures.
+     */
+    const RedundantBMCConfig& getConfig() const override
+    {
+        return config;
+    }
+
   private:
+    /**
+     * @brief The parsed configuration
+     */
+    RedundantBMCConfig config;
+
     /**
      * @brief The Services implementation
      */

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 #include "sibling_impl.hpp"
 
+#include "gpio.hpp"
+
 #include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/ObjectMapper/client.hpp>
 #include <xyz/openbmc_project/Software/Version/common.hpp>
@@ -20,9 +22,11 @@ using BMCStateIntf = sdbusplus::common::xyz::openbmc_project::state::BMC;
 using AvailIntf =
     sdbusplus::common::xyz::openbmc_project::state::decorator::Availability;
 
-SiblingImpl::SiblingImpl(sdbusplus::async::context& ctx) :
-    ctx(ctx), objectPath(std::string{RedIntf::namespace_path::value} + '/' +
-                         RedIntf::namespace_path::sibling_bmc)
+SiblingImpl::SiblingImpl(sdbusplus::async::context& ctx,
+                         const RedundantBMCConfig& config, Services& services) :
+    ctx(ctx), config(config), services(services),
+    objectPath(std::string{RedIntf::namespace_path::value} + '/' +
+               RedIntf::namespace_path::sibling_bmc)
 {}
 
 // NOLINTNEXTLINE
@@ -492,6 +496,67 @@ sdbusplus::async::task<> SiblingImpl::waitForBMCSteadyState() const
 }
 // NOLINTEND(clang-analyzer-core.uninitialized.Branch,
 //           readability-static-accessed-through-instance)
+
+bool SiblingImpl::isBMCPresent()
+{
+    // The GPIO:
+    // 1. May not be defined for this system
+    // 2. May be in use by someone else for too long, or
+    // 3. May have something wrong with the hardware (like an IO expander)
+    //    it's on.
+    // So, only use the GPIO 'present = true' value, otherwise
+    // fall back to looking at other hints in an effort to get
+    // the right answer.
+
+    std::optional<bool> gpioActive;
+
+    auto gpioConfig = getSibPresentGPIOConfig();
+    if (gpioConfig.has_value())
+    {
+        gpioActive =
+            readGPIO(gpioConfig.value().name, gpioConfig.value().polarity);
+    }
+
+    if (gpioActive.value_or(false))
+    {
+        return true;
+    }
+
+    bool fallbackPresent = availability.available ||
+                           services.getPeerConnected();
+
+    if (gpioActive.has_value() && !gpioActive.value() && fallbackPresent)
+    {
+        lg2::warning(
+            "Sibling present GPIO indicates not present, but fallback data "
+            "{AVAILABILITY}/{PEER_CONNECTED} indicates present",
+            "AVAILABILITY", availability.available, "PEER_CONNECTED",
+            services.getPeerConnected());
+    }
+
+    return fallbackPresent;
+}
+
+std::optional<GPIOConfig> SiblingImpl::getSibPresentGPIOConfig() const
+{
+    auto bmcPos = services.getBMCPosition();
+    if (!bmcPos.has_value())
+    {
+        return std::nullopt;
+    }
+
+    auto it = config.bmcConfigs.find(bmcPos.value());
+    if (it != config.bmcConfigs.end())
+    {
+        return it->second.siblingBMCPresentGPIO;
+    }
+    else
+    {
+        lg2::warning("BMC pos {POS} not in config file", "POS", bmcPos.value());
+    }
+
+    return std::nullopt;
+}
 
 // NOLINTNEXTLINE
 sdbusplus::async::task<> SiblingImpl::pauseForHeartbeatChange() const

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -1,9 +1,12 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 #pragma once
+#include "config_data.hpp"
+#include "services.hpp"
 #include "sibling.hpp"
 
 #include <sdbusplus/async/barrier.hpp>
 
+#include <optional>
 #include <vector>
 
 namespace rbmc
@@ -37,8 +40,11 @@ class SiblingImpl : public Sibling
      * @brief Constructor
      *
      * @param[in] ctx - The async context object
+     * @param[in] config - The redundant BMC configuration
+     * @param[in] services - The Services provider for BMC position lookup
      */
-    explicit SiblingImpl(sdbusplus::async::context& ctx);
+    explicit SiblingImpl(sdbusplus::async::context& ctx,
+                         const RedundantBMCConfig& config, Services& services);
 
     /**
      * @brief Returns if the sibling BMC has a good heartbeat
@@ -219,10 +225,7 @@ class SiblingImpl : public Sibling
      *
      * @return bool - if present
      */
-    bool isBMCPresent() override
-    {
-        return availability.available;
-    }
+    bool isBMCPresent() override;
 
     /**
      * @brief Waits for up to 10 minutes for the sibling BMC to
@@ -340,9 +343,26 @@ class SiblingImpl : public Sibling
     sdbusplus::async::task<std::string> lookupServiceName() const;
 
     /**
+     * @brief Get the GPIO config for the sibling BMC
+     *
+     * @return The GPIO config if available, nullopt otherwise
+     */
+    std::optional<GPIOConfig> getSibPresentGPIOConfig() const;
+
+    /**
      * @brief The async context object
      */
     sdbusplus::async::context& ctx;
+
+    /**
+     * @brief The redundant BMC configuration
+     */
+    const RedundantBMCConfig& config;
+
+    /**
+     * @brief The Services provider for system information
+     */
+    Services& services;
 
     /**
      * @brief The sibling's D-Bus service name.

--- a/redundant-bmc/src/types.hpp
+++ b/redundant-bmc/src/types.hpp
@@ -11,4 +11,10 @@ namespace rbmc
 
 using FailoverOptions = std::map<std::string, std::variant<bool>>;
 
+enum class GPIOPolarity
+{
+    low,
+    high
+};
+
 } // namespace rbmc

--- a/redundant-bmc/test/config_parser_test.cpp
+++ b/redundant-bmc/test/config_parser_test.cpp
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "config_parser.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <string_view>
+
+#include <gtest/gtest.h>
+
+using namespace rbmc::config_parser;
+
+class ConfigParserTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        std::string templatePath =
+            (std::filesystem::temp_directory_path() / "rbmc_config_test_XXXXXX")
+                .string();
+        testDir = mkdtemp(templatePath.data());
+    }
+
+    void TearDown() override
+    {
+        std::filesystem::remove_all(testDir);
+    }
+
+    void writeConfigFile(std::string_view filename, const std::string& content)
+    {
+        std::ofstream file(testDir / filename);
+        file << content;
+    }
+
+    std::filesystem::path testDir;
+};
+
+TEST_F(ConfigParserTest, ParseValidConfig)
+{
+    const std::string config = R"({
+        "sibling_bmc_reset_gpio": {
+            "name": "sibling-bmc-reset-n",
+            "polarity": "low"
+        },
+        "bmc_configs": [
+            {
+                "bmc_pos": 0,
+                "sibling_bmc_present_gpio": {
+                    "name": "chassis2-present",
+                    "polarity": "low"
+                }
+            },
+            {
+                "bmc_pos": 1,
+                "sibling_bmc_present_gpio": {
+                    "name": "chassis1-present",
+                    "polarity": "high"
+                }
+            }
+        ]
+    })";
+
+    writeConfigFile("valid_config.json", config);
+
+    auto result = parse(testDir / "valid_config.json");
+
+    EXPECT_EQ(result.bmcConfigs.size(), 2);
+
+    // Check reset GPIO
+    EXPECT_EQ(result.siblingBMCResetGPIO.name, "sibling-bmc-reset-n");
+    EXPECT_EQ(result.siblingBMCResetGPIO.polarity, rbmc::GPIOPolarity::low);
+
+    // Check first BMC config
+    ASSERT_TRUE(result.bmcConfigs.contains(0));
+    const auto& bmc0 = result.bmcConfigs.at(0);
+    EXPECT_EQ(bmc0.bmcPos, 0);
+    EXPECT_EQ(bmc0.siblingBMCPresentGPIO.name, "chassis2-present");
+    EXPECT_EQ(bmc0.siblingBMCPresentGPIO.polarity, rbmc::GPIOPolarity::low);
+
+    // Check second BMC config
+    ASSERT_TRUE(result.bmcConfigs.contains(1));
+    const auto& bmc1 = result.bmcConfigs.at(1);
+    EXPECT_EQ(bmc1.bmcPos, 1);
+    EXPECT_EQ(bmc1.siblingBMCPresentGPIO.name, "chassis1-present");
+    EXPECT_EQ(bmc1.siblingBMCPresentGPIO.polarity, rbmc::GPIOPolarity::high);
+}
+
+TEST_F(ConfigParserTest, ParseOptionalBMCConfigs)
+{
+    const std::string config = R"({
+        "sibling_bmc_reset_gpio": {
+            "name": "sibling-bmc-reset-n",
+            "polarity": "low"
+        }
+    })";
+
+    writeConfigFile("optional_bmc_configs.json", config);
+
+    auto result = parse(testDir / "optional_bmc_configs.json");
+
+    EXPECT_EQ(result.bmcConfigs.size(), 0);
+}
+
+TEST_F(ConfigParserTest, ParseEmptyBMCConfigsArray)
+{
+    const std::string config = R"({
+        "sibling_bmc_reset_gpio": {
+            "name": "sibling-bmc-reset-n",
+            "polarity": "low"
+        },
+        "bmc_configs": []
+    })";
+
+    writeConfigFile("empty_bmc_configs.json", config);
+
+    auto result = parse(testDir / "empty_bmc_configs.json");
+
+    EXPECT_EQ(result.bmcConfigs.size(), 0);
+}
+
+TEST_F(ConfigParserTest, ParseMissingPresentGPIO)
+{
+    const std::string config = R"({
+        "sibling_bmc_reset_gpio": {
+            "name": "sibling-bmc-reset",
+            "polarity": "high"
+        },
+        "bmc_configs": [
+            {
+                "bmc_pos": 0
+            }
+        ]
+    })";
+
+    writeConfigFile("no_present_gpio_config.json", config);
+
+    // sibling_bmc_present_gpio is now required
+    EXPECT_THROW(parse(testDir / "no_present_gpio_config.json"),
+                 std::runtime_error);
+}
+
+TEST_F(ConfigParserTest, ParseNonExistentFile)
+{
+    EXPECT_THROW(parse(testDir / "nonexistent.json"), std::runtime_error);
+}
+
+TEST_F(ConfigParserTest, ParseInvalidJSON)
+{
+    const std::string config = R"({
+        "sibling_bmc_reset_gpio": {
+            "name": "sibling-bmc-reset-n",
+            "polarity": "low"
+        },
+        "bmc_configs": [
+            {
+                "bmc_pos": 0
+            }
+    )"; // missing closing brace
+
+    writeConfigFile("invalid.json", config);
+
+    EXPECT_THROW(parse(testDir / "invalid.json"), std::runtime_error);
+}
+
+TEST_F(ConfigParserTest, ParseMissingResetGPIO)
+{
+    const std::string config = R"({
+        "bmc_configs": [
+            {
+                "bmc_pos": 0
+            }
+        ]
+    })";
+
+    writeConfigFile("missing_reset_gpio.json", config);
+
+    EXPECT_THROW(parse(testDir / "missing_reset_gpio.json"),
+                 std::runtime_error);
+}
+
+TEST_F(ConfigParserTest, ParseMissingBMCPos)
+{
+    const std::string config = R"({
+        "sibling_bmc_reset_gpio": {
+            "name": "sibling-bmc-reset-n",
+            "polarity": "low"
+        },
+        "bmc_configs": [
+            {
+                "sibling_bmc_present_gpio": {
+                    "name": "test-gpio",
+                    "polarity": "low"
+                }
+            }
+        ]
+    })";
+
+    writeConfigFile("missing_bmc_pos.json", config);
+
+    EXPECT_THROW(parse(testDir / "missing_bmc_pos.json"), std::runtime_error);
+}
+
+TEST_F(ConfigParserTest, ParseInvalidResetGPIOPolarity)
+{
+    const std::string config = R"({
+        "sibling_bmc_reset_gpio": {
+            "name": "sibling-bmc-reset",
+            "polarity": "invalid"
+        }
+    })";
+
+    writeConfigFile("invalid_reset_polarity.json", config);
+
+    EXPECT_THROW(parse(testDir / "invalid_reset_polarity.json"),
+                 std::runtime_error);
+}
+
+TEST_F(ConfigParserTest, ParseInvalidPresentGPIOPolarity)
+{
+    const std::string config = R"({
+        "sibling_bmc_reset_gpio": {
+            "name": "sibling-bmc-reset-n",
+            "polarity": "low"
+        },
+        "bmc_configs": [
+            {
+                "bmc_pos": 0,
+                "sibling_bmc_present_gpio": {
+                    "name": "test-gpio",
+                    "polarity": "invalid"
+                }
+            }
+        ]
+    })";
+
+    writeConfigFile("invalid_present_polarity.json", config);
+
+    EXPECT_THROW(parse(testDir / "invalid_present_polarity.json"),
+                 std::runtime_error);
+}
+
+TEST_F(ConfigParserTest, ParseMissingResetGPIOName)
+{
+    const std::string config = R"({
+        "sibling_bmc_reset_gpio": {
+            "polarity": "low"
+        }
+    })";
+
+    writeConfigFile("missing_reset_gpio_name.json", config);
+
+    EXPECT_THROW(parse(testDir / "missing_reset_gpio_name.json"),
+                 std::runtime_error);
+}
+
+TEST_F(ConfigParserTest, ParseMissingResetGPIOPolarity)
+{
+    const std::string config = R"({
+        "sibling_bmc_reset_gpio": {
+            "name": "sibling-bmc-reset"
+        }
+    })";
+
+    writeConfigFile("missing_reset_gpio_polarity.json", config);
+
+    EXPECT_THROW(parse(testDir / "missing_reset_gpio_polarity.json"),
+                 std::runtime_error);
+}
+
+TEST_F(ConfigParserTest, ParseMissingPresentGPIOName)
+{
+    const std::string config = R"({
+        "sibling_bmc_reset_gpio": {
+            "name": "sibling-bmc-reset-n",
+            "polarity": "low"
+        },
+        "bmc_configs": [
+            {
+                "bmc_pos": 0,
+                "sibling_bmc_present_gpio": {
+                    "polarity": "low"
+                }
+            }
+        ]
+    })";
+
+    writeConfigFile("missing_present_gpio_name.json", config);
+
+    EXPECT_THROW(parse(testDir / "missing_present_gpio_name.json"),
+                 std::runtime_error);
+}
+
+TEST_F(ConfigParserTest, ParseMissingPresentGPIOPolarity)
+{
+    const std::string config = R"({
+        "sibling_bmc_reset_gpio": {
+            "name": "sibling-bmc-reset-n",
+            "polarity": "low"
+        },
+        "bmc_configs": [
+            {
+                "bmc_pos": 0,
+                "sibling_bmc_present_gpio": {
+                    "name": "test-gpio"
+                }
+            }
+        ]
+    })";
+
+    writeConfigFile("missing_present_gpio_polarity.json", config);
+
+    EXPECT_THROW(parse(testDir / "missing_present_gpio_polarity.json"),
+                 std::runtime_error);
+}
+
+TEST_F(ConfigParserTest, ParseBMCConfigsNotArray)
+{
+    const std::string config = R"({
+        "sibling_bmc_reset_gpio": {
+            "name": "sibling-bmc-reset-n",
+            "polarity": "low"
+        },
+        "bmc_configs": "not an array"
+    })";
+
+    writeConfigFile("bmc_configs_not_array.json", config);
+
+    EXPECT_THROW(parse(testDir / "bmc_configs_not_array.json"),
+                 std::runtime_error);
+}
+
+TEST_F(ConfigParserTest, ParseDuplicateBMCPosition)
+{
+    const std::string config = R"({
+        "sibling_bmc_reset_gpio": {
+            "name": "sibling-bmc-reset-n",
+            "polarity": "low"
+        },
+        "bmc_configs": [
+            {
+                "bmc_pos": 0,
+                "sibling_bmc_present_gpio": {
+                    "name": "gpio1",
+                    "polarity": "low"
+                }
+            },
+            {
+                "bmc_pos": 0,
+                "sibling_bmc_present_gpio": {
+                    "name": "gpio2",
+                    "polarity": "high"
+                }
+            }
+        ]
+    })";
+
+    writeConfigFile("duplicate_bmc_pos.json", config);
+
+    // Duplicate bmc_pos should cause parsing to fail
+    EXPECT_THROW(parse(testDir / "duplicate_bmc_pos.json"), std::runtime_error);
+}

--- a/redundant-bmc/test/meson.build
+++ b/redundant-bmc/test/meson.build
@@ -4,10 +4,12 @@ test(
     'rbmc-tests',
     executable(
         'rbmc-tests',
+        'config_parser_test.cpp',
         'error_data_test.cpp',
         'persistent_data_test.cpp',
         'redundancy_test.cpp',
         'role_determination_test.cpp',
+        '../src/config_parser.cpp',
         '../src/error_data.cpp',
         '../src/persistent_data.cpp',
         '../src/redundancy.cpp',


### PR DESCRIPTION
Add support for a config file to hold the GPIOs for sibling BMC presence and sibling reset.

The config files are all checked in under the redundant-bmc/config_files/ directory, and the one to use is specified with a meson option.

Make use of the sibling present GPIOs in the isBMCPresent function.  Since not all systems have GPIOs for this, it will fallback to what it was previously using for presence if there isn't one.

Using the config file sibling-reset GPIO instead of just hardcoding it will come in a future PR.

