### PR TITLE
RBMC: Add a config file schema

### DIFF
--- a/redundant-bmc/config_files/README.md
+++ b/redundant-bmc/config_files/README.md
@@ -56,3 +56,15 @@ It is then installed into
 - **name** (string, required): Name of the GPIO line.
 - **polarity** (string, required): Either "low" or "high" - indicates the active
   state of the GPIO.
+
+### Validating Config Files
+
+Validate the config files with `validate_configs.py`.
+
+```bash
+# Validate all config files in the current directory
+python3 validate_configs.py schema/schema.json .
+
+# Validate a specific config file
+python3 validate_configs.py schema/schema.json default.json
+```

--- a/redundant-bmc/config_files/schema/schema.json
+++ b/redundant-bmc/config_files/schema/schema.json
@@ -1,0 +1,61 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://github.com/ibm-openbmc/phosphor-state-manager/redundant-bmc/config-schema.json",
+    "title": "Schema for Redundant BMC Configuration Files",
+    "description": "Configuration schema for OpenBMC redundant BMC functionality",
+    "type": "object",
+    "required": ["sibling_bmc_reset_gpio"],
+    "properties": {
+        "sibling_bmc_reset_gpio": {
+            "description": "GPIO configuration for resetting the sibling BMC",
+            "$ref": "#/$defs/gpio_config"
+        },
+        "bmc_configs": {
+            "description": "Array of BMC configuration objects. Required when sibling_bmc_present_gpio is necessary, optional otherwise.",
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/bmc_config"
+            },
+            "minItems": 0,
+            "uniqueItems": true
+        }
+    },
+    "additionalProperties": false,
+    "$defs": {
+        "gpio_config": {
+            "type": "object",
+            "description": "Configuration for a GPIO line",
+            "required": ["name", "polarity"],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The GPIO line name",
+                    "minLength": 1
+                },
+                "polarity": {
+                    "type": "string",
+                    "description": "The polarity of the GPIO line. 'low' means active when the GPIO reads low, 'high' means active when the GPIO reads high.",
+                    "enum": ["low", "high"]
+                }
+            },
+            "additionalProperties": false
+        },
+        "bmc_config": {
+            "type": "object",
+            "description": "Configuration for a single BMC in the redundant system",
+            "required": ["bmc_pos", "sibling_bmc_present_gpio"],
+            "properties": {
+                "bmc_pos": {
+                    "type": "integer",
+                    "description": "Position/index of this BMC (0-based). Typically 0 or 1 for dual BMC systems.",
+                    "minimum": 0
+                },
+                "sibling_bmc_present_gpio": {
+                    "description": "GPIO configuration for detecting sibling BMC presence",
+                    "$ref": "#/$defs/gpio_config"
+                }
+            },
+            "additionalProperties": false
+        }
+    }
+}

--- a/redundant-bmc/config_files/validate_configs.py
+++ b/redundant-bmc/config_files/validate_configs.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""
+Validate redundant BMC configuration files against JSON schema.
+
+Usage:
+    validate_configs.py <schema_file> <config_file_or_directory>
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+try:
+    from jsonschema import Draft7Validator
+except ImportError:
+    print(
+        "Error: jsonschema module not found. Install with: pip install jsonschema",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def load_json_file(filepath: Path) -> dict:
+    """Load and parse a JSON file."""
+    try:
+        with open(filepath, "r") as f:
+            return json.load(f)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid JSON in {filepath}: {e}")
+    except Exception as e:
+        raise ValueError(f"Failed to read {filepath}: {e}")
+
+
+def validate_config(config_path: Path, schema: dict) -> Tuple[bool, str]:
+    """
+    Validate a single config file against the schema.
+
+    Returns:
+        Tuple of (is_valid, error_message)
+    """
+    try:
+        config = load_json_file(config_path)
+        validator = Draft7Validator(schema)
+        errors = list(validator.iter_errors(config))
+
+        if errors:
+            error_messages = []
+            for error in errors:
+                path = (
+                    ".".join(str(p) for p in error.path)
+                    if error.path
+                    else "root"
+                )
+                error_messages.append(f"  - At '{path}': {error.message}")
+            return False, "\n".join(error_messages)
+
+        return True, ""
+    except Exception as e:
+        return False, f"  - {str(e)}"
+
+
+def find_config_files(path: Path) -> List[Path]:
+    """Find all JSON config files in the given path."""
+    if path.is_file():
+        if path.suffix == ".json":
+            return [path]
+        return []
+
+    # Directory - find all .json files (excluding subdirectories)
+    config_files = []
+    for json_file in path.glob("*.json"):
+        if json_file.is_file():
+            config_files.append(json_file)
+    return sorted(config_files)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Validate redundant BMC configuration files against JSON schema"
+    )
+    parser.add_argument(
+        "schema", type=Path, help="Path to the JSON schema file"
+    )
+    parser.add_argument(
+        "config",
+        type=Path,
+        help="Path to config file or directory containing config files",
+    )
+
+    args = parser.parse_args()
+
+    # Load schema
+    if not args.schema.exists():
+        print(f"Error: Schema file not found: {args.schema}", file=sys.stderr)
+        return 1
+
+    try:
+        schema = load_json_file(args.schema)
+    except ValueError as e:
+        print(f"Error loading schema: {e}", file=sys.stderr)
+        return 1
+
+    # Find config files
+    if not args.config.exists():
+        print(f"Error: Config path not found: {args.config}", file=sys.stderr)
+        return 1
+
+    config_files = find_config_files(args.config)
+    if not config_files:
+        print(
+            f"Error: No config files found in {args.config}", file=sys.stderr
+        )
+        return 1
+
+    all_valid = True
+    for config_file in config_files:
+        is_valid, error_msg = validate_config(config_file, schema)
+
+        if is_valid:
+            print(f"{config_file.name}: VALID")
+        else:
+            print(f"{config_file.name}: INVALID")
+            print(error_msg)
+            all_valid = False
+
+    return 0 if all_valid else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+/usr/bin/python3 redundant-bmc/config_files/validate_configs.py \
+    redundant-bmc/config_files/schema/schema.json \
+    redundant-bmc/config_files


### PR DESCRIPTION
Create a JSON schema file for the config files, with a validate_configs.py script to do the validation.

Call it in scripts/run-ci.sh which will then run the schema validation during CI.

Tested:
```
$ ./scripts/run-ci.sh
default.json: VALID
huygens.json: VALID
rbmc-prototype.json: VALID
skiboards.json: VALID
```

A fail:
```
$ ./scripts/run-ci.sh
default.json: VALID
huygens.json: INVALID
  - At 'bmc_configs.1.sibling_bmc_present_gpio.polarity': 'Low' is not one of ['low', 'high']
rbmc-prototype.json: VALID
skiboards.json: VALID

$ echo $?
1
```

Change-Id: Ieae09a60a0f0b0ab3684e263412fd3bc2929943f