### PR TITLE
RBMC:  Change 'provision' terminology to 'pair'

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -58,7 +58,7 @@ The actual reason the code used to determine the role is saved in the
 There are some error cases that require that the BMC is passive regardless of
 what the sibling is doing. These are:
 
-1. The BMC is not provisioned.
+1. The BMC is not paired.
 1. The BMC position cannot be determined.
 1. System inventory processing failed.
 1. The systemd service that maintains the sibling API isn't running. Without
@@ -102,7 +102,7 @@ items to see if redundancy can be enabled:
 1. If the sibling BMC indicates that it can never be active.
 1. Redundancy hasn't been manually disabled with the D-bus property that does
    so.
-1. The sibling BMC has been provisioned.
+1. The sibling BMC has been paired.
 1. The firmware versions are the same on the BMCs.
 1. The network between the BMCs is connected.
 1. If attempting to enable any time at runtime, redundancy must have been

--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -58,11 +58,10 @@ sdbusplus::async::task<> ActiveRoleHandler::start()
             sibling.waitForSiblingRole(), sibling.waitForBMCSteadyState(),
             services.waitForPeerConnection());
 
-        // If PeerConnected == true and sibling provisioned == false
-        // a small delay will be needed to let the new provisioned
+        // If PeerConnected == true and sibling paired == false
+        // a small delay will be needed to let the new paired
         // value propagate to this BMC.
-        if (services.getPeerConnected() &&
-            !sibling.getProvisioned().value_or(true))
+        if (services.getPeerConnected() && !sibling.getPaired().value_or(true))
         {
             co_await sibling.pauseForDataPropagation();
         }
@@ -142,8 +141,8 @@ sdbusplus::async::task<> ActiveRoleHandler::siblingHealthy()
         services.waitForPeerConnection());
 
     // Just like in start(), a delay may be needed to let
-    // the sibling provisioned value propagate.
-    if (services.getPeerConnected() && !sibling.getProvisioned().value_or(true))
+    // the sibling paired value propagate.
+    if (services.getPeerConnected() && !sibling.getPaired().value_or(true))
     {
         co_await sibling.pauseForDataPropagation();
     }

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -106,9 +106,9 @@ sdbusplus::async::task<> Manager::startup()
 
     spawnRoleHandler();
 
-    if (!services.getProvisioned())
+    if (!services.getPaired())
     {
-        setupProvisionedWatch();
+        setupPairedWatch();
     }
 }
 
@@ -245,10 +245,10 @@ sdbusplus::async::task<std::optional<role_determination::RoleInfo>>
 {
     using namespace role_determination;
 
-    // An unprovisioned BMC cannot be active.
-    if (!providers->getServices().getProvisioned())
+    // An unpaired BMC cannot be active.
+    if (!providers->getServices().getPaired())
     {
-        co_return RoleInfo{Role::Passive, RoleReason::notProvisioned};
+        co_return RoleInfo{Role::Passive, RoleReason::notPaired};
     }
 
     // A BMC with no position cannot be active.
@@ -460,21 +460,20 @@ sdbusplus::async::task<> Manager::doFailoverFromPassive(Requester requester)
     co_await active->failoverDetermineRedundancy();
 }
 
-void Manager::setupProvisionedWatch()
+void Manager::setupPairedWatch()
 {
-    providers->getServices().addProvisionedCallback(
-        Role::Passive,
-        std::bind_front(&Manager::provisionedChangeHandler, this));
+    providers->getServices().addPairedCallback(
+        Role::Passive, std::bind_front(&Manager::pairedChangeHandler, this));
 }
 
-void Manager::provisionedChangeHandler(bool provisioned)
+void Manager::pairedChangeHandler(bool paired)
 {
-    ctx.spawn(handleProvisionedChange(provisioned));
+    ctx.spawn(handlePairedChange(paired));
 }
 
-sdbusplus::async::task<> Manager::handleProvisionedChange(bool provisioned)
+sdbusplus::async::task<> Manager::handlePairedChange(bool paired)
 {
-    if (!provisioned)
+    if (!paired)
     {
         co_return;
     }
@@ -483,8 +482,8 @@ sdbusplus::async::task<> Manager::handleProvisionedChange(bool provisioned)
     if (redundancyInterface.role() != Role::Passive)
     {
         lg2::warning(
-            "Provisioned just changed to true but BMC not already passive?");
-        providers->getServices().removeProvisionedCallback(Role::Passive);
+            "Paired just changed to true but BMC not already passive?");
+        providers->getServices().removePairedCallback(Role::Passive);
         co_return;
     }
 
@@ -503,12 +502,12 @@ sdbusplus::async::task<> Manager::handleProvisionedChange(bool provisioned)
         redundancyInterface.reasons_for_no_redundancy({});
 
         // No need for future callbacks.
-        providers->getServices().removeProvisionedCallback(Role::Passive);
+        providers->getServices().removePairedCallback(Role::Passive);
     }
     else
     {
-        lg2::warning(
-            "After provisioned property change to true, BMC still required to be passive: {REASON}",
+        lg2::info(
+            "After paired property change to true, BMC still required to be passive: {REASON}",
             "REASON",
             role_determination::getRoleReasonDescription(
                 passiveRoleInfo->reason));

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -140,23 +140,23 @@ class Manager :
         const FailoverOptions& options);
 
     /**
-     * @brief Setup watch for provisioning changes
+     * @brief Setup watch for pairing changes
      */
-    void setupProvisionedWatch();
+    void setupPairedWatch();
 
     /**
-     * @brief Handler for provisioned property changes
+     * @brief Handler for paired property changes
      *
-     * @param[in] provisioned - The new provisioned value
+     * @param[in] paired - The new paired value
      */
-    void provisionedChangeHandler(bool provisioned);
+    void pairedChangeHandler(bool paired);
 
     /**
-     * @brief Async handler spawned by provisionedChangeHandler
+     * @brief Async handler spawned by pairedChangeHandler
      *
-     * @param[in] provisioned - The new provisioned value
+     * @param[in] paired - The new paired value
      */
-    sdbusplus::async::task<> handleProvisionedChange(bool provisioned);
+    sdbusplus::async::task<> handlePairedChange(bool paired);
 
     /**
      * @brief The async context object

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -24,14 +24,14 @@ using BMCState = sdbusplus::client::xyz::openbmc_project::state::BMC<>;
 using Role = Redundancy::Role;
 using Failover = sdbusplus::client::xyz::openbmc_project::control::Failover<>;
 using Version = sdbusplus::client::xyz::openbmc_project::software::Version<>;
-using Provisioning =
+using Pairing =
     sdbusplus::client::xyz::openbmc_project::provisioning::Provisioning<>;
 using PeerConnectionStatus = sdbusplus::common::xyz::openbmc_project::
     provisioning::Provisioning::PeerConnectionStatus;
 
 constexpr auto siblingService =
     "xyz.openbmc_project.State.BMC.Redundancy.Sibling";
-constexpr auto provService = "xyz.openbmc_project.Provisioning";
+constexpr auto pairingService = "xyz.openbmc_project.Provisioning";
 
 template <typename T>
 void printParam(std::string key, const T& value)
@@ -205,19 +205,19 @@ sdbusplus::async::task<> getLocalBMCInfo(sdbusplus::async::context& ctx,
 
         try
         {
-            auto provProps = co_await Provisioning(ctx)
-                                 .service(provService)
-                                 .path(Provisioning::instance_path)
-                                 .properties();
-            if (!provProps.provisioned)
+            auto pairingProps = co_await Pairing(ctx)
+                                    .service(pairingService)
+                                    .path(Pairing::instance_path)
+                                    .properties();
+            if (!pairingProps.provisioned)
             {
-                output["Paired"] = provProps.provisioned;
+                output["Paired"] = pairingProps.provisioned;
             }
 
-            if (provProps.peer_connected != PeerConnectionStatus::Connected)
+            if (pairingProps.peer_connected != PeerConnectionStatus::Connected)
             {
                 output["Peer Connected"] =
-                    getPDIEnumString(provProps.peer_connected);
+                    getPDIEnumString(pairingProps.peer_connected);
             }
         }
         catch (const std::exception& e)
@@ -294,18 +294,18 @@ sdbusplus::async::task<> getSiblingBMCInfo(sdbusplus::async::context& ctx,
                          .path(path.str)
                          .current_bmc_state();
 
-        auto provProps = co_await Provisioning(ctx)
-                             .service(siblingService)
-                             .path(path.str)
-                             .properties();
+        auto pairingProps = co_await Pairing(ctx)
+                                .service(siblingService)
+                                .path(path.str)
+                                .properties();
 
         output["Redundancy Enabled"] = rProps.redundancy_enabled;
         output["Failovers Allowed"] = rProps.failovers_allowed;
         output["BMC State"] = getPDIEnumString(state);
         output["FW Version Hash"] = fwVersion;
-        if (!provProps.provisioned)
+        if (!pairingProps.provisioned)
         {
-            output["Paired"] = provProps.provisioned;
+            output["Paired"] = pairingProps.provisioned;
         }
     }
     catch (const std::exception& e)

--- a/redundant-bmc/src/redundancy.cpp
+++ b/redundant-bmc/src/redundancy.cpp
@@ -35,7 +35,7 @@ ReasonsForNoRedundancy getNoRedundancyReasons(const Input& input)
         }
         else
         {
-            if (!input.siblingProvisioned)
+            if (!input.siblingPaired)
             {
                 reasons.push_back(SiblingNotProvisioned);
             }

--- a/redundant-bmc/src/redundancy.hpp
+++ b/redundant-bmc/src/redundancy.hpp
@@ -30,7 +30,7 @@ struct Input
     Role role;
     bool siblingPresent;
     bool siblingAlive;
-    bool siblingProvisioned;
+    bool siblingPaired;
     Role siblingRole;
     bool siblingCannotBeActive;
     BMCState siblingState;

--- a/redundant-bmc/src/redundancy_mgr.cpp
+++ b/redundant-bmc/src/redundancy_mgr.cpp
@@ -130,7 +130,7 @@ redundancy::ReasonsForNoRedundancy RedundancyMgr::getNoRedundancyReasons()
         .role = redundancyInterface.role(),
         .siblingPresent = sibling.isBMCPresent(),
         .siblingAlive = sibling.alive(),
-        .siblingPaired = sibling.getProvisioned().value_or(false),
+        .siblingPaired = sibling.getPaired().value_or(false),
         .siblingRole = sibling.getRole().value_or(Role::Unknown),
         .siblingCannotBeActive =
             sibling.getHasReasonForNoRedundancy().value_or(false),

--- a/redundant-bmc/src/redundancy_mgr.cpp
+++ b/redundant-bmc/src/redundancy_mgr.cpp
@@ -130,7 +130,7 @@ redundancy::ReasonsForNoRedundancy RedundancyMgr::getNoRedundancyReasons()
         .role = redundancyInterface.role(),
         .siblingPresent = sibling.isBMCPresent(),
         .siblingAlive = sibling.alive(),
-        .siblingProvisioned = sibling.getProvisioned().value_or(false),
+        .siblingPaired = sibling.getProvisioned().value_or(false),
         .siblingRole = sibling.getRole().value_or(Role::Unknown),
         .siblingCannotBeActive =
             sibling.getHasReasonForNoRedundancy().value_or(false),

--- a/redundant-bmc/src/role_determination.cpp
+++ b/redundant-bmc/src/role_determination.cpp
@@ -7,7 +7,7 @@ namespace rbmc::role_determination
 
 // Reasons for being passive that are errors.
 constexpr auto errorRoleReasons = std::to_array(
-    {RoleReason::notProvisioned, RoleReason::siblingServiceNotRunning,
+    {RoleReason::notPaired, RoleReason::siblingServiceNotRunning,
      RoleReason::exception, RoleReason::unknownBMCPosition,
      RoleReason::systemInventoryNotAvailable});
 
@@ -92,8 +92,8 @@ std::string getRoleReasonDescription(RoleReason reason)
         case RoleReason::positionNonzero:
             desc = "BMC is not position 0"s;
             break;
-        case RoleReason::notProvisioned:
-            desc = "BMC is not provisioned"s;
+        case RoleReason::notPaired:
+            desc = "BMC is not paired"s;
             break;
         case RoleReason::siblingServiceNotRunning:
             desc = "Sibling BMC service is not running"s;

--- a/redundant-bmc/src/role_determination.hpp
+++ b/redundant-bmc/src/role_determination.hpp
@@ -37,7 +37,7 @@ enum class RoleReason
     resumePrevious,
     positionZero,
     positionNonzero,
-    notProvisioned,
+    notPaired,
     siblingServiceNotRunning,
     exception,
     failover,

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -46,7 +46,7 @@ class Services
 
     using SystemStateCallback = std::function<void(SystemState)>;
     using PeerConnectedCallback = std::function<void(bool)>;
-    using ProvisionedCallback = std::function<void(bool)>;
+    using PairedCallback = std::function<void(bool)>;
 
     /**
      * @brief Sets up the D-Bus matches
@@ -87,11 +87,11 @@ class Services
         const std::string& unitName) const = 0;
 
     /**
-     * @brief If this BMC has been provisioned
+     * @brief If this BMC has been paired
      *
-     * @return bool - If provisioned or not.
+     * @return bool - If paired or not.
      */
-    virtual bool getProvisioned() const = 0;
+    virtual bool getPaired() const = 0;
 
     /**
      * @brief Returns an 8 character hash of the FW version
@@ -225,25 +225,25 @@ class Services
     }
 
     /**
-     * @brief Add a function that gets called when the provisioned status
+     * @brief Add a function that gets called when the paired status
      *        changes.
      *
      * @param[in] role - The role to register with
      * @param[in] callback - The function to call
      */
-    void addProvisionedCallback(Role role, ProvisionedCallback&& callback)
+    void addPairedCallback(Role role, PairedCallback&& callback)
     {
-        provisionedCBs.emplace(role, std::move(callback));
+        pairedCBs.emplace(role, std::move(callback));
     }
 
     /**
-     * @brief Remove a specific provisioned change callback by role.
+     * @brief Remove a specific paired change callback by role.
      *
      * @param[in] role - The role of the callback to remove
      */
-    void removeProvisionedCallback(Role role)
+    void removePairedCallback(Role role)
     {
-        provisionedCBs.erase(role);
+        pairedCBs.erase(role);
     }
 
     /**
@@ -285,9 +285,9 @@ class Services
     std::map<Role, PeerConnectedCallback> peerConnectedCBs;
 
     /**
-     * @brief The functions to call when the provisioned status changes
+     * @brief The functions to call when the paired status changes
      */
-    std::map<Role, ProvisionedCallback> provisionedCBs;
+    std::map<Role, PairedCallback> pairedCBs;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -30,7 +30,7 @@ using SystemInv =
 using InvProgress = sdbusplus::client::xyz::openbmc_project::common::Progress<>;
 using SidebandBus =
     sdbusplus::client::xyz::openbmc_project::control::SideBandBus<>;
-using Provisioning =
+using Pairing =
     sdbusplus::client::xyz::openbmc_project::provisioning::Provisioning<>;
 using PeerConnectionStatus = sdbusplus::common::xyz::openbmc_project::
     provisioning::Provisioning::PeerConnectionStatus;
@@ -200,14 +200,14 @@ sdbusplus::async::task<> ServicesImpl::init()
     ctx.spawn(watchHostInterfacesAdded(barrier));
     ctx.spawn(watchHostStatePropertiesChanged(barrier));
     ctx.spawn(watchBootProgressPropertiesChanged(barrier));
-    ctx.spawn(watchProvisioningInterfacesAdded(barrier));
-    ctx.spawn(watchProvisioningPropertiesChanged(barrier));
+    ctx.spawn(watchPairingInterfacesAdded(barrier));
+    ctx.spawn(watchPairingPropertiesChanged(barrier));
 
     co_await barrier->wait();
 
     co_await readHostState();
     co_await readBootProgress();
-    co_await readProvisioningProperties();
+    co_await readPairingProperties();
     updateSystemState();
 
     co_await waitForSystemInventoryPath();
@@ -333,22 +333,22 @@ sdbusplus::async::task<> ServicesImpl::readBootProgress()
     co_return;
 }
 
-sdbusplus::async::task<> ServicesImpl::readProvisioningProperties()
+sdbusplus::async::task<> ServicesImpl::readPairingProperties()
 {
     try
     {
-        auto service = co_await util::getService(
-            ctx, Provisioning::instance_path, Provisioning::interface);
-        auto props = co_await Provisioning(ctx)
+        auto service = co_await util::getService(ctx, Pairing::instance_path,
+                                                 Pairing::interface);
+        auto props = co_await Pairing(ctx)
                          .service(service)
-                         .path(Provisioning::instance_path)
+                         .path(Pairing::instance_path)
                          .properties();
 
-        provisioned = props.provisioned;
+        paired = props.provisioned;
         peerConnected = props.peer_connected == PeerConnectionStatus::Connected;
 
-        lg2::debug("Initial Provisioned = {PROV} and PeerConnected = {STATUS}",
-                   "PROV", props.provisioned, "STATUS", props.peer_connected);
+        lg2::debug("Initial Paired = {PAIR} and PeerConnected = {STATUS}",
+                   "PAIR", props.provisioned, "STATUS", props.peer_connected);
     }
     catch (const sdbusplus::exception_t& e)
     {
@@ -384,15 +384,14 @@ sdbusplus::async::task<> ServicesImpl::watchBootProgressPropertiesChanged(
     co_return;
 }
 
-void ServicesImpl::loadProvisioningProps(const ProvisioningPropMap& propertyMap)
+void ServicesImpl::loadPairingProps(const PairingPropMap& propertyMap)
 {
     auto it = propertyMap.find("PeerConnected");
     if (it != propertyMap.end())
     {
         auto prevConnected = peerConnected;
 
-        auto rawStatus =
-            std::get<Provisioning::PeerConnectionStatus>(it->second);
+        auto rawStatus = std::get<Pairing::PeerConnectionStatus>(it->second);
 
         lg2::info("The new PeerConnected value is {STATUS}", "STATUS",
                   rawStatus);
@@ -414,58 +413,58 @@ void ServicesImpl::loadProvisioningProps(const ProvisioningPropMap& propertyMap)
     it = propertyMap.find("Provisioned");
     if (it != propertyMap.end())
     {
-        auto prevProvisioned = provisioned;
-        provisioned = std::get<bool>(it->second);
+        auto prevPaired = paired;
+        paired = std::get<bool>(it->second);
 
-        lg2::info("The new Provisioned value is {PROV}", "PROV", provisioned);
+        lg2::info("The new Paired value is {PROV}", "PROV", paired);
 
         // Invoke callbacks if value changed
-        if (prevProvisioned != provisioned)
+        if (prevPaired != paired)
         {
-            std::ranges::for_each(provisionedCBs, [this](const auto& entry) {
-                entry.second(provisioned);
+            std::ranges::for_each(pairedCBs, [this](const auto& entry) {
+                entry.second(paired);
             });
         }
     }
 }
 
-sdbusplus::async::task<> ServicesImpl::watchProvisioningInterfacesAdded(
+sdbusplus::async::task<> ServicesImpl::watchPairingInterfacesAdded(
     std::shared_ptr<sdbusplus::async::barrier> barrier)
 {
     sdbusplus::async::match match(
-        ctx, rules::interfacesAddedAtPath(Provisioning::instance_path));
+        ctx, rules::interfacesAddedAtPath(Pairing::instance_path));
 
     co_await barrier->wait();
 
     while (!ctx.stop_requested())
     {
         auto [_, interfaces] =
-            co_await match.next<sdbusplus::message::object_path,
-                                ProvisioningInterfaceMap>();
+            co_await match
+                .next<sdbusplus::message::object_path, PairingInterfaceMap>();
 
-        auto it = interfaces.find(Provisioning::interface);
+        auto it = interfaces.find(Pairing::interface);
         if (it != interfaces.end())
         {
-            lg2::info("Provisioning interface added");
-            loadProvisioningProps(it->second);
+            lg2::info("Pairing interface added");
+            loadPairingProps(it->second);
         }
     }
 }
 
-sdbusplus::async::task<> ServicesImpl::watchProvisioningPropertiesChanged(
+sdbusplus::async::task<> ServicesImpl::watchPairingPropertiesChanged(
     std::shared_ptr<sdbusplus::async::barrier> barrier)
 {
     sdbusplus::async::match match(
-        ctx, rules::propertiesChanged(Provisioning::instance_path,
-                                      Provisioning::interface));
+        ctx,
+        rules::propertiesChanged(Pairing::instance_path, Pairing::interface));
 
     co_await barrier->wait();
 
     while (!ctx.stop_requested())
     {
-        auto [_, properties] =
-            co_await match.next<std::string, ProvisioningPropMap>();
-        loadProvisioningProps(properties);
+        auto [_,
+              properties] = co_await match.next<std::string, PairingPropMap>();
+        loadPairingProps(properties);
     }
 }
 
@@ -708,10 +707,10 @@ sdbusplus::async::task<> ServicesImpl::startUnit(
     }
 }
 
-bool ServicesImpl::getProvisioned() const
+bool ServicesImpl::getPaired() const
 {
     // TODO: Return the actual value.
-    // return provisioned;
+    // return paired;
     return true;
 }
 

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -33,11 +33,11 @@ class ServicesImpl : public Services
     ServicesImpl(ServicesImpl&&) = delete;
     ServicesImpl& operator=(ServicesImpl&&) = delete;
 
-    using ProvisioningCommon =
+    using PairingCommon =
         sdbusplus::common::xyz::openbmc_project::provisioning::Provisioning;
-    using ProvisioningPropMap =
-        std::unordered_map<std::string, ProvisioningCommon::PropertiesVariant>;
-    using ProvisioningInterfaceMap = std::map<std::string, ProvisioningPropMap>;
+    using PairingPropMap =
+        std::unordered_map<std::string, PairingCommon::PropertiesVariant>;
+    using PairingInterfaceMap = std::map<std::string, PairingPropMap>;
 
     /**
      * @brief Constructor
@@ -84,11 +84,11 @@ class ServicesImpl : public Services
         const std::string& name) const override;
 
     /**
-     * @brief If this BMC has been provisioned
+     * @brief If this BMC has been paired
      *
-     * @return bool - If provisioned or not.
+     * @return bool - If paired or not.
      */
-    bool getProvisioned() const override;
+    bool getPaired() const override;
 
     /**
      * @brief Returns an 8 character hash of the FW version
@@ -244,27 +244,27 @@ class ServicesImpl : public Services
         std::shared_ptr<sdbusplus::async::barrier> barrier);
 
     /**
-     * @brief Starts the InterfacesAdded watch for the Provisioning interface
+     * @brief Starts the InterfacesAdded watch for the Pairing interface
      *
      * @param[in] barrier - Initialization barrier
      */
-    sdbusplus::async::task<> watchProvisioningInterfacesAdded(
+    sdbusplus::async::task<> watchPairingInterfacesAdded(
         std::shared_ptr<sdbusplus::async::barrier> barrier);
 
     /**
-     * @brief Starts the PropertiesChanged watch for the Provisioning interface
+     * @brief Starts the PropertiesChanged watch for the Pairing interface
      *
      * @param[in] barrier - Initialization barrier
      */
-    sdbusplus::async::task<> watchProvisioningPropertiesChanged(
+    sdbusplus::async::task<> watchPairingPropertiesChanged(
         std::shared_ptr<sdbusplus::async::barrier> barrier);
 
     /**
-     * @brief Reads the Provisioning interface properties
+     * @brief Reads the Pairing interface properties
      */
-    sdbusplus::async::task<> readProvisioningProperties();
+    sdbusplus::async::task<> readPairingProperties();
 
-    void loadProvisioningProps(const ProvisioningPropMap& propertyMap);
+    void loadPairingProps(const PairingPropMap& propertyMap);
 
     /**
      * @brief Called when either the host state or boot progress property
@@ -308,9 +308,9 @@ class ServicesImpl : public Services
     bool peerConnected{false};
 
     /**
-     * @brief The provisioned status value
+     * @brief The paired status value
      */
-    bool provisioned;
+    bool paired;
 
     /**
      * @brief D-Bus path for the Item.System object

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -102,11 +102,11 @@ class Sibling
     virtual std::optional<bool> getRedundancyEnabled() const = 0;
 
     /**
-     * @brief Returns the sibling BMC's provisioning status
+     * @brief Returns the sibling BMC's pairing status
      *
      * @return - The status, or nullopt if not available
      */
-    virtual std::optional<bool> getProvisioned() const = 0;
+    virtual std::optional<bool> getPaired() const = 0;
 
     /**
      * @brief Returns the sibling BMC's FW version representation

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -22,7 +22,7 @@ using VersionIntf = sdbusplus::common::xyz::openbmc_project::software::Version;
 using BMCStateIntf = sdbusplus::common::xyz::openbmc_project::state::BMC;
 using AvailIntf =
     sdbusplus::common::xyz::openbmc_project::state::decorator::Availability;
-using ProvisioningIntf =
+using PairingIntf =
     sdbusplus::common::xyz::openbmc_project::provisioning::Provisioning;
 
 SiblingImpl::SiblingImpl(sdbusplus::async::context& ctx,
@@ -225,15 +225,14 @@ void SiblingImpl::loadAvailabilityProps(
     }
 }
 
-void SiblingImpl::loadProvisioningProps(
-    const SiblingImpl::PropertyMap& propertyMap)
+void SiblingImpl::loadPairingProps(const SiblingImpl::PropertyMap& propertyMap)
 {
-    provisioning.present = true;
+    pairing.present = true;
 
     auto it = propertyMap.find("Provisioned");
     if (it != propertyMap.end())
     {
-        provisioning.provisioned = std::get<bool>(it->second);
+        pairing.paired = std::get<bool>(it->second);
     }
 }
 
@@ -318,9 +317,9 @@ sdbusplus::async::task<> SiblingImpl::watchInterfaceRemoved(
         {
             availability.present = false;
         }
-        if (std::ranges::contains(interfaces, ProvisioningIntf::interface))
+        if (std::ranges::contains(interfaces, PairingIntf::interface))
         {
-            provisioning.present = false;
+            pairing.present = false;
         }
 
         // If alive before and all interfaces are now gone invoke the callbacks
@@ -429,9 +428,9 @@ void SiblingImpl::loadFromPropertyMap(const std::string& interface,
     {
         loadAvailabilityProps(propertyMap);
     }
-    else if (interface == ProvisioningIntf::interface)
+    else if (interface == PairingIntf::interface)
     {
-        loadProvisioningProps(propertyMap);
+        loadPairingProps(propertyMap);
     }
 }
 

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -130,15 +130,15 @@ class SiblingImpl : public Sibling
     }
 
     /**
-     * @brief Returns the sibling BMC's provisioning status
+     * @brief Returns the sibling BMC's pairing status
      *
      * @return - The status, or nullopt if not available
      */
-    std::optional<bool> getProvisioned() const override
+    std::optional<bool> getPaired() const override
     {
         if (alive())
         {
-            return provisioning.provisioned;
+            return pairing.paired;
         }
 
         return std::nullopt;
@@ -318,12 +318,12 @@ class SiblingImpl : public Sibling
     void loadAvailabilityProps(const PropertyMap& propertyMap);
 
     /**
-     * @brief Sets Provisioning data members with whatever is in the property
+     * @brief Sets Pairing data members with whatever is in the property
      * map
      *
      * @param[in] propertyMap - The property name -> value map
      */
-    void loadProvisioningProps(const PropertyMap& propertyMap);
+    void loadPairingProps(const PropertyMap& propertyMap);
 
     /**
      * @brief Sets data members with whatever is in the property map
@@ -343,7 +343,7 @@ class SiblingImpl : public Sibling
         bmcState.present = false;
         version.present = false;
         availability.present = false;
-        provisioning.present = false;
+        pairing.present = false;
     }
 
     /**
@@ -436,16 +436,16 @@ class SiblingImpl : public Sibling
      */
     Availability availability;
 
-    struct Provisioning
+    struct Pairing
     {
         bool present = false;
-        bool provisioned = false;
+        bool paired = false;
     };
 
     /**
-     * @brief Provisioning presence and value
+     * @brief Pairing presence and value
      */
-    Provisioning provisioning;
+    Pairing pairing;
 
     /**
      * @brief The D-Bus object path for the sibling.

--- a/redundant-bmc/test/redundancy_test.cpp
+++ b/redundant-bmc/test/redundancy_test.cpp
@@ -14,7 +14,7 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
         .role = rbmc::Role::Active,
         .siblingPresent = true,
         .siblingAlive = true,
-        .siblingProvisioned = true,
+        .siblingPaired = true,
         .siblingRole = rbmc::Role::Passive,
         .siblingCannotBeActive = false,
         .siblingState = rbmc::BMCState::Ready,
@@ -60,10 +60,10 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
         EXPECT_EQ(*reasons.begin(), SiblingNotAlive);
     }
 
-    // Sibling isn't provisioned
+    // Sibling isn't paired
     {
         auto input = golden;
-        input.siblingProvisioned = false;
+        input.siblingPaired = false;
 
         auto reasons = getNoRedundancyReasons(input);
         ASSERT_EQ(reasons.size(), 1);

--- a/redundant-bmc/test/role_determination_test.cpp
+++ b/redundant-bmc/test/role_determination_test.cpp
@@ -152,6 +152,6 @@ TEST(RoleDeterminationTest, RoleDeterminationTest)
 
 TEST(RoleDeterminationTest, ErrorReasonTest)
 {
-    EXPECT_TRUE(isErrorReason(RoleReason::notProvisioned));
+    EXPECT_TRUE(isErrorReason(RoleReason::notPaired));
     EXPECT_FALSE(isErrorReason(RoleReason::resumePrevious));
 }


### PR DESCRIPTION
Change all of the occurrences of 'provision' to 'pair' since that is the proper terminology.

The D-Bus interface, properties, and service name that provides that information hasn't changed yet, so those still contain the 'provision' word.