### PR TITLE
Changes for upcoming RBMC unit tests

### DIFF
--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -18,10 +18,12 @@ const std::string failoverPath =
     RedundancyInterface::namespace_path::bmc;
 
 Manager::Manager(sdbusplus::async::context& ctx,
-                 std::unique_ptr<Providers>&& providers) :
+                 std::unique_ptr<Providers>&& providers,
+                 std::chrono::milliseconds heartbeatInterval) :
     sdbusplus::aserver::xyz::openbmc_project::control::Failover<Manager>(
         ctx, failoverPath.c_str()),
-    ctx(ctx), redundancyInterface(ctx, *this), providers(std::move(providers))
+    ctx(ctx), redundancyInterface(ctx, *this), providers(std::move(providers)),
+    heartbeatInterval(heartbeatInterval)
 {
     try
     {
@@ -164,16 +166,12 @@ void Manager::startHeartbeat()
     ctx.spawn(doHeartBeat());
 }
 
-// clang-tidy currently mangles this into something unreadable
-// NOLINTNEXTLINE
 sdbusplus::async::task<> Manager::doHeartBeat()
 {
-    using namespace std::chrono_literals;
-
     while (!ctx.stop_requested())
     {
         redundancyInterface.heartbeat();
-        co_await sdbusplus::async::sleep_for(ctx, 1s);
+        co_await sdbusplus::async::sleep_for(ctx, heartbeatInterval);
     }
 
     co_return;

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -37,9 +37,12 @@ class Manager :
      *
      * @param[in] ctx - The async context object
      * @param[in] providers - The Providers access object
+     * @param[in] heartbeatInterval - Interval between heartbeats (default: 1s)
      */
     Manager(sdbusplus::async::context& ctx,
-            std::unique_ptr<Providers>&& providers);
+            std::unique_ptr<Providers>&& providers,
+            std::chrono::milliseconds heartbeatInterval = std::chrono::seconds{
+                1});
 
     /**
      * @brief Handler for the DisableRedundancyOverride
@@ -197,6 +200,11 @@ class Manager :
      */
     role_determination::RoleReason roleReason{
         role_determination::RoleReason::unknown};
+
+    /**
+     * @brief The interval between heartbeats
+     */
+    std::chrono::milliseconds heartbeatInterval;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -172,14 +172,17 @@ class Manager :
     RedundancyInterface redundancyInterface;
 
     /**
+     * @brief Contains the various provider helpers
+     *
+     * NOTE: Must be declared before handler so it's destroyed
+     * after handler, since handler's destructor accesses providers.
+     */
+    std::unique_ptr<Providers> providers;
+
+    /**
      * @brief The role handler class
      */
     std::unique_ptr<RoleHandler> handler;
-
-    /**
-     * @brief Contains the various provider helpers
-     */
-    std::unique_ptr<Providers> providers;
 
     /**
      * @brief The previously serialized role value.


### PR DESCRIPTION
1. Fix a destruction ordering bug
2. Make the heartbeat timer configurable, so in unit test a test can finish in under a second when running using the Manager class.