### PR TITLE
Add PCIe MMIO support for RBMC redundancy

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -337,3 +337,46 @@ the following to prepare to be reset and come back as the passive BMC:
 
 1. Stop background syncing.
 2. Flush any unwritten journal messages to disk.
+
+## PCIe MMIO Redundancy State
+
+If enabled, redundancy state information is exposed to the host through PCIe
+MMIO. This allows the host to read the current redundancy state (BMC role,
+redundancy enabled status, failover status, etc.) directly from PCIe
+memory-mapped I/O space. This mechanism provides early access to redundancy
+information during host boot, before higher-level communication protocols are
+initialized, and works regardless of whether the BMC is active or passive. A
+dedicated PCIe MMIO offset is reserved for redundancy-related properties.
+
+### PCIe MMIO Layout
+
+```text
+ * @brief PCIe MMIO Redundancy State Layout
+ *
+ * Single-byte layout shared between BMC and host via PCIe MMIO.
+ *
+ * ┌─────────────────────────────────────────────────────────────┐
+ * │ Bit 7   │ Bit 6      │ Bit 5    │ Bit 4-3 │ Bit 2-0 │
+ * │ allowed │ inProgress │ enabled  │ role    │ version │
+ * └─────────────────────────────────────────────────────────────┘
+ *
+ * Layout (LSB to MSB):
+ *   Bits 0-2: version (0-7, current=1)
+ *   Bits 3-4: role (Unknown=0, Active=1, Passive=2)
+ *   Bit 5:    redundancyEnabled
+ *   Bit 6:    failoverInProgress
+ *   Bit 7:    failoversAllowed
+```
+
+### Configuration
+
+The PCIe MMIO location is configurable through the JSON configuration file. See
+[`config_files/README.md`](config_files/README.md#pcie-config-object) for
+details on the `pcie_config` configuration options.
+
+### Notes
+
+- PCIe BAR/MMIO is a standard PCIe mechanism, but the redundancy state layout
+  and offset definitions are vendor-specific.
+- The configured offsets are reserved for redundancy state information and must
+  not overlap with other PCIe MMIO users.

--- a/redundant-bmc/config_files/README.md
+++ b/redundant-bmc/config_files/README.md
@@ -31,7 +31,11 @@ It is then installed into
         "polarity": "high"
       }
     }
-  ]
+  ],
+  "pcie_config": {
+    "device_path": "/dev/bmc-device0",
+    "redundancy_offset": "0x3F00000"
+  }
 }
 ```
 
@@ -44,6 +48,8 @@ It is then installed into
 - **bmc_configs** (array, conditionally required): Array of BMC configuration
   objects. Required when there is a `sibling_bmc_reset_gpio`, optional when
   false.
+- **pcie_config** (object, optional): PCIe storage configuration for redundancy
+  data. If not present, PCIe storage functionality is disabled.
 
 ### BMC Config Object
 
@@ -56,6 +62,13 @@ It is then installed into
 - **name** (string, required): Name of the GPIO line.
 - **polarity** (string, required): Either "low" or "high" - indicates the active
   state of the GPIO.
+
+### PCIe Config Object
+
+- **device_path** (string, required): Path to the PCIe device (e.g.,
+  '/dev/bmc-device0').
+- **redundancy_offset** (string, required): Offset in the PCIe device for
+  redundancy data as a hex string (e.g., '0x3F000000').
 
 ### Validating Config Files
 

--- a/redundant-bmc/config_files/default.json
+++ b/redundant-bmc/config_files/default.json
@@ -2,5 +2,9 @@
     "sibling_bmc_reset_gpio": {
         "name": "sibling-bmc-reset-n",
         "polarity": "low"
+    },
+    "pcie_config": {
+        "device_path": "/dev/bmc-device0",
+        "redundancy_offset": "0x3F00000"
     }
 }

--- a/redundant-bmc/config_files/huygens.json
+++ b/redundant-bmc/config_files/huygens.json
@@ -18,5 +18,9 @@
                 "polarity": "low"
             }
         }
-    ]
+    ],
+    "pcie_config": {
+        "device_path": "/dev/bmc-device0",
+        "redundancy_offset": "0x3F00000"
+    }
 }

--- a/redundant-bmc/config_files/rbmc-prototype.json
+++ b/redundant-bmc/config_files/rbmc-prototype.json
@@ -2,5 +2,9 @@
     "sibling_bmc_reset_gpio": {
         "name": "sibling-bmc-reset-n",
         "polarity": "low"
+    },
+    "pcie_config": {
+        "device_path": "/dev/bmc-device0",
+        "redundancy_offset": "0x3F00000"
     }
 }

--- a/redundant-bmc/config_files/schema/schema.json
+++ b/redundant-bmc/config_files/schema/schema.json
@@ -18,6 +18,10 @@
             },
             "minItems": 0,
             "uniqueItems": true
+        },
+        "pcie_config": {
+            "description": "PCIe storage configuration for redundancy data. Optional - if not present, PCIe storage functionality is disabled.",
+            "$ref": "#/$defs/pcie_config"
         }
     },
     "additionalProperties": false,
@@ -53,6 +57,24 @@
                 "sibling_bmc_present_gpio": {
                     "description": "GPIO configuration for detecting sibling BMC presence",
                     "$ref": "#/$defs/gpio_config"
+                }
+            },
+            "additionalProperties": false
+        },
+        "pcie_config": {
+            "type": "object",
+            "description": "PCIe storage configuration for redundancy data",
+            "required": ["device_path", "redundancy_offset"],
+            "properties": {
+                "device_path": {
+                    "type": "string",
+                    "description": "Path to the PCIe device (e.g., '/dev/bmc-device0')",
+                    "minLength": 1
+                },
+                "redundancy_offset": {
+                    "type": "string",
+                    "description": "Offset in the PCIe device for redundancy data as a hex string (e.g., '0x3F000000')",
+                    "minLength": 1
                 }
             },
             "additionalProperties": false

--- a/redundant-bmc/config_files/skiboards.json
+++ b/redundant-bmc/config_files/skiboards.json
@@ -2,5 +2,9 @@
     "sibling_bmc_reset_gpio": {
         "name": "sibling-bmc-reset",
         "polarity": "high"
+    },
+    "pcie_config": {
+        "device_path": "/dev/bmc-device0",
+        "redundancy_offset": "0x3F00000"
     }
 }

--- a/redundant-bmc/src/config_data.hpp
+++ b/redundant-bmc/src/config_data.hpp
@@ -50,6 +50,24 @@ struct BMCConfig
 };
 
 /**
+ * @struct PCIeConfig
+ *
+ * Configuration for PCIe storage
+ */
+struct PCIeConfig
+{
+    /**
+     * @brief The PCIe device path (e.g., "/dev/bmc-device0")
+     */
+    std::string devicePath;
+
+    /**
+     * @brief The offset in the PCIe device for redundancy data as a hex string
+     */
+    std::string redundancyOffset;
+};
+
+/**
  * @struct RedundantBMCConfig
  *
  * Top-level configuration for redundant BMC functionality
@@ -66,6 +84,13 @@ struct RedundantBMCConfig
      *        Map key is the BMC position (0-based)
      */
     std::map<size_t, BMCConfig> bmcConfigs;
+
+    /**
+     * @brief PCIe storage configuration (optional)
+     *
+     * If not present, PCIe storage functionality is disabled
+     */
+    std::optional<PCIeConfig> pcieConfig;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/config_parser.cpp
+++ b/redundant-bmc/src/config_parser.cpp
@@ -141,6 +141,45 @@ std::map<size_t, BMCConfig> parseBMCConfigs(const nlohmann::json& jsonData)
     return configs;
 }
 
+/**
+ * @brief Parse PCIe configuration from JSON
+ *
+ * @param[in] jsonData - The root JSON object
+ *
+ * @return Optional PCIeConfig object (empty if pcie_config not present)
+ * @throws std::runtime_error if required fields are missing or invalid
+ */
+std::optional<PCIeConfig> parsePCIeConfig(const nlohmann::json& jsonData)
+{
+    auto pcieConfigIt = jsonData.find("pcie_config");
+    if (pcieConfigIt == jsonData.end())
+    {
+        // pcie_config is optional
+        return std::nullopt;
+    }
+
+    const auto& pcieJSON = *pcieConfigIt;
+
+    auto devicePathIt = pcieJSON.find("device_path");
+    if (devicePathIt == pcieJSON.end())
+    {
+        throw std::runtime_error(
+            "pcie_config missing required 'device_path' field");
+    }
+
+    auto redundancyOffsetIt = pcieJSON.find("redundancy_offset");
+    if (redundancyOffsetIt == pcieJSON.end())
+    {
+        throw std::runtime_error(
+            "pcie_config missing required 'redundancy_offset' field");
+    }
+
+    PCIeConfig config;
+    config.devicePath = devicePathIt->get<std::string>();
+    config.redundancyOffset = redundancyOffsetIt->get<std::string>();
+    return config;
+}
+
 } // anonymous namespace
 
 RedundantBMCConfig parse(const std::filesystem::path& path)
@@ -175,6 +214,7 @@ RedundantBMCConfig parse(const std::filesystem::path& path)
             parseGPIOConfig(*resetGpioIt, "sibling_bmc_reset_gpio");
 
         config.bmcConfigs = parseBMCConfigs(jsonData);
+        config.pcieConfig = parsePCIeConfig(jsonData);
 
         return config;
     }

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -23,7 +23,8 @@ Manager::Manager(sdbusplus::async::context& ctx,
                  std::chrono::milliseconds heartbeatInterval) :
     sdbusplus::aserver::xyz::openbmc_project::control::Failover<Manager>(
         ctx, failoverPath.c_str()),
-    ctx(ctx), redundancyInterface(ctx, *this), providers(std::move(providers)),
+    ctx(ctx), providers(std::move(providers)),
+    redundancyInterface(ctx, *this, this->providers->getPCIeStorage()),
     heartbeatInterval(heartbeatInterval)
 {
     try

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -179,17 +179,17 @@ class Manager :
     sdbusplus::async::context& ctx;
 
     /**
+     * @brief Contains the various provider helpers
+     *
+     * NOTE: Must be declared before redundancyInterface and handler so it's
+     * destroyed after them, since their destructors access providers.
+     */
+    std::unique_ptr<Providers> providers;
+
+    /**
      * @brief The Redundancy D-Bus interface
      */
     RedundancyInterface redundancyInterface;
-
-    /**
-     * @brief Contains the various provider helpers
-     *
-     * NOTE: Must be declared before handler so it's destroyed
-     * after handler, since handler's destructor accesses providers.
-     */
-    std::unique_ptr<Providers> providers;
 
     /**
      * @brief The role handler class

--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -22,6 +22,7 @@ rbmc_lib = static_library(
     'gpio.cpp',
     'manager.cpp',
     'passive_role_handler.cpp',
+    'pcie_storage.cpp',
     'persistent_data.cpp',
     'redundancy.cpp',
     'redundancy_interface.cpp',

--- a/redundant-bmc/src/pcie_storage.cpp
+++ b/redundant-bmc/src/pcie_storage.cpp
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "pcie_storage.hpp"
+
+#include "phosphor-logging/lg2.hpp"
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <stdexcept>
+
+namespace pcie_data
+{
+PCIeStorageImpl::PCIeStorageImpl(const std::string& devPath, size_t offset) :
+    devicePath(devPath), redundancyOffset(offset)
+{
+    try
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+        fd = open(devicePath.c_str(), O_RDWR | O_CLOEXEC);
+        if (fd == -1)
+        {
+            lg2::error("PCIe device not available at {PATH}", "PATH",
+                       devicePath);
+            return;
+        }
+
+        mmioBase = mmap(nullptr, redundancySize, PROT_READ | PROT_WRITE,
+                        MAP_SHARED, fd, static_cast<off_t>(redundancyOffset));
+        if (mmioBase == MAP_FAILED)
+        {
+            close(fd);
+            fd = -1;
+            lg2::error("PCIe mmap failed at offset {OFFSET}", "OFFSET",
+                       redundancyOffset);
+            return;
+        }
+
+        lg2::debug(
+            "PCIe storage initialized successfully at {PATH} offset {OFFSET}",
+            "PATH", devicePath, "OFFSET", redundancyOffset);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("PCIe storage initialization failed: {ERROR}", "ERROR", e);
+    }
+}
+
+PCIeStorageImpl::~PCIeStorageImpl()
+{
+    if (mmioBase != nullptr && mmioBase != MAP_FAILED)
+    {
+        munmap(mmioBase, redundancySize);
+    }
+    if (fd != -1)
+    {
+        close(fd);
+    }
+}
+
+void PCIeStorageImpl::validateMMIO() const
+{
+    if (mmioBase == nullptr || mmioBase == MAP_FAILED)
+    {
+        throw std::runtime_error("PCIe storage not initialized");
+    }
+}
+
+void PCIeStorageImpl::writeState(const RedundancyState& state)
+{
+    std::lock_guard<std::mutex> lock(stateMutex);
+    validateMMIO();
+
+    RedundancyState modifiedState = state;
+    modifiedState.version = redundancyDataVersion;
+
+    std::memcpy(mmioBase, &modifiedState, sizeof(RedundancyState));
+    __sync_synchronize();
+}
+
+RedundancyState PCIeStorageImpl::readState()
+{
+    std::lock_guard<std::mutex> lock(stateMutex);
+    validateMMIO();
+
+    RedundancyState state{};
+    std::memcpy(&state, mmioBase, sizeof(RedundancyState));
+
+    return state;
+}
+
+void PCIeStorageImpl::updateRole(uint8_t role)
+{
+    auto state = readState();
+    state.role = role;
+    writeState(state);
+    lg2::debug("Role updated in PCIe memory to {VALUE}", "VALUE", role);
+}
+
+void PCIeStorageImpl::updateRedundancyEnabled(bool enabled)
+{
+    auto state = readState();
+    state.redundancyEnabled = enabled ? 1 : 0;
+    writeState(state);
+    lg2::debug("RedundancyEnabled updated in PCIe memory to {VALUE}", "VALUE",
+               enabled);
+}
+
+void PCIeStorageImpl::updateFailoverInProgress(bool inProgress)
+{
+    auto state = readState();
+    state.failoverInProgress = inProgress ? 1 : 0;
+    writeState(state);
+    lg2::debug("FailoverInProgress updated in PCIe memory to {VALUE}", "VALUE",
+               inProgress);
+}
+
+void PCIeStorageImpl::updateFailoversAllowed(bool allowed)
+{
+    auto state = readState();
+    state.failoversAllowed = allowed ? 1 : 0;
+    writeState(state);
+    lg2::debug("FailoversAllowed updated in PCIe memory to {VALUE}", "VALUE",
+               allowed);
+}
+
+} // namespace pcie_data

--- a/redundant-bmc/src/pcie_storage.hpp
+++ b/redundant-bmc/src/pcie_storage.hpp
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <string>
+
+namespace pcie_data
+{
+// Default values for PCIe configuration
+constexpr auto defaultDevicePath = "/dev/bmc-device0";
+constexpr auto defaultRedundancyOffset = 0x3F00000;
+constexpr size_t redundancySize = 1;
+
+constexpr uint8_t redundancyDataVersion = 1;
+
+/**
+ * @brief PCIe MMIO Redundancy State Layout
+ *
+ * Single-byte layout shared between BMC and host via PCIe MMIO.
+ *
+ * ┌─────────────────────────────────────────────────────────────┐
+ * │ Bit 7   │ Bit 6      │ Bit 5    │ Bit 4-3 │ Bit 2-0 │
+ * │ allowed │ inProgress │ enabled  │ role    │ version │
+ * └─────────────────────────────────────────────────────────────┘
+ *
+ * Layout (LSB to MSB):
+ *   Bits 0-2: version (0-7, current=1)
+ *   Bits 3-4: role (Unknown=0, Active=1, Passive=2)
+ *   Bit 5:    redundancyEnabled
+ *   Bit 6:    failoverInProgress
+ *   Bit 7:    failoversAllowed
+ *
+ * BMC Perspective:
+ *   C bitfields in LSB-to-MSB order. BMC writes struct
+ *   directly to PCIe MMIO with first field in lowest bits.
+ *
+ * Endianness Interoperability:
+ *   Single byte eliminates endianness concerns. Both little-endian
+ *   and big-endian hosts read identical bit pattern. No byte-order conversion
+ *   needed since there's only one byte.
+ *
+ * Version field allows 7 future layout revisions.
+ */
+struct RedundancyState
+{
+    uint8_t version:3; // Bits 0-2: Layout version (0-7, current=1)
+    uint8_t role:2;    // Bits 3-4: Role (Unknown=0, Active=1, Passive=2)
+    uint8_t redundancyEnabled:1;  // Bit 5: Redundancy enabled flag
+    uint8_t failoverInProgress:1; // Bit 6: Failover in progress flag
+    uint8_t failoversAllowed:1;   // Bit 7: Failovers allowed flag
+} __attribute__((packed));
+
+static_assert(sizeof(RedundancyState) == redundancySize);
+
+/**
+ * @class PCIeStorage
+ *
+ * Abstract interface for PCIe storage operations.
+ * Allows for mocking in unit tests.
+ */
+class PCIeStorage
+{
+  public:
+    PCIeStorage() = default;
+    virtual ~PCIeStorage() = default;
+    PCIeStorage(const PCIeStorage&) = delete;
+    PCIeStorage& operator=(const PCIeStorage&) = delete;
+    PCIeStorage(PCIeStorage&&) = delete;
+    PCIeStorage& operator=(PCIeStorage&&) = delete;
+
+    /**
+     * @brief Write the complete redundancy state to PCIe storage
+     *
+     * @param[in] state - The redundancy state to write
+     */
+    virtual void writeState(const RedundancyState& state) = 0;
+
+    /**
+     * @brief Read the complete redundancy state from PCIe storage
+     *
+     * @return The redundancy state
+     */
+    virtual RedundancyState readState() = 0;
+
+    /**
+     * @brief Update only the role field in PCIe storage
+     *
+     * @param[in] role - The role value to set
+     */
+    virtual void updateRole(uint8_t role) = 0;
+
+    /**
+     * @brief Update only the redundancy enabled field in PCIe storage
+     *
+     * @param[in] enabled - The redundancy enabled value to set
+     */
+    virtual void updateRedundancyEnabled(bool enabled) = 0;
+
+    /**
+     * @brief Update only the failover in progress field in PCIe storage
+     *
+     * @param[in] inProgress - The failover in progress value to set
+     */
+    virtual void updateFailoverInProgress(bool inProgress) = 0;
+
+    /**
+     * @brief Update only the failovers allowed field in PCIe storage
+     *
+     * @param[in] allowed - The failovers allowed value to set
+     */
+    virtual void updateFailoversAllowed(bool allowed) = 0;
+};
+
+/**
+ * @class PCIeStorageImpl
+ *
+ * Implementation of PCIeStorage that uses actual PCIe device.
+ */
+class PCIeStorageImpl : public PCIeStorage
+{
+  private:
+    int fd{-1};
+    void* mmioBase{nullptr};
+    std::mutex stateMutex;
+    std::string devicePath;
+    size_t redundancyOffset;
+
+    void validateMMIO() const;
+
+  public:
+    PCIeStorageImpl(const std::string& devPath, size_t offset);
+    ~PCIeStorageImpl() override;
+
+    void writeState(const RedundancyState& state) override;
+    RedundancyState readState() override;
+
+    void updateRole(uint8_t role) override;
+    void updateRedundancyEnabled(bool enabled) override;
+    void updateFailoverInProgress(bool inProgress) override;
+    void updateFailoversAllowed(bool allowed) override;
+};
+
+} // namespace pcie_data

--- a/redundant-bmc/src/providers.hpp
+++ b/redundant-bmc/src/providers.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "pcie_storage.hpp"
 #include "services.hpp"
 #include "sibling.hpp"
 #include "sibling_reset.hpp"
@@ -44,6 +45,11 @@ class Providers
      * @brief Returns the SiblingReset provider
      */
     virtual SiblingReset& getSiblingReset() = 0;
+
+    /**
+     * @brief Returns the PCIeStorage provider if configured
+     */
+    virtual pcie_data::PCIeStorage* getPCIeStorage() = 0;
 };
 
 }; // namespace rbmc

--- a/redundant-bmc/src/providers_impl.hpp
+++ b/redundant-bmc/src/providers_impl.hpp
@@ -10,6 +10,8 @@
 
 #include <phosphor-logging/lg2.hpp>
 
+#include <optional>
+
 namespace rbmc
 {
 
@@ -36,7 +38,7 @@ class ProvidersImpl : public Providers
     explicit ProvidersImpl(sdbusplus::async::context& ctx) :
         config(config_parser::readConfig()), services(ctx),
         sibling(ctx, config, services), syncInterface(ctx),
-        siblingReset(ctx, config)
+        siblingReset(ctx, config), pcieStorage(createPCIeStorage())
     {}
 
     /**
@@ -71,7 +73,39 @@ class ProvidersImpl : public Providers
         return siblingReset;
     }
 
+    /**
+     * @brief Returns the PCIeStorage provider
+     */
+    pcie_data::PCIeStorage* getPCIeStorage() override
+    {
+        if (!pcieStorage)
+        {
+            return nullptr;
+        }
+        return &*pcieStorage;
+    }
+
   private:
+    /**
+     * @brief Create PCIeStorage if config is present
+     *
+     * @return Optional PCIeStorageImpl
+     */
+    std::optional<pcie_data::PCIeStorageImpl> createPCIeStorage()
+    {
+        if (!config.pcieConfig.has_value())
+        {
+            lg2::debug("PCIe storage not configured - pcie_config not present");
+            return std::nullopt;
+        }
+
+        const auto& pcieConf = config.pcieConfig.value();
+        // Parse offset string (supports decimal and hex with 0x prefix)
+        size_t offset = std::stoull(pcieConf.redundancyOffset, nullptr, 0);
+        return std::make_optional<pcie_data::PCIeStorageImpl>(
+            pcieConf.devicePath, offset);
+    }
+
     /**
      * @brief The parsed configuration
      */
@@ -96,6 +130,11 @@ class ProvidersImpl : public Providers
      * @brief The SiblingReset implementation
      */
     SiblingResetImpl siblingReset;
+
+    /**
+     * @brief The PCIeStorage implementation (optional)
+     */
+    std::optional<pcie_data::PCIeStorageImpl> pcieStorage;
 };
 
 }; // namespace rbmc

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "config_parser.hpp"
+#include "pcie_storage.hpp"
 #include "persistent_data.hpp"
 #include "redundancy.hpp"
 #include "services_impl.hpp"
@@ -470,6 +471,54 @@ sdbusplus::async::task<> startFailover(sdbusplus::async::context& ctx,
     }
 }
 
+void displayPCIeState()
+{
+    try
+    {
+        auto config = rbmc::config_parser::readConfig();
+
+        if (!config.pcieConfig.has_value())
+        {
+            std::println("Error: PCIe storage not configured in config file");
+            exit(EXIT_FAILURE);
+        }
+
+        const auto& pcieConf = config.pcieConfig.value();
+
+        // Parse offset string (supports decimal and hex with 0x prefix)
+        size_t offset = std::stoull(pcieConf.redundancyOffset, nullptr, 0);
+
+        pcie_data::PCIeStorageImpl pcieStorage(pcieConf.devicePath, offset);
+        auto state = pcieStorage.readState();
+
+        std::println();
+        std::println("PCIe MMIO Redundancy State");
+        std::println("-----------------------------");
+
+        printParam("Version", static_cast<int>(state.version));
+        printParam("Role", getPDIEnumString(static_cast<Role>(state.role)));
+        printParam("Redundancy Enabled",
+                   static_cast<bool>(state.redundancyEnabled));
+        printParam("Failover In Progress",
+                   static_cast<bool>(state.failoverInProgress));
+        printParam("Failovers Allowed",
+                   static_cast<bool>(state.failoversAllowed));
+
+        // Display raw byte value for debugging
+        uint8_t rawByte;
+        std::memcpy(&rawByte, &state, sizeof(state));
+        std::println("{:22}0b{:08b} (0x{:02X})", "Raw Byte Value:", rawByte,
+                     rawByte);
+
+        std::println();
+    }
+    catch (const std::exception& e)
+    {
+        std::println("Error reading PCIe storage: {}", e.what());
+        exit(EXIT_FAILURE);
+    }
+}
+
 int main(int argc, char** argv)
 {
     CLI::App app{"RBMC Tool"};
@@ -481,6 +530,7 @@ int main(int argc, char** argv)
     bool failover{};
     bool forceFailover{};
     bool jsonOutput{};
+    bool readPCIe{};
     sdbusplus::async::context ctx;
 
     auto* displayGroup = app.add_option_group("Display RBMC information");
@@ -514,6 +564,10 @@ int main(int argc, char** argv)
                    "Start a forced failover. Only for emergencies.")
         ->excludes(fo);
 
+    auto* pcieGroup = app.add_option_group("PCIe MMIO operations");
+    pcieGroup->add_flag("-p, --read-pcie", readPCIe,
+                        "Read redundancy state from PCIe MMIO");
+
     app.require_option(1);
 
     CLI11_PARSE(app, argc, argv);
@@ -521,6 +575,11 @@ int main(int argc, char** argv)
     if (info)
     {
         ctx.spawn(displayInfo(ctx, extended, jsonOutput));
+    }
+    else if (readPCIe)
+    {
+        displayPCIeState();
+        return 0;
     }
     else if (resetSibling)
     {

--- a/redundant-bmc/src/redundancy_interface.cpp
+++ b/redundant-bmc/src/redundancy_interface.cpp
@@ -13,10 +13,11 @@ const std::string objectPath =
     RedundancyInterface::namespace_path::bmc;
 
 RedundancyInterface::RedundancyInterface(sdbusplus::async::context& ctx,
-                                         Manager& manager) :
+                                         Manager& manager,
+                                         pcie_data::PCIeStorage* pcieStorage) :
     sdbusplus::aserver::xyz::openbmc_project::state::bmc::Redundancy<
         RedundancyInterface>(ctx, objectPath.c_str()),
-    manager(manager)
+    manager(manager), pcieStorage(pcieStorage)
 {
     try
     {
@@ -54,7 +55,80 @@ RedundancyInterface::RedundancyInterface(sdbusplus::async::context& ctx,
         lg2::error("Failed removing NoRedundancyReasons: {ERROR}", "ERROR", e);
     }
 
+    // Sync initial D-Bus state to PCIe storage to ensure consistency
+    if (pcieStorage != nullptr)
+    {
+        try
+        {
+            pcieStorage->updateFailoverInProgress(failover_in_progress_);
+            pcieStorage->updateRedundancyEnabled(redundancy_enabled_);
+            pcieStorage->updateFailoversAllowed(failovers_allowed_);
+            pcieStorage->updateRole(static_cast<uint8_t>(role_));
+        }
+        catch (const std::exception& e)
+        {
+            lg2::warning("Failed to initialize PCIe storage state: {ERROR}",
+                         "ERROR", e);
+        }
+    }
+    else
+    {
+        lg2::debug(
+            "PCIe storage not configured; skipping initial PCIe state sync");
+    }
+
     emit_added();
+}
+
+bool RedundancyInterface::set_property([[maybe_unused]] role_t type, Role role)
+{
+    if (role == role_)
+    {
+        return false;
+    }
+
+    role_ = role;
+
+    if (pcieStorage != nullptr)
+    {
+        try
+        {
+            pcieStorage->updateRole(static_cast<uint8_t>(role_));
+        }
+        catch (const std::exception& e)
+        {
+            lg2::warning("Could not write Role to PCIe memory: {ERROR}",
+                         "ERROR", e);
+        }
+    }
+
+    return true;
+}
+
+bool RedundancyInterface::set_property(
+    [[maybe_unused]] redundancy_enabled_t type, bool enabled)
+{
+    if (enabled == redundancy_enabled())
+    {
+        return false;
+    }
+
+    if (pcieStorage != nullptr)
+    {
+        try
+        {
+            pcieStorage->updateRedundancyEnabled(enabled);
+        }
+        catch (const std::exception& e)
+        {
+            lg2::warning(
+                "Could not write RedundancyEnabled to PCIe memory: {ERROR}",
+                "ERROR", e);
+        }
+    }
+
+    redundancy_enabled_ = enabled;
+    return true;
 }
 
 bool RedundancyInterface::set_property(
@@ -104,6 +178,20 @@ bool RedundancyInterface::set_property(
             "INPROGRESS", inProgress, "ERROR", e);
     }
 
+    if (pcieStorage != nullptr)
+    {
+        try
+        {
+            pcieStorage->updateFailoverInProgress(inProgress);
+        }
+        catch (const std::exception& e)
+        {
+            lg2::warning(
+                "Could not write FailoverInProgress to PCIe memory: {ERROR}",
+                "ERROR", e);
+        }
+    }
+
     failover_in_progress_ = inProgress;
     return true;
 }
@@ -146,6 +234,32 @@ sdbusplus::async::task<> RedundancyInterface::method_call(
 {
     manager.setExternalRedundancyInput(input, value);
     co_return;
+}
+
+bool RedundancyInterface::set_property(
+    [[maybe_unused]] failovers_allowed_t type, bool allowed)
+{
+    if (allowed == failovers_allowed())
+    {
+        return false;
+    }
+
+    if (pcieStorage != nullptr)
+    {
+        try
+        {
+            pcieStorage->updateFailoversAllowed(allowed);
+        }
+        catch (const std::exception& e)
+        {
+            lg2::warning(
+                "Could not write FailoversAllowed to PCIe memory: {ERROR}",
+                "ERROR", e);
+        }
+    }
+
+    failovers_allowed_ = allowed;
+    return true;
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/redundancy_interface.hpp
+++ b/redundant-bmc/src/redundancy_interface.hpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "pcie_storage.hpp"
+
 #include <sdbusplus/async.hpp>
 #include <xyz/openbmc_project/State/BMC/Redundancy/aserver.hpp>
 
@@ -30,8 +32,33 @@ class RedundancyInterface :
      * @param[in] ctx - The async context object
      *
      * @param[in] manager - Reference to the Manager class
+     *
+     * @param[in] pcieStorage - Pointer to the PCIeStorage class if configured
      */
-    RedundancyInterface(sdbusplus::async::context& ctx, Manager& manager);
+    RedundancyInterface(sdbusplus::async::context& ctx, Manager& manager,
+                        pcie_data::PCIeStorage* pcieStorage);
+
+    /**
+     * @brief Implements property set for the
+     *        Role property
+     *
+     * @param[in] role_t - The type
+     * @param[in] role - the value being set
+     *
+     * @return If the property value changed
+     */
+    bool set_property(role_t type, Role role);
+
+    /**
+     * @brief Implements property set for the
+     *        RedundancyEnabled property
+     *
+     * @param[in] redundancy_enabled_t - The type
+     * @param[in] enabled - the value being set
+     *
+     * @return If the property value changed
+     */
+    bool set_property(redundancy_enabled_t type, bool enabled);
 
     /**
      * @brief Implements property set for the
@@ -78,11 +105,27 @@ class RedundancyInterface :
     sdbusplus::async::task<> method_call(set_redundancy_input_t /* unused */,
                                          RedundancyInput input, bool value);
 
+    /**
+     * @brief Implements property set for the
+     *        FailoversAllowed property
+     *
+     * @param[in] failovers_allowed_t - The type
+     * @param[in] allowed - the value being set
+     *
+     * @return If the property value changed
+     */
+    bool set_property(failovers_allowed_t type, bool allowed);
+
   private:
     /**
      * @brief Reference to the Manager class
      */
     Manager& manager;
+
+    /**
+     * @brief Pointer to the PCIeStorage class if configured
+     */
+    pcie_data::PCIeStorage* pcieStorage;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/test/config_parser_test.cpp
+++ b/redundant-bmc/test/config_parser_test.cpp
@@ -57,7 +57,11 @@ TEST_F(ConfigParserTest, ParseValidConfig)
                     "polarity": "high"
                 }
             }
-        ]
+        ],
+        "pcie_config": {
+            "device_path": "/dev/bmc-device0",
+            "redundancy_offset": "66060288"
+        }
     })";
 
     writeConfigFile("valid_config.json", config);
@@ -91,6 +95,10 @@ TEST_F(ConfigParserTest, ParseOptionalBMCConfigs)
         "sibling_bmc_reset_gpio": {
             "name": "sibling-bmc-reset-n",
             "polarity": "low"
+        },
+        "pcie_config": {
+            "device_path": "/dev/bmc-device0",
+            "redundancy_offset": "66060288"
         }
     })";
 
@@ -108,7 +116,11 @@ TEST_F(ConfigParserTest, ParseEmptyBMCConfigsArray)
             "name": "sibling-bmc-reset-n",
             "polarity": "low"
         },
-        "bmc_configs": []
+        "bmc_configs": [],
+        "pcie_config": {
+            "device_path": "/dev/bmc-device0",
+            "redundancy_offset": "66060288"
+        }
     })";
 
     writeConfigFile("empty_bmc_configs.json", config);
@@ -358,4 +370,82 @@ TEST_F(ConfigParserTest, ParseDuplicateBMCPosition)
 
     // Duplicate bmc_pos should cause parsing to fail
     EXPECT_THROW(parse(testDir / "duplicate_bmc_pos.json"), std::runtime_error);
+}
+
+TEST_F(ConfigParserTest, ParsePCIeConfig)
+{
+    const std::string config = R"({
+        "sibling_bmc_reset_gpio": {
+            "name": "sibling-bmc-reset-n",
+            "polarity":  "low"
+        },
+        "bmc_configs": [],
+        "pcie_config": {
+            "device_path": "/dev/bmc-device0",
+            "redundancy_offset": "0x3F00000"
+        }
+    })";
+
+    writeConfigFile("pcie_config.json", config);
+
+    auto result = parse(testDir / "pcie_config.json");
+
+    ASSERT_TRUE(result.pcieConfig.has_value());
+    EXPECT_EQ(result.pcieConfig->devicePath, "/dev/bmc-device0");
+    EXPECT_EQ(result.pcieConfig->redundancyOffset, "0x3F00000");
+}
+
+TEST_F(ConfigParserTest, ParseOptionalPCIeConfig)
+{
+    const std::string config = R"({
+        "sibling_bmc_reset_gpio": {
+            "name": "sibling-bmc-reset-n",
+            "polarity": "low"
+        },
+        "bmc_configs": []
+    })";
+
+    writeConfigFile("no_pcie_config.json", config);
+
+    auto result = parse(testDir / "no_pcie_config.json");
+
+    EXPECT_FALSE(result.pcieConfig.has_value());
+}
+
+TEST_F(ConfigParserTest, ParsePCIeConfigMissingDevicePath)
+{
+    const std::string config = R"({
+        "sibling_bmc_reset_gpio": {
+            "name": "sibling-bmc-reset-n",
+            "polarity": "low"
+        },
+        "bmc_configs": [],
+        "pcie_config": {
+            "redundancy_offset": "0x3F00000"
+        }
+    })";
+
+    writeConfigFile("pcie_missing_device_path.json", config);
+
+    EXPECT_THROW(parse(testDir / "pcie_missing_device_path.json"),
+                 std::runtime_error);
+}
+
+TEST_F(ConfigParserTest, ParsePCIeConfigMissingOffset)
+{
+    const std::string config = R"({
+        "sibling_bmc_reset_gpio": {
+            "name": "sibling-bmc-reset-n",
+            "polarity": "low"
+        },
+        "bmc_configs": [],
+        "pcie_config": {
+            "device_path": "/dev/bmc-device0"
+        }
+    })";
+
+    writeConfigFile("pcie_missing_offset.json", config);
+
+    EXPECT_THROW(parse(testDir / "pcie_missing_offset.json"),
+                 std::runtime_error);
 }

--- a/redundant-bmc/test/mocks/mock_pcie_storage.hpp
+++ b/redundant-bmc/test/mocks/mock_pcie_storage.hpp
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "pcie_storage.hpp"
+
+#include <gmock/gmock.h>
+
+namespace rbmc
+{
+
+/**
+ * @class MockPCIeStorage
+ *
+ * Mock implementation of PCIeStorage for testing.
+ */
+class MockPCIeStorage : public pcie_data::PCIeStorage
+{
+  public:
+    MOCK_METHOD(void, writeState, (const pcie_data::RedundancyState&),
+                (override));
+    MOCK_METHOD(pcie_data::RedundancyState, readState, (), (override));
+    MOCK_METHOD(void, updateRole, (uint8_t), (override));
+    MOCK_METHOD(void, updateRedundancyEnabled, (bool), (override));
+    MOCK_METHOD(void, updateFailoverInProgress, (bool), (override));
+    MOCK_METHOD(void, updateFailoversAllowed, (bool), (override));
+};
+
+} // namespace rbmc

--- a/redundant-bmc/test/mocks/mock_providers.hpp
+++ b/redundant-bmc/test/mocks/mock_providers.hpp
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "mock_pcie_storage.hpp"
 #include "mock_services.hpp"
 #include "mock_sibling.hpp"
 #include "mock_sibling_reset.hpp"
 #include "mock_sync_interface.hpp"
 #include "providers.hpp"
+
+#include <gmock/gmock.h>
 
 namespace rbmc
 {
@@ -20,7 +23,6 @@ class MockProviders : public Providers
 {
   public:
     MockProviders() = default;
-
     ~MockProviders() override = default;
 
     Services& getServices() override
@@ -41,6 +43,11 @@ class MockProviders : public Providers
     SiblingReset& getSiblingReset() override
     {
         return mockSiblingReset;
+    }
+
+    pcie_data::PCIeStorage* getPCIeStorage() override
+    {
+        return &mockPCIeStorage;
     }
 
     // Helpers to get the Mock versions
@@ -64,11 +71,17 @@ class MockProviders : public Providers
         return mockSiblingReset;
     }
 
+    MockPCIeStorage& getMockPCIeStorage()
+    {
+        return mockPCIeStorage;
+    }
+
   private:
     MockServices mockServices;
     MockSibling mockSibling;
     MockSyncInterface mockSyncInterface;
     MockSiblingReset mockSiblingReset;
+    MockPCIeStorage mockPCIeStorage;
 };
 
 } // namespace rbmc


### PR DESCRIPTION
Create support for transferring RBMC redundancy information through
PCIe memory mapped address space.