### PR TITLE
 RBMC: Add mock classes for future testing

### DIFF
--- a/redundant-bmc/src/providers.hpp
+++ b/redundant-bmc/src/providers.hpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
-#include "config_data.hpp"
 #include "services.hpp"
 #include "sibling.hpp"
 #include "sibling_reset.hpp"
@@ -45,13 +44,6 @@ class Providers
      * @brief Returns the SiblingReset provider
      */
     virtual SiblingReset& getSiblingReset() = 0;
-
-    /**
-     * @brief Returns the config file data structures.
-     *
-     * @return The configuration
-     */
-    virtual const RedundantBMCConfig& getConfig() const = 0;
 };
 
 }; // namespace rbmc

--- a/redundant-bmc/src/providers_impl.hpp
+++ b/redundant-bmc/src/providers_impl.hpp
@@ -70,14 +70,6 @@ class ProvidersImpl : public Providers
         return siblingReset;
     }
 
-    /**
-     * @brief Returns the config file data structures.
-     */
-    const RedundantBMCConfig& getConfig() const override
-    {
-        return config;
-    }
-
   private:
     /**
      * @brief The parsed configuration

--- a/redundant-bmc/test/manager_test.cpp
+++ b/redundant-bmc/test/manager_test.cpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "mocks/mock_providers.hpp"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using namespace rbmc;
+
+class ManagerTest
+{
+  protected:
+    void SetUp()
+    {
+        mockProviders = std::make_unique<MockProviders>();
+    }
+
+    void TearDown()
+    {
+        mockProviders.reset();
+    }
+
+    std::unique_ptr<MockProviders> mockProviders;
+};

--- a/redundant-bmc/test/meson.build
+++ b/redundant-bmc/test/meson.build
@@ -6,11 +6,13 @@ test(
         'rbmc-tests',
         'config_parser_test.cpp',
         'error_data_test.cpp',
+        'manager_test.cpp',
         'persistent_data_test.cpp',
         'redundancy_test.cpp',
         'role_determination_test.cpp',
         dependencies: [
             gtest,
+            gmock,
             nlohmann_json_dep,
             sdbusplus,
             phosphordbusinterfaces,

--- a/redundant-bmc/test/mocks/mock_providers.hpp
+++ b/redundant-bmc/test/mocks/mock_providers.hpp
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "mock_services.hpp"
+#include "mock_sibling.hpp"
+#include "mock_sibling_reset.hpp"
+#include "mock_sync_interface.hpp"
+#include "providers.hpp"
+
+namespace rbmc
+{
+
+/**
+ * @class MockProviders
+ *
+ * Mock implementation of the Providers interface that holds
+ * all the mock provider objects for testing.
+ */
+class MockProviders : public Providers
+{
+  public:
+    MockProviders() = default;
+
+    ~MockProviders() override = default;
+
+    Services& getServices() override
+    {
+        return mockServices;
+    }
+
+    Sibling& getSibling() override
+    {
+        return mockSibling;
+    }
+
+    SyncInterface& getSyncInterface() override
+    {
+        return mockSyncInterface;
+    }
+
+    SiblingReset& getSiblingReset() override
+    {
+        return mockSiblingReset;
+    }
+
+    // Helpers to get the Mock versions
+    MockServices& getMockServices()
+    {
+        return mockServices;
+    }
+
+    MockSibling& getMockSibling()
+    {
+        return mockSibling;
+    }
+
+    MockSyncInterface& getMockSyncInterface()
+    {
+        return mockSyncInterface;
+    }
+
+    MockSiblingReset& getMockSiblingReset()
+    {
+        return mockSiblingReset;
+    }
+
+  private:
+    MockServices mockServices;
+    MockSibling mockSibling;
+    MockSyncInterface mockSyncInterface;
+    MockSiblingReset mockSiblingReset;
+};
+
+} // namespace rbmc

--- a/redundant-bmc/test/mocks/mock_services.hpp
+++ b/redundant-bmc/test/mocks/mock_services.hpp
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "services.hpp"
+
+#include <gmock/gmock.h>
+
+namespace rbmc
+{
+
+/**
+ * @class MockServices
+ *
+ * Mock implementation of the Services interface for testing.
+ */
+class MockServices : public testing::NiceMock<Services>
+{
+  public:
+    MockServices() = default;
+    ~MockServices() override = default;
+
+    MOCK_METHOD(sdbusplus::async::task<>, init, (), (override));
+
+    MOCK_METHOD(bool, getPaired, (), (const, override));
+
+    MOCK_METHOD(std::optional<size_t>, getBMCPosition, (), (const, override));
+
+    MOCK_METHOD(sdbusplus::async::task<bool>, checkSystemInventoryStatus, (),
+                (override));
+
+    MOCK_METHOD(std::filesystem::path, getPersistentDataPath, (),
+                (const, override));
+
+    MOCK_METHOD(sdbusplus::async::task<>, logError,
+                (std::string error, errors::Level severity,
+                 errors::AdditionalData data),
+                (const, override));
+
+    MOCK_METHOD(sdbusplus::async::task<>, startUnit,
+                (const std::string& unitName, std::chrono::seconds timeout),
+                (const, override));
+
+    MOCK_METHOD(sdbusplus::async::task<std::string>, getUnitState,
+                (const std::string& unitName), (const, override));
+
+    MOCK_METHOD(std::string, getFWVersion, (), (const, override));
+
+    MOCK_METHOD(
+        sdbusplus::async::task<
+            sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState>,
+        getBMCState, (), (const, override));
+
+    MOCK_METHOD(SystemState, getSystemState, (), (const, override));
+
+    MOCK_METHOD(bool, getPeerConnected, (), (const, override));
+
+    MOCK_METHOD(sdbusplus::async::task<>, waitForPeerConnection, (),
+                (override));
+
+    MOCK_METHOD(sdbusplus::async::task<>, doFailoverImminentDelay, (),
+                (const, override));
+
+    MOCK_METHOD(sdbusplus::async::task<>, flushJournal, (), (const, override));
+
+    MOCK_METHOD(sdbusplus::async::task<>, acquireFullHardwareAccess, (),
+                (override));
+
+    MOCK_METHOD(void, setRedundancyDetermined, (), (override));
+};
+
+} // namespace rbmc

--- a/redundant-bmc/test/mocks/mock_sibling.hpp
+++ b/redundant-bmc/test/mocks/mock_sibling.hpp
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "sibling.hpp"
+
+#include <gmock/gmock.h>
+
+namespace rbmc
+{
+
+/**
+ * @class MockSibling
+ *
+ * Mock implementation of the Sibling interface for testing.
+ */
+class MockSibling : public testing::NiceMock<Sibling>
+{
+  public:
+    MockSibling() = default;
+    ~MockSibling() override = default;
+
+    MOCK_METHOD(sdbusplus::async::task<>, init, (), (override));
+
+    MOCK_METHOD(bool, isBMCPresent, (), (override));
+    MOCK_METHOD(bool, alive, (), (const, override));
+
+    MOCK_METHOD(sdbusplus::async::task<>, waitForSiblingUp, (), (override));
+    MOCK_METHOD(sdbusplus::async::task<>, waitForSiblingRole, (), (override));
+    MOCK_METHOD(sdbusplus::async::task<>, waitForBMCSteadyState, (),
+                (const, override));
+
+    MOCK_METHOD(std::optional<Role>, getRole, (), (const, override));
+    MOCK_METHOD(std::optional<bool>, getRedundancyEnabled, (),
+                (const, override));
+    MOCK_METHOD(std::optional<bool>, getPaired, (), (const, override));
+    MOCK_METHOD(std::optional<std::string>, getFWVersion, (),
+                (const, override));
+    MOCK_METHOD(std::optional<bool>, getFailoversAllowed, (),
+                (const, override));
+    MOCK_METHOD(std::optional<bool>, getFailoverInProgress, (),
+                (const, override));
+    MOCK_METHOD(std::optional<bool>, getFailoverImminent, (),
+                (const, override));
+    MOCK_METHOD(std::optional<bool>, getHasReasonForNoRedundancy, (),
+                (const, override));
+    MOCK_METHOD(std::optional<BMCState>, getBMCState, (), (const, override));
+
+    MOCK_METHOD(const std::string&, getServiceName, (), (const, override));
+
+    MOCK_METHOD(sdbusplus::async::task<>, pauseForHeartbeatChange, (),
+                (const, override));
+    MOCK_METHOD(sdbusplus::async::task<>, pauseForDataPropagation, (),
+                (const, override));
+};
+
+} // namespace rbmc

--- a/redundant-bmc/test/mocks/mock_sibling_reset.hpp
+++ b/redundant-bmc/test/mocks/mock_sibling_reset.hpp
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "sibling_reset.hpp"
+
+#include <gmock/gmock.h>
+
+namespace rbmc
+{
+
+/**
+ * @class MockSiblingReset
+ *
+ * Mock implementation of the SiblingReset interface for testing.
+ */
+class MockSiblingReset : public testing::NiceMock<SiblingReset>
+{
+  public:
+    MockSiblingReset() = default;
+    ~MockSiblingReset() override = default;
+
+    MOCK_METHOD(void, assertReset, (), (override));
+    MOCK_METHOD(void, releaseReset, (), (override));
+    MOCK_METHOD(sdbusplus::async::task<>, toggleReset, (), (override));
+};
+
+} // namespace rbmc

--- a/redundant-bmc/test/mocks/mock_sync_interface.hpp
+++ b/redundant-bmc/test/mocks/mock_sync_interface.hpp
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "sync_interface.hpp"
+
+#include <gmock/gmock.h>
+
+namespace rbmc
+{
+
+/**
+ * @class MockSyncInterface
+ *
+ * Mock implementation of the SyncInterface for testing.
+ */
+class MockSyncInterface : public testing::NiceMock<SyncInterface>
+{
+  public:
+    MockSyncInterface() = default;
+    ~MockSyncInterface() override = default;
+
+    MOCK_METHOD(sdbusplus::async::task<bool>, doFullSync, (), (override));
+    MOCK_METHOD(sdbusplus::async::task<>, disableBackgroundSync, (),
+                (override));
+};
+
+} // namespace rbmc


### PR DESCRIPTION
Create mock versions of all of the classes provided by Providers, and
also create a mock Providers to return those mock classes.

NiceMocks are used because there are lots of functions that won't always
be interesting to testcases, and without a NiceMock there would be
warnings emitted for each call that doesn't have an EXPECT_CALL.

The manager_test.cpp will eventually be filled in, but for now it's just
enough so that if a new pure virtual is added to one of the base classes
the compile will fail if it isn't also added to the mock.