### PR TITLE
RBMC: Extract sys state funcs to new file

### DIFF
--- a/redundant-bmc/src/error_data.cpp
+++ b/redundant-bmc/src/error_data.cpp
@@ -4,6 +4,7 @@
 #include "error_data.hpp"
 
 #include "persistent_data.hpp"
+#include "system_state.hpp"
 
 namespace rbmc::errors
 {
@@ -123,8 +124,7 @@ void addServicesData(const Services& services, bool isActive,
     {
         try
         {
-            data["SysState"] =
-                Services::getSystemStateName(services.getSystemState());
+            data["SysState"] = getSystemStateName(services.getSystemState());
         }
         catch (const std::exception& e)
         {

--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -31,6 +31,7 @@ rbmc_lib = static_library(
     'sibling_impl.cpp',
     'sibling_reset_impl.cpp',
     'sync_interface_impl.cpp',
+    'system_state.cpp',
     dependencies: rbmc_deps,
 )
 

--- a/redundant-bmc/src/redundancy_mgr.cpp
+++ b/redundant-bmc/src/redundancy_mgr.cpp
@@ -213,8 +213,7 @@ void RedundancyMgr::initSystemState()
         systemState = services.getSystemState();
 
         lg2::info("RedundancyMgr: Initial system state is {STATE}", "STATE",
-                  Services::getSystemStateName(
-                      systemState.value_or(SystemState::other)));
+                  getSystemStateName(systemState.value_or(SystemState::other)));
     }
     catch (const std::exception& e)
     {
@@ -233,7 +232,7 @@ void RedundancyMgr::initSystemState()
 void RedundancyMgr::systemStateChange(SystemState newState)
 {
     lg2::info("System state change to {NEW}", "NEW",
-              Services::getSystemStateName(newState));
+              getSystemStateName(newState));
 
     if (newState == SystemState::off)
     {

--- a/redundant-bmc/src/redundancy_mgr.hpp
+++ b/redundant-bmc/src/redundancy_mgr.hpp
@@ -4,6 +4,7 @@
 #include "providers.hpp"
 #include "redundancy.hpp"
 #include "redundancy_interface.hpp"
+#include "system_state.hpp"
 
 namespace rbmc
 {

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 #pragma once
 #include "errors.hpp"
+#include "system_state.hpp"
 
 #include <sdbusplus/async.hpp>
 #include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
@@ -14,14 +15,6 @@ namespace rbmc
 
 using Role =
     sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy::Role;
-
-enum class SystemState
-{
-    off,
-    booting,
-    runtime,
-    other
-};
 
 /**
  * @class Services
@@ -157,29 +150,6 @@ class Services
     virtual sdbusplus::async::task<> logError(
         std::string error, errors::Level severity,
         errors::AdditionalData data) const = 0;
-
-    /**
-     * @brief Returns the string name for the system state enum
-     *
-     * @param[in] state - The state enum
-     *
-     * @return The string name
-     */
-    static inline std::string getSystemStateName(SystemState state)
-    {
-        switch (state)
-        {
-            case SystemState::off:
-                return "Off";
-            case SystemState::booting:
-                return "Booting";
-            case SystemState::runtime:
-                return "Runtime";
-            case SystemState::other:
-                return "Other";
-        }
-        return std::string{"Unknown"};
-    }
 
     /**
      * @brief Add a function that gets called when the system state changes.

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 #include "services_impl.hpp"
 
+#include "system_state.hpp"
+
 #include <openssl/evp.h>
 
 #include <phosphor-logging/lg2.hpp>
@@ -470,37 +472,14 @@ sdbusplus::async::task<> ServicesImpl::watchPairingPropertiesChanged(
 
 void ServicesImpl::updateSystemState()
 {
-    using BProgress = BootProgress::ProgressStages;
-    using HState = HostState::HostState;
-
     if (!hostState.has_value() || !bootProgress.has_value())
     {
         lg2::debug("Cannot calculate system state yet");
         return;
     }
 
-    SystemState newState = SystemState::other;
-
-    if (hostState == HState::Off)
-    {
-        newState = SystemState::off;
-    }
-    else if (hostState == HState::TransitioningToRunning)
-    {
-        newState = SystemState::booting;
-    }
-    else if (hostState == HState::Running)
-    {
-        if ((bootProgress.value() == BProgress::SystemInitComplete) ||
-            (bootProgress.value() == BProgress::OSRunning))
-        {
-            newState = SystemState::runtime;
-        }
-        else
-        {
-            newState = SystemState::booting;
-        }
-    }
+    SystemState newState =
+        calculateSystemState(hostState.value(), bootProgress.value());
 
     lg2::info("Calculated system state is {STATE}", "STATE",
               getSystemStateName(newState));

--- a/redundant-bmc/src/system_state.cpp
+++ b/redundant-bmc/src/system_state.cpp
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#include "system_state.hpp"
+
+namespace rbmc
+{
+
+using HostState =
+    sdbusplus::common::xyz::openbmc_project::state::Host::HostState;
+using BootProgress = sdbusplus::common::xyz::openbmc_project::state::boot::
+    Progress::ProgressStages;
+
+SystemState calculateSystemState(HostState hostState, BootProgress bootProgress)
+{
+    SystemState state = SystemState::other;
+
+    if (hostState == HostState::Off)
+    {
+        state = SystemState::off;
+    }
+    else if (hostState == HostState::TransitioningToRunning)
+    {
+        state = SystemState::booting;
+    }
+    else if (hostState == HostState::Running)
+    {
+        if ((bootProgress == BootProgress::SystemInitComplete) ||
+            (bootProgress == BootProgress::OSRunning))
+        {
+            state = SystemState::runtime;
+        }
+        else
+        {
+            state = SystemState::booting;
+        }
+    }
+
+    return state;
+}
+
+} // namespace rbmc

--- a/redundant-bmc/src/system_state.hpp
+++ b/redundant-bmc/src/system_state.hpp
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <xyz/openbmc_project/State/Boot/Progress/common.hpp>
+#include <xyz/openbmc_project/State/Host/common.hpp>
+
+#include <string>
+
+namespace rbmc
+{
+
+enum class SystemState
+{
+    off,
+    booting,
+    runtime,
+    other
+};
+
+/**
+ * @brief Calculate the system state based on host state and boot progress
+ *
+ * @param[in] hostState - The current host state
+ * @param[in] bootProgress - The current boot progress stage
+ *
+ * @return The calculated system state
+ */
+SystemState calculateSystemState(
+    sdbusplus::common::xyz::openbmc_project::state::Host::HostState hostState,
+    sdbusplus::common::xyz::openbmc_project::state::boot::Progress::
+        ProgressStages bootProgress);
+
+/**
+ * @brief Returns the string name for the system state enum
+ *
+ * @param[in] state - The state enum
+ *
+ * @return The string name
+ */
+inline std::string getSystemStateName(SystemState state)
+{
+    switch (state)
+    {
+        case SystemState::off:
+            return "Off";
+        case SystemState::booting:
+            return "Booting";
+        case SystemState::runtime:
+            return "Runtime";
+        case SystemState::other:
+            return "Other";
+    }
+
+    return "Unknown";
+}
+
+} // namespace rbmc

--- a/redundant-bmc/test/meson.build
+++ b/redundant-bmc/test/meson.build
@@ -9,6 +9,7 @@ test(
         'persistent_data_test.cpp',
         'redundancy_test.cpp',
         'role_determination_test.cpp',
+        'system_state_test.cpp',
         dependencies: [
             gtest,
             nlohmann_json_dep,

--- a/redundant-bmc/test/system_state_test.cpp
+++ b/redundant-bmc/test/system_state_test.cpp
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "system_state.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace rbmc;
+
+using HostState =
+    sdbusplus::common::xyz::openbmc_project::state::Host::HostState;
+using BootProgress = sdbusplus::common::xyz::openbmc_project::state::boot::
+    Progress::ProgressStages;
+
+TEST(SystemStateTest, HostStateOff)
+{
+    // When host state is Off, system state should be off
+    // regardless of boot progress
+    auto result =
+        calculateSystemState(HostState::Off, BootProgress::Unspecified);
+    EXPECT_EQ(result, SystemState::off);
+
+    result = calculateSystemState(HostState::Off, BootProgress::OSRunning);
+    EXPECT_EQ(result, SystemState::off);
+
+    result =
+        calculateSystemState(HostState::Off, BootProgress::SystemInitComplete);
+    EXPECT_EQ(result, SystemState::off);
+}
+
+TEST(SystemStateTest, HostStateTransitioningToRunning)
+{
+    // When host state is TransitioningToRunning, system state
+    // should be booting regardless of boot progress
+    auto result = calculateSystemState(HostState::TransitioningToRunning,
+                                       BootProgress::Unspecified);
+    EXPECT_EQ(result, SystemState::booting);
+
+    result = calculateSystemState(HostState::TransitioningToRunning,
+                                  BootProgress::OSRunning);
+    EXPECT_EQ(result, SystemState::booting);
+
+    result = calculateSystemState(HostState::TransitioningToRunning,
+                                  BootProgress::SystemInitComplete);
+    EXPECT_EQ(result, SystemState::booting);
+}
+
+TEST(SystemStateTest, HostStateRunningWithSystemInitComplete)
+{
+    // When host state is Running and boot progress is SystemInitComplete,
+    // system state should be runtime
+    auto result = calculateSystemState(HostState::Running,
+                                       BootProgress::SystemInitComplete);
+    EXPECT_EQ(result, SystemState::runtime);
+}
+
+TEST(SystemStateTest, HostStateRunningWithOSRunning)
+{
+    // When host state is Running and boot progress is OSRunning,
+    // system state should be runtime
+    auto result =
+        calculateSystemState(HostState::Running, BootProgress::OSRunning);
+    EXPECT_EQ(result, SystemState::runtime);
+}
+
+TEST(SystemStateTest, HostStateRunningWithOtherBootProgress)
+{
+    // When host state is Running but boot progress is not SystemInitComplete
+    // or OSRunning, system state should be booting
+    auto result =
+        calculateSystemState(HostState::Running, BootProgress::Unspecified);
+    EXPECT_EQ(result, SystemState::booting);
+
+    result = calculateSystemState(HostState::Running, BootProgress::MemoryInit);
+    EXPECT_EQ(result, SystemState::booting);
+
+    result = calculateSystemState(HostState::Running, BootProgress::PCIInit);
+    EXPECT_EQ(result, SystemState::booting);
+
+    result =
+        calculateSystemState(HostState::Running, BootProgress::PrimaryProcInit);
+    EXPECT_EQ(result, SystemState::booting);
+
+    result = calculateSystemState(HostState::Running,
+                                  BootProgress::SecondaryProcInit);
+    EXPECT_EQ(result, SystemState::booting);
+
+    result = calculateSystemState(HostState::Running, BootProgress::OSStart);
+    EXPECT_EQ(result, SystemState::booting);
+
+    result =
+        calculateSystemState(HostState::Running, BootProgress::MotherboardInit);
+    EXPECT_EQ(result, SystemState::booting);
+}
+
+TEST(SystemStateTest, OtherHostStates)
+{
+    // For any other host state, system state should be other
+    auto result =
+        calculateSystemState(HostState::Quiesced, BootProgress::Unspecified);
+    EXPECT_EQ(result, SystemState::other);
+
+    result = calculateSystemState(HostState::DiagnosticMode,
+                                  BootProgress::Unspecified);
+    EXPECT_EQ(result, SystemState::other);
+
+    result = calculateSystemState(HostState::TransitioningToOff,
+                                  BootProgress::Unspecified);
+    EXPECT_EQ(result, SystemState::other);
+}
+
+TEST(SystemStateTest, GetSystemStateName)
+{
+    EXPECT_EQ(getSystemStateName(SystemState::off), "Off");
+    EXPECT_EQ(getSystemStateName(SystemState::booting), "Booting");
+    EXPECT_EQ(getSystemStateName(SystemState::runtime), "Runtime");
+    EXPECT_EQ(getSystemStateName(SystemState::other), "Other");
+}


### PR DESCRIPTION
Create system_state.cpp to hold the SystemState functions so they can be isolated and tested.

Tested:
- New unit tests work
- Everything still works

Change-Id: Idaf1558a836f7544dc95bf320cdd16a98b16092b