### PR TITLE
RBMC: Move reset GPIO use into gpio.cpp

### DIFF
--- a/redundant-bmc/src/gpio.cpp
+++ b/redundant-bmc/src/gpio.cpp
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "gpio.hpp"
 
-#include <gpiod.hpp>
 #include <phosphor-logging/lg2.hpp>
 
 #include <chrono>
 #include <thread>
 
-namespace rbmc
+namespace rbmc::gpio
 {
 
 namespace
@@ -91,4 +90,36 @@ std::optional<bool> readGPIO(const std::string& gpioName, GPIOPolarity polarity)
     return std::nullopt;
 }
 
-} // namespace rbmc
+sdbusplus::async::task<> toggleGPIO(gpiod::line& line, GPIOPolarity polarity,
+                                    sdbusplus::async::context& ctx,
+                                    std::chrono::milliseconds delay)
+{
+    const bool activeHigh = (polarity == GPIOPolarity::high);
+
+    line.request({"RBMC manager", gpiod::line_request::DIRECTION_OUTPUT,
+                  activeHigh ? 0 : gpiod::line_request::FLAG_ACTIVE_LOW},
+                 1);
+
+    GPIOLineGuard guard(line);
+
+    co_await sdbusplus::async::sleep_for(ctx, delay);
+
+    line.set_value(0);
+}
+
+// NOLINTBEGIN(clang-analyzer-core.uninitialized.Branch)
+sdbusplus::async::task<> toggleGPIO(
+    const std::string& gpioName, GPIOPolarity polarity,
+    sdbusplus::async::context& ctx, std::chrono::milliseconds delay)
+{
+    auto line = gpiod::find_line(gpioName);
+    if (!line)
+    {
+        throw std::runtime_error("GPIO line " + gpioName + " not found");
+    }
+
+    co_await toggleGPIO(line, polarity, ctx, delay);
+}
+// NOLINTEND(clang-analyzer-core.uninitialized.Branch)
+
+} // namespace rbmc::gpio

--- a/redundant-bmc/src/gpio.hpp
+++ b/redundant-bmc/src/gpio.hpp
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "gpiod.hpp"
 #include "types.hpp"
+
+#include <sdbusplus/async.hpp>
 
 #include <optional>
 #include <string>
 
-namespace rbmc
+namespace rbmc::gpio
 {
 
 /**
@@ -21,4 +24,32 @@ namespace rbmc
 std::optional<bool> readGPIO(const std::string& gpioName,
                              GPIOPolarity polarity);
 
-} // namespace rbmc
+/**
+ * @brief Toggle a GPIO line
+ *
+ * @param[in] gpioName - The GPIO line name
+ * @param[in] polarity - The GPIO polarity
+ * @param[in] ctx - The async context for sleep
+ * @param[in] delay - How long to hold the GPIO asserted
+ * @return Async task that completes when toggle is done
+ * @throws std::runtime_error if GPIO line not found or operation failed
+ */
+sdbusplus::async::task<> toggleGPIO(
+    const std::string& gpioName, GPIOPolarity polarity,
+    sdbusplus::async::context& ctx, std::chrono::milliseconds delay);
+
+/**
+ * @brief Toggle a GPIO line on an existing gpiod::line
+ *
+ * @param[in] line - The GPIO line
+ * @param[in] polarity - The GPIO polarity
+ * @param[in] ctx - The async context for sleep
+ * @param[in] delay - How long to hold the GPIO asserted
+ * @return Async task that completes when toggle is done
+ * @throws std::runtime_error if operation failed after retries
+ */
+sdbusplus::async::task<> toggleGPIO(gpiod::line& line, GPIOPolarity polarity,
+                                    sdbusplus::async::context& ctx,
+                                    std::chrono::milliseconds delay);
+
+} // namespace rbmc::gpio

--- a/redundant-bmc/src/providers_impl.hpp
+++ b/redundant-bmc/src/providers_impl.hpp
@@ -35,7 +35,8 @@ class ProvidersImpl : public Providers
      */
     explicit ProvidersImpl(sdbusplus::async::context& ctx) :
         config(config_parser::readConfig()), services(ctx),
-        sibling(ctx, config, services), syncInterface(ctx), siblingReset(ctx)
+        sibling(ctx, config, services), syncInterface(ctx),
+        siblingReset(ctx, config)
     {}
 
     /**

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#include "config_parser.hpp"
 #include "persistent_data.hpp"
 #include "redundancy.hpp"
 #include "services_impl.hpp"
@@ -373,7 +374,8 @@ sdbusplus::async::task<> displayInfo(sdbusplus::async::context& ctx,
 // NOLINTNEXTLINE
 sdbusplus::async::task<> resetSiblingBMC(sdbusplus::async::context& ctx)
 {
-    rbmc::SiblingResetImpl reset{ctx};
+    auto config = rbmc::config_parser::readConfig();
+    rbmc::SiblingResetImpl reset{ctx, config};
 
     try
     {

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -544,8 +544,8 @@ bool SiblingImpl::isBMCPresent()
     auto gpioConfig = getSibPresentGPIOConfig();
     if (gpioConfig.has_value())
     {
-        gpioActive =
-            readGPIO(gpioConfig.value().name, gpioConfig.value().polarity);
+        gpioActive = gpio::readGPIO(gpioConfig.value().name,
+                                    gpioConfig.value().polarity);
     }
 
     if (gpioActive.value_or(false))

--- a/redundant-bmc/src/sibling_reset_impl.cpp
+++ b/redundant-bmc/src/sibling_reset_impl.cpp
@@ -2,70 +2,36 @@
 
 #include "sibling_reset_impl.hpp"
 
-#include <gpiod.hpp>
-#include <phosphor-logging/lg2.hpp>
-
-#include <cassert>
+#include "gpio.hpp"
 
 namespace rbmc
 {
 
-const std::string gpioName = "sibling-bmc-reset";
-
-SiblingResetImpl::SiblingResetImpl(sdbusplus::async::context& ctx) : ctx(ctx)
+SiblingResetImpl::SiblingResetImpl(sdbusplus::async::context& ctx,
+                                   const RedundantBMCConfig& config) :
+    ctx(ctx), polarity(config.siblingBMCResetGPIO.polarity)
 {
-    resetLine = gpiod::find_line(gpioName);
+    resetLine = gpiod::find_line(config.siblingBMCResetGPIO.name);
     if (!resetLine)
     {
-        // Attempt to find the active low version.
-        resetLine = gpiod::find_line(gpioName + "-n");
-        if (resetLine)
-        {
-            activeLow = true;
-        }
-    }
-
-    if (resetLine)
-    {
-        config.consumer = "Sibling BMC Reset";
-        config.request_type = gpiod::line_request::DIRECTION_OUTPUT;
-        config.flags = activeLow ? gpiod::line_request::FLAG_ACTIVE_LOW : 0;
-    }
-    else
-    {
-        // This will cause a fail during the assert/release
-        lg2::error("Could not find BMC reset GPIO {GPIO}", "GPIO", gpioName);
+        throw std::runtime_error(
+            "Could not find BMC reset GPIO " + config.siblingBMCResetGPIO.name);
     }
 }
 
 void SiblingResetImpl::assertReset()
 {
-    if (!resetLine)
-    {
-        throw std::runtime_error("Could not find sibling reset GPIO");
-    }
-
-    lg2::info("Asserting sibling BMC reset GPIO");
-
-    resetLine.request(config, 1);
-    resetLine.release();
+    // TODO - Concurrent Maintenance design pending
+    throw std::runtime_error{"assertReset not implemented yet"};
 }
 
 void SiblingResetImpl::releaseReset()
 {
-    if (!resetLine)
-    {
-        throw std::runtime_error("Could not find sibling reset GPIO");
-    }
-
-    lg2::info("Releasing sibling BMC reset GPIO");
-
-    resetLine.request(config, 0);
-    resetLine.release();
+    // TODO - Concurrent Maintenance design pending
+    throw std::runtime_error{"releaseReset not implemented yet"};
 }
 
 // NOLINTBEGIN(clang-analyzer-core.uninitialized.Branch)
-// NOLINTNEXTLINE(readability-static-accessed-through-instance)
 sdbusplus::async::task<> SiblingResetImpl::toggleReset()
 {
     if (!resetLine)
@@ -75,15 +41,8 @@ sdbusplus::async::task<> SiblingResetImpl::toggleReset()
 
     lg2::info("Toggling sibling reset GPIO");
 
-    resetLine.request(config, 1);
-
     using namespace std::chrono_literals;
-
-    co_await sdbusplus::async::sleep_for(ctx, 200ms);
-
-    resetLine.set_value(0);
-
-    resetLine.release();
+    co_await gpio::toggleGPIO(resetLine, polarity, ctx, 200ms);
 }
 // NOLINTEND(clang-analyzer-core.uninitialized.Branch)
 

--- a/redundant-bmc/src/sibling_reset_impl.hpp
+++ b/redundant-bmc/src/sibling_reset_impl.hpp
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "config_data.hpp"
 #include "sibling_reset.hpp"
+#include "types.hpp"
 
 #include <gpiod.hpp>
 #include <phosphor-logging/lg2.hpp>
@@ -25,8 +27,12 @@ class SiblingResetImpl : public SiblingReset
 
     /**
      * @brief Constructor
+     *
+     * @param[in] ctx - The async context object
+     * @param[in] config - Optional redundant BMC configuration
      */
-    SiblingResetImpl(sdbusplus::async::context& ctx);
+    SiblingResetImpl(sdbusplus::async::context& ctx,
+                     const RedundantBMCConfig& config);
 
     /**
      * @brief Asserts the reset.
@@ -54,19 +60,14 @@ class SiblingResetImpl : public SiblingReset
     sdbusplus::async::context& ctx;
 
     /**
-     * @brief The GPIO config for requesting a line.
+     * @brief The GPIO polarity
      */
-    gpiod::line_request config;
+    GPIOPolarity polarity;
 
     /**
      * @brief The reset line
      */
     gpiod::line resetLine;
-
-    /**
-     * @brief If the GPIO is active low
-     */
-    bool activeLow{false};
 };
 
 } // namespace rbmc


### PR DESCRIPTION
Create a new toggleGPIO function in gpio.cpp and call that from SiblingResetImpl instead of it doing the gpiod manipulation itself. That way all of the gpiod uses are in the same file.

Also, use the sibling reset GPIO name from the config file instead of hardcoding the name in SiblingResetImpl.

For now, stub out the assertReset and releaseReset calls in SiblingResetImpl until the BMC card concurrent maintenance design is more hashed out.  At that point, either have them also use rbmc::gpio calls (having to add a gpioWrite), or remove them altogether.

Tested:
- rbmctool --reset-sibling still works
- The reset during a failover still works

Change-Id: I7aa7ea4840d5bb29af527a2d78a8cbd5de7268ab