### PR TITLE
RBMC: Add SetRedundancyInput method stub

### DIFF
--- a/redundant-bmc/src/redundancy_interface.cpp
+++ b/redundant-bmc/src/redundancy_interface.cpp
@@ -140,4 +140,12 @@ bool RedundancyInterface::set_property(
     return true;
 }
 
+sdbusplus::async::task<> RedundancyInterface::method_call(
+    RedundancyInterface::set_redundancy_input_t /* unused */,
+    RedundancyInterface::RedundancyInput /* input */, bool /* unused */)
+{
+    // TODO
+    co_return;
+}
+
 } // namespace rbmc

--- a/redundant-bmc/src/redundancy_interface.hpp
+++ b/redundant-bmc/src/redundancy_interface.hpp
@@ -67,6 +67,17 @@ class RedundancyInterface :
     bool set_property(reasons_for_no_redundancy_t type,
                       const std::vector<ReasonForNoRedundancy>& reasons);
 
+    /**
+     * @brief Implements the SetRedundancyInput D-Bus method
+     *
+     * Sets an external redundancy input checked when enabling redundancy
+     *
+     * @param[in] input - The RedundancyInput to set
+     * @param[in] value - The value to set it to
+     */
+    sdbusplus::async::task<> method_call(set_redundancy_input_t /* unused */,
+                                         RedundancyInput input, bool value);
+
   private:
     /**
      * @brief Reference to the Manager class


### PR DESCRIPTION
Just add a stub for this method now as the phosphor-dbus-interfaces definition is a co-requisite.

Change-Id: I83a6b5e9ada2f93cdb2e0906fa187428acbd7f05