### PR TITLE
RBMC: Wait 30 seconds on startup for self-pairing

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -9,9 +9,10 @@ redundancy related properties.
 
 ## Startup
 
-On startup, the code will wait for up to six minutes for the sibling BMC's
-heartbeat to start, assuming the BMC is present. After that it will determine
-its role.
+On startup, the code will first wait up to 30 seconds for the BMC to become
+self-paired if it isn't already. Then, it will wait for up to six minutes for
+the sibling BMC's heartbeat to start, assuming the BMC is present. After that it
+will determine its role.
 
 If the BMCs happen to get to determining the role at the same time, the BMC that
 was previously passive will wait for the other BMC to determine its role first

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -68,6 +68,8 @@ sdbusplus::async::task<> Manager::startup()
     co_await sdbusplus::async::execution::when_all(services.init(),
                                                    sibling.init());
 
+    co_await services.waitForSelfPairing();
+
     // If we know the role must be passive, set that now,
     // before starting the heartbeat or waiting for the sibling.
     auto passiveRoleInfo = co_await determinePassiveRoleIfRequired();

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -243,6 +243,13 @@ class Services
      */
     virtual void setRedundancyDetermined() = 0;
 
+    /**
+     * @brief Waits for the Paired property to become true
+     *
+     * Waits up to 30 seconds.
+     */
+    virtual sdbusplus::async::task<> waitForSelfPairing() = 0;
+
   protected:
     /**
      * @brief The functions to call when the system state changes

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -688,9 +688,7 @@ sdbusplus::async::task<> ServicesImpl::startUnit(
 
 bool ServicesImpl::getPaired() const
 {
-    // TODO: Return the actual value.
-    // return paired;
-    return true;
+    return paired;
 }
 
 std::string ServicesImpl::getFWVersion() const
@@ -971,6 +969,31 @@ sdbusplus::async::task<> ServicesImpl::waitForPeerConnection()
 
     lg2::error("Timed out waiting for peer connection after {MIN} minutes",
                "MIN", timeout.count());
+}
+
+sdbusplus::async::task<> ServicesImpl::waitForSelfPairing()
+{
+    using namespace std::chrono_literals;
+    auto end = std::chrono::steady_clock::now() + 30s;
+    bool traced = false;
+
+    while (std::chrono::steady_clock::now() < end)
+    {
+        if (paired)
+        {
+            co_return;
+        }
+
+        if (!traced)
+        {
+            traced = true;
+            lg2::info("Waiting up to 30s for self pairing");
+        }
+
+        co_await sdbusplus::async::sleep_for(ctx, 1s);
+    }
+
+    lg2::warning("Timed out waiting for self pairing");
 }
 
 void ServicesImpl::setRedundancyDetermined()

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -189,6 +189,13 @@ class ServicesImpl : public Services
      */
     void setRedundancyDetermined() override;
 
+    /**
+     * @brief Waits for the Paired property to become true
+     *
+     * Waits up to 30 seconds.
+     */
+    sdbusplus::async::task<> waitForSelfPairing() override;
+
   private:
     /**
      * @brief Returns the D-Bus object path for the unit in the
@@ -310,7 +317,7 @@ class ServicesImpl : public Services
     /**
      * @brief The paired status value
      */
-    bool paired;
+    bool paired{false};
 
     /**
      * @brief D-Bus path for the Item.System object

--- a/redundant-bmc/test/mocks/mock_services.hpp
+++ b/redundant-bmc/test/mocks/mock_services.hpp
@@ -66,6 +66,8 @@ class MockServices : public testing::NiceMock<Services>
                 (override));
 
     MOCK_METHOD(void, setRedundancyDetermined, (), (override));
+
+    MOCK_METHOD(sdbusplus::async::task<>, waitForSelfPairing, (), (override));
 };
 
 } // namespace rbmc


### PR DESCRIPTION
If a BMC isn't paired and so has to be passive, it would need to rebooted after it was paired in order to become active.

To create a small window where pairing can be done before the role is chosen, add a 30 second wait before determining the role where it watches for the Paired property to change to true.

Also, start checking the real value of the paired property in the 'Sibling::getPaired' function instead of just always returning true.

The action is persistent, so after it is paired for the first time the wait won't be necessary in the future.

The wait is required for the simulation model, where the pairing isn't done until several seconds after the code was looking for it.

Tested:
- If not paired, waits the 30 seconds and goes to passive
- If paired during that wait, stops waiting and goes to active
- If already paired, doesn't wait at all

The traces show up as they should:
```
21:26:48 phosphor-rbmc-state-manager[1310]: Waiting up to 30s for self pairing
21:26:55 phosphor-rbmc-state-manager[1310]: The new Paired value is True
21:26:55 phosphor-rbmc-state-manager[1310]: Starting heartbeat
```

Change-Id: I1c6607a8b3df428ee8d61b093f4b27c003843c58