### PR TITLE
RBMC: Fixup failover options variant

### DIFF
--- a/redundant-bmc/src/redundancy_interface.hpp
+++ b/redundant-bmc/src/redundancy_interface.hpp
@@ -75,8 +75,8 @@ class RedundancyInterface :
      * @param[in] input - The RedundancyInput to set
      * @param[in] value - The value to set it to
      */
-    sdbusplus::async::task<> method_call(set_redundancy_input_t /* unused */,
-                                         RedundancyInput input, bool value);
+    static sdbusplus::async::task<> method_call(
+        set_redundancy_input_t /* unused */, RedundancyInput input, bool value);
 
   private:
     /**

--- a/redundant-bmc/src/types.hpp
+++ b/redundant-bmc/src/types.hpp
@@ -9,7 +9,7 @@
 namespace rbmc
 {
 
-using FailoverOptions = std::map<std::string, std::variant<bool>>;
+using FailoverOptions = std::map<std::string, std::variant<bool, std::string>>;
 
 enum class GPIOPolarity
 {


### PR DESCRIPTION
There is now a std::string in the failover options variant in the PDI definition for StartFailover, so it's also needed by the code.

Change-Id: I6c49533d621cef66d0ee8e7588870ef7f4170cb3