### PR TITLE
Add helpers for accessing the external redundancy inputs

### DIFF
--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -32,6 +32,7 @@ rbmc_lib = static_library(
     'sibling_reset_impl.cpp',
     'sync_interface_impl.cpp',
     'system_state.cpp',
+    'util.cpp',
     dependencies: rbmc_deps,
 )
 

--- a/redundant-bmc/src/persistent_data.cpp
+++ b/redundant-bmc/src/persistent_data.cpp
@@ -71,8 +71,9 @@ static std::string makeTimestampString(const time_t& timestamp)
 
 } // namespace util
 
-void remove(std::string_view name, const std::filesystem::path& path)
+void remove(std::string_view name)
 {
+    auto path = dataFile();
     auto json = util::readFile(path);
     if (!json)
     {

--- a/redundant-bmc/src/persistent_data.hpp
+++ b/redundant-bmc/src/persistent_data.hpp
@@ -10,8 +10,34 @@
 namespace data
 {
 
-const std::filesystem::path dataFile{
-    "/var/lib/phosphor-state-manager/redundant-bmc/data.json"};
+// Default path for persistent data directory
+inline std::filesystem::path dataDirPath{
+    "/var/lib/phosphor-state-manager/redundant-bmc"};
+
+constexpr auto dataFileName = "data.json";
+
+/**
+ * @brief Get the full path to the data file
+ *
+ * @return The full path combining dataDirPath and dataFileName
+ */
+inline std::filesystem::path dataFile()
+{
+    return dataDirPath / dataFileName;
+}
+
+/**
+ * @brief Set the persistent data directory path
+ *
+ * This should be called early in initialization to set the directory
+ * where persistent data files will be stored.
+ *
+ * @param[in] dirPath - The directory path for persistent data
+ */
+inline void setDataDirectory(const std::filesystem::path& dirPath)
+{
+    dataDirPath = dirPath;
+}
 
 using FailoverLogs = std::vector<std::pair<std::string, std::string>>;
 
@@ -62,9 +88,9 @@ void writeFile(const nlohmann::json& json, const std::filesystem::path& path);
  * @param[in] value - The value to save
  */
 template <typename T>
-void write(std::string_view name, const T& value,
-           const std::filesystem::path& path = dataFile)
+void write(std::string_view name, const T& value)
 {
+    auto path = dataFile();
     auto json = util::readFile(path).value_or(nlohmann::json::object());
     if constexpr (std::is_enum_v<T>)
     {
@@ -85,16 +111,14 @@ void write(std::string_view name, const T& value,
  *
  * @tparam T - The data type
  * @param[in] name - The key the value is saved under
- * @param[in] path - The path to the file
  *
  * @return optional<T> - The value, or std::nullopt if the file or
  *                       key isn't present.
  */
 template <typename T>
-std::optional<T> read(std::string_view name,
-                      const std::filesystem::path& path = dataFile)
+std::optional<T> read(std::string_view name)
 {
-    auto json = util::readFile(path);
+    auto json = util::readFile(dataFile());
     if (!json)
     {
         return std::nullopt;
@@ -121,11 +145,8 @@ std::optional<T> read(std::string_view name,
  * @brief Remove an entry from the file
  *
  * @param[in] name - The key for the entry to remove
- *
- * @param[in] path - The path to the file
  */
-void remove(std::string_view name,
-            const std::filesystem::path& path = dataFile);
+void remove(std::string_view name);
 
 /**
  * @brief Log the requester and timestamp of a failover.

--- a/redundant-bmc/src/persistent_data.hpp
+++ b/redundant-bmc/src/persistent_data.hpp
@@ -3,9 +3,11 @@
 
 #include <nlohmann/json.hpp>
 #include <xyz/openbmc_project/Control/Failover/common.hpp>
+#include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
 
 #include <filesystem>
 #include <optional>
+#include <set>
 
 namespace data
 {
@@ -53,6 +55,7 @@ constexpr auto noRedReasons = "NoRedundancyReasons";
 constexpr auto disableRed = "DisableRedundancy";
 constexpr auto redundancyOffAtRuntime = "RedundancyOffAtRuntime";
 constexpr auto failoverInProgress = "FailoverInProgress";
+constexpr auto externalRedundancyInputs = "ExternalRedundancyInputs";
 } // namespace key
 
 namespace util

--- a/redundant-bmc/src/rbmc_manager_main.cpp
+++ b/redundant-bmc/src/rbmc_manager_main.cpp
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include "manager.hpp"
+#include "persistent_data.hpp"
 #include "providers_impl.hpp"
 
 #include <sdbusplus/async/context.hpp>
@@ -14,6 +15,8 @@ int main()
 
     std::unique_ptr<rbmc::Providers> providers =
         std::make_unique<rbmc::ProvidersImpl>(ctx);
+
+    data::setDataDirectory(providers->getServices().getPersistentDataPath());
 
     rbmc::Manager manager{ctx, std::move(providers)};
 

--- a/redundant-bmc/src/util.cpp
+++ b/redundant-bmc/src/util.cpp
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "util.hpp"
+
+#include "persistent_data.hpp"
+#include "phosphor-logging/lg2.hpp"
+
+namespace rbmc::util
+{
+
+RedundancyInputSet readExternalRedundancyInputs()
+{
+    try
+    {
+        // data::read uses the underlying type
+        using UnderlyingSet = std::set<std::underlying_type_t<RedundancyInput>>;
+        auto underlyingInputs =
+            data::read<UnderlyingSet>(data::key::externalRedundancyInputs);
+        if (underlyingInputs.has_value())
+        {
+            RedundancyInputSet enumInputs;
+            for (const auto& val : underlyingInputs.value())
+            {
+                enumInputs.insert(static_cast<RedundancyInput>(val));
+            }
+            return enumInputs;
+        }
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Could not read external redundancy inputs: {ERROR}",
+                   "ERROR", e);
+    }
+    return RedundancyInputSet{};
+}
+
+bool hasExternalRedundancyInput(RedundancyInput input)
+{
+    try
+    {
+        auto inputs = readExternalRedundancyInputs();
+        return inputs.contains(input);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Could not read external redundancy input: {ERROR}", "ERROR",
+                   e);
+    }
+    return false;
+}
+
+void writeExternalRedundancyInput(RedundancyInput input, bool set)
+{
+    RedundancyInputSet inputs;
+    try
+    {
+        inputs = readExternalRedundancyInputs();
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error(
+            "Failed trying to obtain saved RedundancyInput value: {ERROR}",
+            "ERROR", e);
+    }
+
+    if (set)
+    {
+        inputs.insert(input);
+    }
+    else
+    {
+        inputs.erase(input);
+    }
+
+    // data::write uses the underlying type
+    using UnderlyingSet = std::set<std::underlying_type_t<RedundancyInput>>;
+    UnderlyingSet underlyingInputs;
+    for (const auto& enumVal : inputs)
+    {
+        underlyingInputs.insert(std::to_underlying(enumVal));
+    }
+
+    try
+    {
+        data::write(data::key::externalRedundancyInputs, underlyingInputs);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Could not serialize RedundancyInput value: {ERROR}",
+                   "ERROR", e);
+        throw;
+    }
+}
+
+bool clearExternalRedundancyInputs()
+{
+    try
+    {
+        auto inputs = readExternalRedundancyInputs();
+
+        if (!inputs.empty())
+        {
+            data::remove(data::key::externalRedundancyInputs);
+            return true;
+        }
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Could not clear external redundancy inputs: {ERROR}",
+                   "ERROR", e);
+    }
+    return false;
+}
+
+} // namespace rbmc::util

--- a/redundant-bmc/src/util.hpp
+++ b/redundant-bmc/src/util.hpp
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
+
+#include <set>
+
+namespace rbmc::util
+{
+
+using RedundancyInput = sdbusplus::common::xyz::openbmc_project::state::bmc::
+    Redundancy::RedundancyInput;
+using RedundancyInputSet = std::set<RedundancyInput>;
+
+/**
+ * @brief Read all saved external redundancy inputs
+ *
+ * @return RedundancyInputSet - Set of external redundancy inputs, or empty set
+ *                              if none exist or on error
+ */
+RedundancyInputSet readExternalRedundancyInputs();
+
+/**
+ * @brief Check if a specific external redundancy input is set
+ *
+ * @param[in] input - The external input enum value to check
+ *
+ * @return bool - True if the input is set, false otherwise
+ */
+bool hasExternalRedundancyInput(RedundancyInput input);
+
+/**
+ * @brief Check if any of the specified external redundancy inputs are set
+ *
+ * @param[in] first - The first external input enum value to check
+ * @param[in] rest - Additional external input enum values to check
+ *
+ * @return bool - True if any input is set, false otherwise
+ */
+template <typename... Inputs>
+bool hasExternalRedundancyInput(RedundancyInput first, Inputs... rest)
+{
+    return hasExternalRedundancyInput(first) ||
+           (... || hasExternalRedundancyInput(rest));
+}
+
+/**
+ * @brief Add or remove an external redundancy input to/from persistent storage
+ *
+ * @param[in] input - The external input enum value to add or remove
+ * @param[in] set - True to set the input, false to reset it.
+ */
+void writeExternalRedundancyInput(RedundancyInput input, bool set);
+
+/**
+ * @brief Clear all external redundancy inputs from persistent storage
+ *
+ * @return bool - True if inputs were cleared, false otherwise
+ */
+bool clearExternalRedundancyInputs();
+
+} // namespace rbmc::util

--- a/redundant-bmc/test/meson.build
+++ b/redundant-bmc/test/meson.build
@@ -11,6 +11,7 @@ test(
         'redundancy_test.cpp',
         'role_determination_test.cpp',
         'system_state_test.cpp',
+        'util_test.cpp',
         dependencies: [
             gtest,
             gmock,

--- a/redundant-bmc/test/persistent_data_test.cpp
+++ b/redundant-bmc/test/persistent_data_test.cpp
@@ -1,4 +1,5 @@
 #include "persistent_data.hpp"
+#include "persistent_data_test_fixture.hpp"
 #include "role_determination.hpp"
 
 #include <fstream>
@@ -6,85 +7,62 @@
 #include <gtest/gtest.h>
 
 using namespace rbmc;
+using namespace rbmc::test;
 using namespace role_determination;
 
-class PersistentDataTest : public ::testing::Test
-{
-  protected:
-    static void SetUpTestCase()
-    {
-        char d[] = "/tmp/datatestXXXXXX";
-        dataDir = mkdtemp(d);
-        saveFile = dataDir / "save.json";
-    }
-
-    static void TearDownTestCase()
-    {
-        std::filesystem::remove_all(dataDir);
-    }
-
-    static std::filesystem::path saveFile;
-    static std::filesystem::path dataDir;
-};
-
-std::filesystem::path PersistentDataTest::saveFile;
-std::filesystem::path PersistentDataTest::dataDir;
+class PersistentDataTest : public PersistentDataTestFixture
+{};
 
 TEST_F(PersistentDataTest, WriteAndReadTest)
 {
     // Write
-    data::write("Role", Role::Active, saveFile);
-    data::write("Bool", true, saveFile);
-    data::write("String", std::string{"String"}, saveFile);
-    data::write("Uint32", uint32_t{0xAABBCCDD}, saveFile);
+    data::write("Role", Role::Active);
+    data::write("Bool", true);
+    data::write("String", std::string{"String"});
+    data::write("Uint32", uint32_t{0xAABBCCDD});
 
     // Read back
-    EXPECT_EQ(data::read<Role>("Role", saveFile), Role::Active);
-    EXPECT_EQ(data::read<bool>("Bool", saveFile), true);
-    EXPECT_EQ(data::read<std::string>("String", saveFile),
-              std::string{"String"});
-    EXPECT_EQ(data::read<uint32_t>("Uint32", saveFile), 0xAABBCCDD);
+    EXPECT_EQ(data::read<Role>("Role"), Role::Active);
+    EXPECT_EQ(data::read<bool>("Bool"), true);
+    EXPECT_EQ(data::read<std::string>("String"), std::string{"String"});
+    EXPECT_EQ(data::read<uint32_t>("Uint32"), 0xAABBCCDD);
 
     // Write new values
-    data::write("Role", Role::Passive, saveFile);
-    data::write("Bool", false, saveFile);
-    data::write("String", std::string{"New"}, saveFile);
-    data::write("Uint32", uint32_t{0x12345678}, saveFile);
+    data::write("Role", Role::Passive);
+    data::write("Bool", false);
+    data::write("String", std::string{"New"});
+    data::write("Uint32", uint32_t{0x12345678});
 
     // Read back the new values
-    EXPECT_EQ(data::read<Role>("Role", saveFile), Role::Passive);
-    EXPECT_EQ(data::read<bool>("Bool", saveFile), false);
-    EXPECT_EQ(data::read<std::string>("String", saveFile), std::string{"New"});
-    EXPECT_EQ(data::read<uint32_t>("Uint32", saveFile), 0x12345678);
+    EXPECT_EQ(data::read<Role>("Role"), Role::Passive);
+    EXPECT_EQ(data::read<bool>("Bool"), false);
+    EXPECT_EQ(data::read<std::string>("String"), std::string{"New"});
+    EXPECT_EQ(data::read<uint32_t>("Uint32"), 0x12345678);
 
     // Some different types - write
-    data::write("EmptyString", std::string{}, saveFile);
-    data::write("VectorOfStrings", std::vector<std::string>{"a", "b"},
-                saveFile);
-    data::write("EmptyVector", std::vector<std::string>{}, saveFile);
-    data::write("Map", std::map<int, std::string>{{1, "one"}, {2, "two"}},
-                saveFile);
-    data::write("EmptyMap", std::map<int, std::string>{}, saveFile);
+    data::write("EmptyString", std::string{});
+    data::write("VectorOfStrings", std::vector<std::string>{"a", "b"});
+    data::write("EmptyVector", std::vector<std::string>{});
+    data::write("Map", std::map<int, std::string>{{1, "one"}, {2, "two"}});
+    data::write("EmptyMap", std::map<int, std::string>{});
 
     // Some different types - read back
-    EXPECT_EQ(data::read<std::string>("EmptyString", saveFile), std::string{});
-    EXPECT_EQ(data::read<std::vector<std::string>>("VectorOfStrings", saveFile),
+    EXPECT_EQ(data::read<std::string>("EmptyString"), std::string{});
+    EXPECT_EQ(data::read<std::vector<std::string>>("VectorOfStrings"),
               (std::vector<std::string>{"a", "b"}));
-    EXPECT_EQ(data::read<std::vector<std::string>>("EmptyVector", saveFile),
+    EXPECT_EQ(data::read<std::vector<std::string>>("EmptyVector"),
               (std::vector<std::string>{}));
 
-    EXPECT_EQ((data::read<std::map<int, std::string>>("Map", saveFile)),
+    EXPECT_EQ((data::read<std::map<int, std::string>>("Map")),
               (std::map<int, std::string>{{1, "one"}, {2, "two"}}));
-    EXPECT_EQ((data::read<std::map<int, std::string>>("EmptyMap", saveFile)),
+    EXPECT_EQ((data::read<std::map<int, std::string>>("EmptyMap")),
               (std::map<int, std::string>{}));
 
     // Key doesn't exist
-    EXPECT_EQ(data::read<Role>("Blah", saveFile), std::nullopt);
-
-    // File doesn't exist
-    EXPECT_EQ(data::read<Role>("Role", "/blah/blah"), std::nullopt);
+    EXPECT_EQ(data::read<Role>("Blah"), std::nullopt);
 
     // Invalid JSON
+    auto saveFile = data::dataFile();
     std::filesystem::remove(saveFile);
     std::ofstream file{saveFile};
     const char* data = R"(
@@ -96,30 +74,30 @@ TEST_F(PersistentDataTest, WriteAndReadTest)
     file << data;
     file.close();
 
-    EXPECT_EQ(data::read<Role>("Role", saveFile), std::nullopt);
+    EXPECT_EQ(data::read<Role>("Role"), std::nullopt);
 }
 
 TEST_F(PersistentDataTest, RemoveTest)
 {
     // Write three
-    data::write("Role", Role::Active, saveFile);
-    data::write("Bool", true, saveFile);
-    data::write("String", std::string{"String"}, saveFile);
+    data::write("Role", Role::Active);
+    data::write("Bool", true);
+    data::write("String", std::string{"String"});
 
     // Remove the last one
-    data::remove("String", saveFile);
-    EXPECT_EQ(data::read<std::string>("String", saveFile), std::nullopt);
+    data::remove("String");
+    EXPECT_EQ(data::read<std::string>("String"), std::nullopt);
 
     // Make sure other ones still there
-    EXPECT_EQ(data::read<Role>("Role", saveFile), Role::Active);
-    EXPECT_EQ(data::read<bool>("Bool", saveFile), true);
+    EXPECT_EQ(data::read<Role>("Role"), Role::Active);
+    EXPECT_EQ(data::read<bool>("Bool"), true);
 
     // now remove remaining ones
-    data::remove("Role", saveFile);
-    EXPECT_EQ(data::read<Role>("Role", saveFile), std::nullopt);
+    data::remove("Role");
+    EXPECT_EQ(data::read<Role>("Role"), std::nullopt);
 
-    data::remove("Bool", saveFile);
-    EXPECT_EQ(data::read<bool>("Bool", saveFile), std::nullopt);
+    data::remove("Bool");
+    EXPECT_EQ(data::read<bool>("Bool"), std::nullopt);
 
     // Not found
     data::remove("Blah");

--- a/redundant-bmc/test/persistent_data_test_fixture.hpp
+++ b/redundant-bmc/test/persistent_data_test_fixture.hpp
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "persistent_data.hpp"
+
+#include <filesystem>
+
+#include <gtest/gtest.h>
+
+namespace rbmc::test
+{
+
+/**
+ * @class PersistentDataTestFixture
+ *
+ * Creates and destroys the persistent data directory
+ * around testcases.
+ *
+ * Tests that need persistent data functionality should inherit from this.
+ */
+class PersistentDataTestFixture : public ::testing::Test
+{
+  protected:
+    PersistentDataTestFixture()
+    {
+        char tempDir[] = "/tmp/rbmc_data_test_XXXXXX";
+        dataDir = mkdtemp(tempDir);
+
+        data::setDataDirectory(dataDir);
+    }
+
+    ~PersistentDataTestFixture() override
+    {
+        if (!dataDir.empty())
+        {
+            std::filesystem::remove_all(dataDir);
+        }
+    }
+
+    std::filesystem::path dataDir;
+};
+
+} // namespace rbmc::test

--- a/redundant-bmc/test/util_test.cpp
+++ b/redundant-bmc/test/util_test.cpp
@@ -1,0 +1,97 @@
+#include "persistent_data_test_fixture.hpp"
+#include "util.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace rbmc::util;
+using namespace rbmc::test;
+
+class UtilTest : public PersistentDataTestFixture
+{};
+
+TEST_F(UtilTest, ExternalRedundancyInputTest)
+{
+    using RedundancyInput = sdbusplus::common::xyz::openbmc_project::state::
+        bmc::Redundancy::RedundancyInput;
+
+    // Initially, no inputs should be set
+    auto inputs = readExternalRedundancyInputs();
+    EXPECT_TRUE(inputs.empty());
+
+    // Not set yet
+    EXPECT_FALSE(
+        hasExternalRedundancyInput(RedundancyInput::PassiveBMCHardwareProblem));
+
+    EXPECT_FALSE(hasExternalRedundancyInput(
+        RedundancyInput::PassiveBMCHostProcessorProblem,
+        RedundancyInput::PassiveBMCHardwareProblem));
+
+    // Add an input
+    writeExternalRedundancyInput(RedundancyInput::PassiveBMCHardwareProblem,
+                                 true);
+
+    // Verify it was added
+    EXPECT_TRUE(
+        hasExternalRedundancyInput(RedundancyInput::PassiveBMCHardwareProblem));
+
+    // Other one still not yet
+    EXPECT_FALSE(hasExternalRedundancyInput(
+        RedundancyInput::PassiveBMCHostProcessorProblem));
+
+    EXPECT_TRUE(hasExternalRedundancyInput(
+        RedundancyInput::PassiveBMCHostProcessorProblem,
+        RedundancyInput::PassiveBMCHardwareProblem));
+
+    // Read all inputs and verify
+    inputs = readExternalRedundancyInputs();
+    ASSERT_EQ(inputs.size(), 1);
+    EXPECT_TRUE(inputs.contains(RedundancyInput::PassiveBMCHardwareProblem));
+
+    // Add another
+    writeExternalRedundancyInput(
+        RedundancyInput::PassiveBMCHostProcessorProblem, true);
+    inputs = readExternalRedundancyInputs();
+    EXPECT_EQ(inputs.size(), 2);
+
+    // Verify it was added
+    EXPECT_TRUE(hasExternalRedundancyInput(
+        RedundancyInput::PassiveBMCHostProcessorProblem));
+
+    // Clear the first one only
+    writeExternalRedundancyInput(RedundancyInput::PassiveBMCHardwareProblem,
+                                 false);
+
+    EXPECT_FALSE(
+        hasExternalRedundancyInput(RedundancyInput::PassiveBMCHardwareProblem));
+    EXPECT_TRUE(hasExternalRedundancyInput(
+        RedundancyInput::PassiveBMCHostProcessorProblem));
+
+    // Now clear the other one
+    writeExternalRedundancyInput(
+        RedundancyInput::PassiveBMCHostProcessorProblem, false);
+    EXPECT_FALSE(hasExternalRedundancyInput(
+        RedundancyInput::PassiveBMCHostProcessorProblem));
+    EXPECT_FALSE(hasExternalRedundancyInput(
+        RedundancyInput::PassiveBMCHostProcessorProblem,
+        RedundancyInput::PassiveBMCHardwareProblem));
+
+    inputs = readExternalRedundancyInputs();
+    EXPECT_EQ(inputs.size(), 0);
+
+    // Add them back
+    writeExternalRedundancyInput(RedundancyInput::PassiveBMCHardwareProblem,
+                                 true);
+    writeExternalRedundancyInput(
+        RedundancyInput::PassiveBMCHostProcessorProblem, true);
+    // Clear all inputs
+    bool cleared = clearExternalRedundancyInputs();
+    EXPECT_TRUE(cleared);
+
+    // Verify inputs are cleared
+    inputs = readExternalRedundancyInputs();
+    EXPECT_TRUE(inputs.empty());
+
+    // Clearing when already empty should return false
+    cleared = clearExternalRedundancyInputs();
+    EXPECT_FALSE(cleared);
+}


### PR DESCRIPTION
RBMC: Add RedundancyInput data helpers

The new external redundancy inputs that are provided to the application
need to be persisted across reboots and last until the next power off.

Add helper functions around the data::read/data::write calls for them 
to simplify the calling code since they are a bit unwieldy to use.

Tested:
New testcases pass