### PR TITLE
RBMC: Fill in SetRedundancyInput method

### DIFF
--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -67,6 +67,16 @@ class ActiveRoleHandler : public RoleHandler
     }
 
     /**
+     * @brief Called when external redundancy input changes
+     *
+     * Triggers redundancy re-evaluation.
+     */
+    void externalRedundancyInputChanged() override
+    {
+        ctx.spawn(redMgr.determineRedundancyAndSync());
+    }
+
+    /**
      * @brief Called when a failover is requested, this will return
      *        Reason::none if a failover is allowed right now, or the
      *        reason that it isn't.

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -6,6 +6,7 @@
 #include "errors.hpp"
 #include "passive_role_handler.hpp"
 #include "persistent_data.hpp"
+#include "util.hpp"
 
 #include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
@@ -332,6 +333,30 @@ void Manager::disableRedPropChanged(bool disable)
     }
 
     handler->disableRedPropChanged(disable);
+}
+
+void Manager::setExternalRedundancyInput(
+    RedundancyInterface::RedundancyInput input, bool value)
+{
+    lg2::info("SetRedundancyInput called: {INPUT}={VALUE}", "INPUT", input,
+              "VALUE", value);
+
+    if (redundancyInterface.role() != Role::Active)
+    {
+        lg2::error("SetRedundancyInput can only be called on active BMC");
+        throw sdbusplus::xyz::openbmc_project::Common::Error::NotAllowed();
+    }
+
+    if (!handler)
+    {
+        lg2::error(
+            "SetRedundancyInput cannot be called yet, role handler not initialized");
+        throw sdbusplus::xyz::openbmc_project::Common::Error::NotAllowed();
+    }
+
+    util::writeExternalRedundancyInput(input, value);
+
+    handler->externalRedundancyInputChanged();
 }
 
 sdbusplus::async::task<fo_blocked::Reason> Manager::validateFailoverRequest(

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -55,6 +55,18 @@ class Manager :
     void disableRedPropChanged(bool disable);
 
     /**
+     * @brief Handler for external redundancy input changes
+     *
+     * Called when an external application signals a hardware
+     * configuration issue that should disable redundancy.
+     *
+     * @param[in] input - The external input type
+     * @param[in] value - The value to set it to
+     */
+    void setExternalRedundancyInput(RedundancyInterface::RedundancyInput input,
+                                    bool value);
+
+    /**
      * @brief Implements the StartFailover D-Bus method.
      *
      * @param[in] requester - For logging who requested the failover

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -188,6 +188,12 @@ void PassiveRoleHandler::disableRedPropChanged(bool /*disable*/)
     throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
 }
 
+void PassiveRoleHandler::externalRedundancyInputChanged()
+{
+    // Not supported on the passive BMC
+    throw sdbusplus::xyz::openbmc_project::Common::Error::NotAllowed();
+}
+
 // NOLINTNEXTLINE
 sdbusplus::async::task<> PassiveRoleHandler::tryFullSync()
 {

--- a/redundant-bmc/src/passive_role_handler.hpp
+++ b/redundant-bmc/src/passive_role_handler.hpp
@@ -103,6 +103,14 @@ class PassiveRoleHandler : public RoleHandler
     void disableRedPropChanged(bool disable) override;
 
     /**
+     * @brief Handler for external redundancy input changes
+     *
+     * Not supported on the passive BMC so an error will
+     * be thrown.
+     */
+    void externalRedundancyInputChanged() override;
+
+    /**
      * @brief Setup watching the sibling BMC's health
      */
     inline void setupSiblingHealthWatch()

--- a/redundant-bmc/src/redundancy_interface.cpp
+++ b/redundant-bmc/src/redundancy_interface.cpp
@@ -142,9 +142,9 @@ bool RedundancyInterface::set_property(
 
 sdbusplus::async::task<> RedundancyInterface::method_call(
     RedundancyInterface::set_redundancy_input_t /* unused */,
-    RedundancyInterface::RedundancyInput /* input */, bool /* unused */)
+    RedundancyInterface::RedundancyInput input, bool value)
 {
-    // TODO
+    manager.setExternalRedundancyInput(input, value);
     co_return;
 }
 

--- a/redundant-bmc/src/redundancy_interface.hpp
+++ b/redundant-bmc/src/redundancy_interface.hpp
@@ -75,8 +75,8 @@ class RedundancyInterface :
      * @param[in] input - The RedundancyInput to set
      * @param[in] value - The value to set it to
      */
-    static sdbusplus::async::task<> method_call(
-        set_redundancy_input_t /* unused */, RedundancyInput input, bool value);
+    sdbusplus::async::task<> method_call(set_redundancy_input_t /* unused */,
+                                         RedundancyInput input, bool value);
 
   private:
     /**

--- a/redundant-bmc/src/role_handler.hpp
+++ b/redundant-bmc/src/role_handler.hpp
@@ -55,6 +55,14 @@ class RoleHandler
     virtual void disableRedPropChanged(bool disable) = 0;
 
     /**
+     * @brief Handler for external redundancy input changes
+     *
+     * Called when an external application signals a hardware
+     * configuration issue that should affect redundancy.
+     */
+    virtual void externalRedundancyInputChanged() = 0;
+
+    /**
      * @brief Called when a failover is requested, this will return
      *        Reason::none if a failover is allowed right now, or the
      *        reason that it isn't.


### PR DESCRIPTION
When SetRedundancyInput is called, persist the value and then forward the call to the role handler.  The active role handler will re-evaluate redundancy.  If called on the passive, the method will return an error.

A future commit will use the input in the redundancy calculation.

Change-Id: Ida872ee53b2ec34e087f5a877a0d2b5446688e0c