### PR TITLE
downstream-only: fix up cherry pick issue with multi-chassis-smp

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -287,6 +287,7 @@ if get_option('multi-chassis-smp').allowed()
         ],
         implicit_include_directories: true,
         install: true,
+        install_dir: get_option('libexecdir') / 'phosphor-state-manager',
     )
 endif
 

--- a/service_files/phosphor-chassis-wait-for-smp-poweron.service
+++ b/service_files/phosphor-chassis-wait-for-smp-poweron.service
@@ -9,7 +9,7 @@ Conflicts=obmc-chassis-poweroff@0.target
 [Service]
 Type=oneshot
 RemainAfterExit=no
-ExecStart=/usr/bin/phosphor-chassis-wait-for-smp-poweron
+ExecStart=/usr/libexec/phosphor-state-manager/phosphor-chassis-wait-for-smp-poweron
 
 [Install]
 RequiredBy=obmc-chassis-poweron@0.target


### PR DESCRIPTION
A change was made upstream to a patch set to move the smp wait app to /usr/libexec but that was not correctly cherry picked into our downstream fork. This fixes the files. When we rebase with upstream we'll get the real change so this commit will not be needed.