### PR TITLE
RBMC: Handle red inputs on host state changes

### DIFF
--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -2,6 +2,7 @@
 #include "passive_role_handler.hpp"
 
 #include "persistent_data.hpp"
+#include "util.hpp"
 
 #include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
@@ -77,6 +78,8 @@ PassiveRoleHandler::PassiveRoleHandler(sdbusplus::async::context& ctx,
                    "ERROR", e);
         iface.reasons_for_no_redundancy({});
     }
+
+    util::clearExternalRedundancyInputs();
 }
 
 // NOLINTNEXTLINE

--- a/redundant-bmc/src/persistent_data.hpp
+++ b/redundant-bmc/src/persistent_data.hpp
@@ -56,6 +56,7 @@ constexpr auto disableRed = "DisableRedundancy";
 constexpr auto redundancyOffAtRuntime = "RedundancyOffAtRuntime";
 constexpr auto failoverInProgress = "FailoverInProgress";
 constexpr auto externalRedundancyInputs = "ExternalRedundancyInputs";
+constexpr auto hostOff = "HostOff";
 } // namespace key
 
 namespace util

--- a/redundant-bmc/src/redundancy_mgr.cpp
+++ b/redundant-bmc/src/redundancy_mgr.cpp
@@ -4,6 +4,7 @@
 
 #include "error_data.hpp"
 #include "errors.hpp"
+#include "util.hpp"
 
 #include <persistent_data.hpp>
 #include <phosphor-logging/lg2.hpp>
@@ -11,6 +12,9 @@
 
 namespace rbmc
 {
+
+using RedundancyInput = sdbusplus::common::xyz::openbmc_project::state::bmc::
+    Redundancy::RedundancyInput;
 
 RedundancyMgr::RedundancyMgr(sdbusplus::async::context& ctx,
                              Providers& providers, RedundancyInterface& iface) :
@@ -221,11 +225,40 @@ void RedundancyMgr::initSystemState()
         systemState = SystemState::other;
     }
 
-    // Ensure a value for redundancy off at runtime isn't
-    // still valid if system is off, as may have lost AC.
+    bool wasHostOff = false;
+    try
+    {
+        wasHostOff = data::read<bool>(data::key::hostOff).value_or(true);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed trying to obtain HostOff: {ERROR}", "ERROR", e);
+    }
+
     if (systemState == SystemState::off)
     {
+        // Ensure a value for redundancy off at runtime isn't
+        // still valid if system is off, as may have lost AC.
         clearRedundancyOffAtRuntime();
+
+        // Only clear the redundancy inputs on an AC loss so
+        // they don't get cleared in a failover.
+        if (!wasHostOff)
+        {
+            if (util::clearExternalRedundancyInputs())
+            {
+                lg2::info("Cleared external redundancy inputs on an AC loss");
+            }
+        }
+    }
+
+    try
+    {
+        data::write(data::key::hostOff, systemState == SystemState::off);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed serializing HostOff: {ERROR}", "ERROR", e);
     }
 }
 
@@ -234,9 +267,22 @@ void RedundancyMgr::systemStateChange(SystemState newState)
     lg2::info("System state change to {NEW}", "NEW",
               getSystemStateName(newState));
 
+    try
+    {
+        data::write(data::key::hostOff, newState == SystemState::off);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed serializing HostOff: {ERROR}", "ERROR", e);
+    }
+
+    bool inputsCleared = false;
+
     if (newState == SystemState::off)
     {
         clearRedundancyOffAtRuntime();
+
+        inputsCleared = util::clearExternalRedundancyInputs();
     }
     else if (newState == SystemState::runtime)
     {
@@ -255,7 +301,16 @@ void RedundancyMgr::systemStateChange(SystemState newState)
 
     systemState = newState;
 
-    determineAndSetFailoversAllowed();
+    if (newState == SystemState::off && inputsCleared)
+    {
+        lg2::info(
+            "Re-evaluating redundancy since external inputs were cleared");
+        ctx.spawn(determineRedundancyAndSync());
+    }
+    else
+    {
+        determineAndSetFailoversAllowed();
+    }
 }
 
 void RedundancyMgr::setRedundancyOffAtRuntime(bool valid, bool off)


### PR DESCRIPTION
The system host/power state is already tracked by RedundancyMgr.

When it changes to off, clear the redundancy inputs, and if one was cleared run determineRedundancyAndSync to try to enable redundancy again.

Also start persisting the 'host off' value, because in initSystemState the redundancy inputs should only be cleared if there was an AC loss and the way to know that is to track the last known power state.  If the last known state was on, but the current state is off, then AC must have been lost.

They shouldn't be cleared otherwise because this code also runs during a failover and there could be existing inputs that need to be used.

Tested:
- Redundancy is determined when inputs are set
- Inputs are cleared on a power off and redundancy is re-determined
- After an AC loss, inputs are cleared

Change-Id: I43ea1b2c9be434be582e30cfe5bd245cd847b44e