### PR TITLE
RBMC: Check if sibling waits can be stopped early

### DIFF
--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -56,7 +56,8 @@ sdbusplus::async::task<> ActiveRoleHandler::start()
         // 3. The network to connect to the sibling BMC.
         co_await sdbusplus::async::execution::when_all(
             sibling.waitForSiblingRole(), sibling.waitForBMCSteadyState(),
-            services.waitForPeerConnection());
+            services.waitForPeerConnection(std::bind_front(
+                &ActiveRoleHandler::canStopPeerConnectionWait, this)));
 
         // If PeerConnected == true and sibling paired == false
         // a small delay will be needed to let the new paired
@@ -138,7 +139,8 @@ sdbusplus::async::task<> ActiveRoleHandler::siblingHealthy()
     // 3. Peer connection to be established.
     co_await sdbusplus::async::execution::when_all(
         sibling.waitForSiblingRole(), sibling.waitForBMCSteadyState(),
-        services.waitForPeerConnection());
+        services.waitForPeerConnection(std::bind_front(
+            &ActiveRoleHandler::canStopPeerConnectionWait, this)));
 
     // Just like in start(), a delay may be needed to let
     // the sibling paired value propagate.
@@ -311,7 +313,9 @@ sdbusplus::async::task<> ActiveRoleHandler::failoverWaitForSibling()
     if (sibling.alive())
     {
         co_await sdbusplus::async::execution::when_all(
-            sibling.waitForBMCSteadyState(), services.waitForPeerConnection());
+            sibling.waitForBMCSteadyState(),
+            services.waitForPeerConnection(std::bind_front(
+                &ActiveRoleHandler::canStopPeerConnectionWait, this)));
     }
 }
 

--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -238,6 +238,18 @@ class ActiveRoleHandler : public RoleHandler
     sdbusplus::async::task<> syncHealthCritical();
 
     /**
+     * @brief Predicate passed into waitForPeerConnection to stop
+     *        the wait if the sibling dies or isn't paired
+     *
+     * @return true if the wait can be stopped, false else.
+     */
+    inline bool canStopPeerConnectionWait() const
+    {
+        const auto& sibling = providers.getSibling();
+        return !sibling.alive() || !sibling.getPaired().value_or(true);
+    }
+
+    /**
      * @brief Called when the passive BMC is about to start a failover
      *        so that any preparation can be done.
      *

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -8,6 +8,7 @@
 #include <xyz/openbmc_project/State/BMC/common.hpp>
 
 #include <filesystem>
+#include <functional>
 #include <map>
 
 namespace rbmc
@@ -15,6 +16,13 @@ namespace rbmc
 
 using Role =
     sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy::Role;
+
+/**
+ * @brief Predicate function type for aborting wait operations
+ *
+ * Returns true if the wait should be aborted, false otherwise.
+ */
+using AbortPredicate = std::function<bool()>;
 
 /**
  * @class Services
@@ -120,8 +128,12 @@ class Services
 
     /**
      * @brief Waits for the PeerConnected property to reach Connected
+     *
+     * @param[in] shouldAbort - Optional predicate to check if wait should abort
+     *                          early. If it returns true, the wait will stop.
      */
-    virtual sdbusplus::async::task<> waitForPeerConnection() = 0;
+    virtual sdbusplus::async::task<> waitForPeerConnection(
+        AbortPredicate shouldAbort = nullptr) = 0;
 
     /**
      * @brief Execute the 'failover imminent' delay to the other BMC

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -935,7 +935,8 @@ sdbusplus::async::task<> ServicesImpl::logError(
     }
 }
 
-sdbusplus::async::task<> ServicesImpl::waitForPeerConnection()
+sdbusplus::async::task<> ServicesImpl::waitForPeerConnection(
+    AbortPredicate shouldAbort)
 {
     using namespace std::chrono_literals;
     std::chrono::minutes timeout{10};
@@ -956,6 +957,12 @@ sdbusplus::async::task<> ServicesImpl::waitForPeerConnection()
         if (peerConnected)
         {
             lg2::info("Peer now connected");
+            co_return;
+        }
+
+        if (shouldAbort && shouldAbort())
+        {
+            lg2::info("Peer connection wait no longer necessary");
             co_return;
         }
 

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -118,8 +118,12 @@ class ServicesImpl : public Services
 
     /**
      * @brief Waits for the PeerConnected property to reach Connected
+     *
+     * @param[in] shouldAbort - Optional predicate to check if wait should abort
+     *                          early. If it returns true, the wait will stop.
      */
-    sdbusplus::async::task<> waitForPeerConnection() override;
+    sdbusplus::async::task<> waitForPeerConnection(
+        AbortPredicate shouldAbort = nullptr) override;
 
     /**
      * @brief Reads the BMC state

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -511,6 +511,14 @@ sdbusplus::async::task<> SiblingImpl::waitForBMCSteadyState() const
     while (!steadyState(bmcState.state) &&
            ((std::chrono::steady_clock::now() - start) < timeout))
     {
+        // If sibling dies while waiting, stop.
+        if (!alive())
+        {
+            lg2::warning(
+                "Sibling no longer alive inside waitForBMCSteadyState, stopping wait");
+            co_return;
+        }
+
         if (!waiting)
         {
             lg2::info(

--- a/redundant-bmc/test/mocks/mock_services.hpp
+++ b/redundant-bmc/test/mocks/mock_services.hpp
@@ -54,8 +54,8 @@ class MockServices : public testing::NiceMock<Services>
 
     MOCK_METHOD(bool, getPeerConnected, (), (const, override));
 
-    MOCK_METHOD(sdbusplus::async::task<>, waitForPeerConnection, (),
-                (override));
+    MOCK_METHOD(sdbusplus::async::task<>, waitForPeerConnection,
+                (AbortPredicate), (override));
 
     MOCK_METHOD(sdbusplus::async::task<>, doFailoverImminentDelay, (),
                 (const, override));


### PR DESCRIPTION
Add checks to see if some of the long running waits on the sibling can be stopped early:
1. Get out of the peer connection wait if the sibling isn't paired, or it dies.
2. Get out of the sibling steady state wait if it dies.

The waitForPeerConnection change will be helpful in BMC CM when an unpaired BMC comes online.
