### PR TITLE
RBMC: Check external redundancy inputs when enabling redundancy

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -108,6 +108,9 @@ items to see if redundancy can be enabled:
 1. The network between the BMCs is connected.
 1. If attempting to enable any time at runtime, redundancy must have been
    enabled when runtime was first reached.
+1. The 'passive hardware problem'
+   [external redundancy input](#another-application-needs-to-disable-redundancy)
+   isn't set.
 
 ## Scenarios
 
@@ -156,6 +159,24 @@ started since the overall loss of the passive BMC is already being handled.
 
 In addition, if the network loss timer is already running when the heartbeat
 loss is noticed, it will be canceled when the heartbeat loss timer is started.
+
+### Another application needs to disable redundancy
+
+There is a `SetRedundancyInput` D-Bus method that can be used by another
+application to provide inputs to the redundancy algorithm.
+
+The possible inputs are:
+
+- `PassiveBMCHardwareProblem`: There is a hardware problem with the passive BMC
+  preventing it from being active so redundancy can't be enabled. An example is
+  the passive BMC can't talk to its connected host processor.
+- `PassiveBMCHostProcessorProblem`: There is a hardware problem related to the
+  passive BMC's connected host processor preventing it from being active so
+  redundancy can't be enabled. An example is the host processor is deconfigured.
+
+If redundancy was enabled when called, it will immediately be disabled, and
+remain so until the next time the host is powered off, at which point this input
+will be cleared and redundancy calculated again.
 
 ## Interacting with Data Sync on the Active BMC
 

--- a/redundant-bmc/src/error_data.cpp
+++ b/redundant-bmc/src/error_data.cpp
@@ -5,6 +5,7 @@
 
 #include "persistent_data.hpp"
 #include "system_state.hpp"
+#include "util.hpp"
 
 namespace rbmc::errors
 {
@@ -167,6 +168,17 @@ void addFileData(AdditionalData& data)
             {
                 data["RedOffAtRuntime"] = boolToYesOrNo(true);
             }
+        }
+
+        auto inputs = util::readExternalRedundancyInputs();
+        if (!inputs.empty())
+        {
+            data["ExtRedInputs"] = std::ranges::fold_left(
+                inputs, std::string{}, [](const auto& front, auto input) {
+                    auto enumString = getPDIEnumString(input);
+                    return front.empty() ? enumString
+                                         : front + ' ' + enumString;
+                });
         }
     }
     catch (const std::exception& e)

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -6,6 +6,7 @@
 #include "services_impl.hpp"
 #include "sibling_reset_impl.hpp"
 #include "types.hpp"
+#include "util.hpp"
 
 #include <CLI/CLI.hpp>
 #include <nlohmann/json.hpp>
@@ -153,6 +154,21 @@ void addFONotAllowedReason(rbmc::FailoversNotAllowedReason reason,
     output["Reason failovers are not allowed"] = std::move(reasonList);
 }
 
+void addExternalRedundancyInputs(nlohmann::ordered_json& output)
+{
+    auto inputs = rbmc::util::readExternalRedundancyInputs();
+
+    if (!inputs.empty())
+    {
+        nlohmann::json::array_t inputList;
+        for (const auto& input : inputs)
+        {
+            inputList.emplace_back(getPDIEnumString(input));
+        }
+        output["External Redundancy Inputs"] = std::move(inputList);
+    }
+}
+
 void addLastFailoverDetails(const std::filesystem::path& dataPath,
                             size_t bmcPos, nlohmann::ordered_json& output)
 {
@@ -248,6 +264,11 @@ sdbusplus::async::task<> getLocalBMCInfo(sdbusplus::async::context& ctx,
             !props.failovers_allowed)
         {
             addFONotAllowedReason(props.failovers_not_allowed_reason, output);
+        }
+
+        if (role == "Active")
+        {
+            addExternalRedundancyInputs(output);
         }
 
         if ((role == "Active") && pos.has_value())

--- a/redundant-bmc/src/redundancy.cpp
+++ b/redundant-bmc/src/redundancy.cpp
@@ -77,6 +77,11 @@ ReasonsForNoRedundancy getNoRedundancyReasons(const Input& input)
         reasons.push_back(RedundancyOffAtRuntimeStart);
     }
 
+    if (input.passiveHWIssue)
+    {
+        reasons.push_back(SystemHWConfigIssue);
+    }
+
     return reasons;
 }
 

--- a/redundant-bmc/src/redundancy.hpp
+++ b/redundant-bmc/src/redundancy.hpp
@@ -39,6 +39,7 @@ struct Input
     bool redundancyOffAtRuntimeStart;
     bool syncFailed;
     bool peerConnected;
+    bool passiveHWIssue;
 };
 
 using ReasonsForNoRedundancy = std::vector<ReasonForNoRedundancy>;

--- a/redundant-bmc/src/redundancy_mgr.cpp
+++ b/redundant-bmc/src/redundancy_mgr.cpp
@@ -144,7 +144,10 @@ redundancy::ReasonsForNoRedundancy RedundancyMgr::getNoRedundancyReasons()
         .manualDisable = manualDisable,
         .redundancyOffAtRuntimeStart = isRedundancyOffAtRuntime(),
         .syncFailed = syncFailed,
-        .peerConnected = services.getPeerConnected()};
+        .peerConnected = services.getPeerConnected(),
+        .passiveHWIssue = util::hasExternalRedundancyInput(
+            RedundancyInput::PassiveBMCHardwareProblem,
+            RedundancyInput::PassiveBMCHostProcessorProblem)};
 
     return redundancy::getNoRedundancyReasons(input);
 }

--- a/redundant-bmc/test/redundancy_test.cpp
+++ b/redundant-bmc/test/redundancy_test.cpp
@@ -22,7 +22,8 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
         .manualDisable = false,
         .redundancyOffAtRuntimeStart = false,
         .syncFailed = false,
-        .peerConnected = true};
+        .peerConnected = true,
+        .passiveHWIssue = false};
 
     // Nothing stopping redundancy
     {
@@ -148,6 +149,16 @@ TEST(RedundancyTest, NoRedundancyReasonsTest)
         auto reasons = getNoRedundancyReasons(input);
         ASSERT_EQ(reasons.size(), 1);
         EXPECT_EQ(*reasons.begin(), DataSyncFailed);
+    }
+
+    // Passive hardware issue
+    {
+        auto input = golden;
+        input.passiveHWIssue = true;
+
+        auto reasons = getNoRedundancyReasons(input);
+        ASSERT_EQ(reasons.size(), 1);
+        EXPECT_EQ(*reasons.begin(), SystemHWConfigIssue);
     }
 
     // Multiple fails


### PR DESCRIPTION
Now that support is there, start checking the external redundancy inputs when enabling redundancy.

Also capture them in errors logs, and show them in rbmctool.