### PR TITLE
RBMC: Add Manager testcases

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -178,6 +178,34 @@ If redundancy was enabled when called, it will immediately be disabled, and
 remain so until the next time the host is powered off, at which point this input
 will be cleared and redundancy calculated again.
 
+## Code Updates
+
+### Preventing error logs due to code updates
+
+The standard sequence of doing a code update on a redundant BMC system is:
+
+1. Update flash of active BMC and reboot it. Wait for it to come back online
+   with the new code level.
+2. Update flash of passive BMC and reboot it.
+
+After the active BMC comes back, the code levels won't match anymore so
+redundancy will be disabled. Normally, that would generate an error log. To
+avoid creating an error log in this case, since it is an expected case, the code
+on the active BMC will:
+
+1. Watch for the code update to start and save that indication persistently.
+2. Any time that redundancy is attempted and it can't be enabled, the code will
+   skip creating an error log if the code update indication is saved and the
+   only reason it can't be enabled is due to a code update.
+
+The indication will be cleared if:
+
+1. Redundancy is successfully enabled, meaning the passive BMC must have been
+   updated and rebooted into the same level.
+2. A boot is started. In this case, the user must have deemed booting more
+   important than finishing the code update, so the code won't treat it
+   differently anymore.
+
 ## Interacting with Data Sync on the Active BMC
 
 ### When Enabling Redundancy

--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -75,6 +75,8 @@ sdbusplus::async::task<> ActiveRoleHandler::start()
     co_await redMgr.determineRedundancyAndSync();
 
     startAllWatches();
+
+    providers.getTracker().track(ProgressPoint::activeHandlerStartComplete);
 }
 
 void ActiveRoleHandler::siblingStateChange(BMCState state)

--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "code_update_activation.hpp"
 #include "redundancy_mgr.hpp"
 #include "role_handler.hpp"
 #include "timer.hpp"
@@ -27,10 +28,13 @@ class ActiveRoleHandler : public RoleHandler
      * @param[in] ctx - The async context object
      * @param[in] providers - The Providers access object
      * @param[in] iface - The redundancy D-Bus interface object
+     * @param[in] codeUpdateActivation - The Activation D-Bus interface object
      */
     ActiveRoleHandler(sdbusplus::async::context& ctx, Providers& providers,
-                      RedundancyInterface& iface) :
-        RoleHandler(ctx, providers, iface), redMgr(ctx, providers, iface),
+                      RedundancyInterface& iface,
+                      CodeUpdateActivation& codeUpdateActivation) :
+        RoleHandler(ctx, providers, iface),
+        redMgr(ctx, providers, iface, codeUpdateActivation),
         siblingHealthTimer(
             ctx, providers.getWaitTracker(),
             std::bind_front(&ActiveRoleHandler::siblingHealthCritical, this)),

--- a/redundant-bmc/src/code_update_activation.cpp
+++ b/redundant-bmc/src/code_update_activation.cpp
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "code_update_activation.hpp"
+
+#include "persistent_data.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+#include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
+
+namespace rbmc
+{
+
+using Redundancy =
+    sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy;
+
+const std::string CodeUpdateActivation::objectPath =
+    std::string{Redundancy::namespace_path::value} + '/' +
+    Redundancy::namespace_path::bmc;
+
+CodeUpdateActivation::CodeUpdateActivation(sdbusplus::async::context& ctx) :
+    sdbusplus::aserver::xyz::openbmc_project::software::Activation<
+        CodeUpdateActivation>(ctx, objectPath.c_str())
+{
+    try
+    {
+        activation_ =
+            data::read<bool>(data::key::codeUpdateInProgress).value_or(false)
+                ? Activations::Activating
+                : Activations::Active;
+    }
+    catch (const std::exception& e)
+    {
+        activation_ = Activations::Active;
+        lg2::error("Failed reading code-update-in-progress state: {ERROR}",
+                   "ERROR", e);
+    }
+
+    if (activation_ == Activations::Activating)
+    {
+        lg2::info("Code update in progress on startup");
+    }
+
+    requested_activation_ = RequestedActivations::None;
+    emit_added();
+}
+
+bool CodeUpdateActivation::codeUpdateInProgress() const
+{
+    return activation_ == Activations::Activating;
+}
+
+void CodeUpdateActivation::setCodeUpdateInProgress()
+{
+    activation(Activations::Activating);
+}
+
+void CodeUpdateActivation::clearCodeUpdateInProgress()
+{
+    activation(Activations::Active);
+}
+
+bool CodeUpdateActivation::set_property([[maybe_unused]] activation_t type,
+                                        Activations activation)
+{
+    if (activation == activation_)
+    {
+        return false;
+    }
+
+    lg2::info("Activation property changing to {VALUE}", "VALUE", activation);
+
+    activation_ = activation;
+
+    // This needs to be saved through a reboot, so persist it.
+    try
+    {
+        data::write(data::key::codeUpdateInProgress,
+                    activation_ == Activations::Activating);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed serializing code-update-in-progress state: {ERROR}",
+                   "ERROR", e);
+    }
+
+    return true;
+}
+
+} // namespace rbmc

--- a/redundant-bmc/src/code_update_activation.hpp
+++ b/redundant-bmc/src/code_update_activation.hpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <sdbusplus/async.hpp>
+#include <xyz/openbmc_project/Software/Activation/aserver.hpp>
+
+namespace rbmc
+{
+
+/**
+ * @class CodeUpdateActivation
+ *
+ * Hosts the code-update-in-progress Activation interface on the
+ * RBMC state object path.
+ */
+class CodeUpdateActivation :
+    public sdbusplus::aserver::xyz::openbmc_project::software::Activation<
+        CodeUpdateActivation>
+{
+  public:
+    CodeUpdateActivation(const CodeUpdateActivation&) = delete;
+    CodeUpdateActivation& operator=(const CodeUpdateActivation&) = delete;
+    CodeUpdateActivation(CodeUpdateActivation&&) = delete;
+    CodeUpdateActivation& operator=(CodeUpdateActivation&&) = delete;
+
+    /**
+     * @brief Constructor
+     *
+     * @param[in] ctx - The async context object
+     */
+    explicit CodeUpdateActivation(sdbusplus::async::context& ctx);
+
+    /**
+     * @brief Returns if code update is in progress
+     */
+    bool codeUpdateInProgress() const;
+
+    /**
+     * @brief Marks a code update as in progress
+     */
+    void setCodeUpdateInProgress();
+
+    /**
+     * @brief Clears the code update in progress value
+     */
+    void clearCodeUpdateInProgress();
+
+    /**
+     * @brief Handles updates to the Activation property
+     *
+     * Updates the stored D-Bus value and persists the corresponding
+     * code-update-in-progress state.
+     *
+     * @param[in] type - The property tag type
+     * @param[in] activation - The requested value
+     *
+     * @return true if the property value changed
+     */
+    bool set_property(activation_t type, Activations activation);
+
+  private:
+    /**
+     * @brief The D-Bus object path for the interface
+     */
+    static const std::string objectPath;
+};
+
+} // namespace rbmc

--- a/redundant-bmc/src/error_data.cpp
+++ b/redundant-bmc/src/error_data.cpp
@@ -170,6 +170,12 @@ void addFileData(AdditionalData& data)
             }
         }
 
+        auto codeUpdate = data::read<bool>(data::key::codeUpdateInProgress);
+        if (codeUpdate.value_or(false))
+        {
+            data["CodeUpdate"] = boolToYesOrNo(true);
+        }
+
         auto inputs = util::readExternalRedundancyInputs();
         if (!inputs.empty())
         {

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -63,7 +63,7 @@ Manager::Manager(sdbusplus::async::context& ctx,
         ctx, failoverPath.c_str()),
     ctx(ctx), providers(std::move(providers)),
     redundancyInterface(ctx, *this, this->providers->getPCIeStorage()),
-    heartbeatInterval(heartbeatInterval)
+    codeUpdateActivation(ctx), heartbeatInterval(heartbeatInterval)
 {
     try
     {

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -180,8 +180,8 @@ void Manager::spawnRoleHandler()
 {
     if (redundancyInterface.role() == Role::Active)
     {
-        handler = std::make_unique<ActiveRoleHandler>(ctx, *providers,
-                                                      redundancyInterface);
+        handler = std::make_unique<ActiveRoleHandler>(
+            ctx, *providers, redundancyInterface, codeUpdateActivation);
     }
     else if (redundancyInterface.role() == Role::Passive)
     {
@@ -564,7 +564,8 @@ sdbusplus::async::task<> Manager::doFailoverFromPassive(Requester requester)
     updateRole(role_determination::RoleInfo{
         Role::Active, role_determination::RoleReason::failover});
 
-    auto* active = new ActiveRoleHandler(ctx, *providers, redundancyInterface);
+    auto* active = new ActiveRoleHandler(ctx, *providers, redundancyInterface,
+                                         codeUpdateActivation);
     handler.reset(active);
 
     active->clearFailoversAllowedDuringFailover();

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 #pragma once
 
+#include "code_update_activation.hpp"
 #include "providers.hpp"
 #include "redundancy_interface.hpp"
 #include "role_determination.hpp"
@@ -209,6 +210,13 @@ class Manager :
      * @brief The Redundancy D-Bus interface
      */
     RedundancyInterface redundancyInterface;
+
+    /**
+     * @brief The code update Activation D-Bus interface.
+     *
+     * Used for tracking in progress code updates.
+     */
+    CodeUpdateActivation codeUpdateActivation;
 
     /**
      * @brief The role handler class

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -78,6 +78,26 @@ class Manager :
                                          Requester requester,
                                          const FailoverOptions& options);
 
+    /**
+     * @brief Returns the Redundancy D-Bus interface object
+     *
+     * @return Reference to the redundancy interface
+     */
+    const RedundancyInterface& getRedundancyInterface() const
+    {
+        return redundancyInterface;
+    }
+
+    /**
+     * @brief Returns the Providers instance used
+     *
+     * @return Reference to providers
+     */
+    Providers& getProviders()
+    {
+        return *providers;
+    }
+
   private:
     /**
      * @brief Kicks off the Manager startup

--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -17,6 +17,7 @@ rbmc_deps = [
 rbmc_lib = static_library(
     'rbmc',
     'active_role_handler.cpp',
+    'code_update_activation.cpp',
     'config_parser.cpp',
     'error_data.cpp',
     'gpio.cpp',

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -98,7 +98,7 @@ sdbusplus::async::task<> PassiveRoleHandler::start()
             "ERROR", e);
     }
 
-    co_return;
+    providers.getTracker().track(ProgressPoint::passiveHandlerStartComplete);
 }
 
 void PassiveRoleHandler::setupSiblingRedEnabledWatch()

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -86,6 +86,18 @@ sdbusplus::async::task<> PassiveRoleHandler::start()
             "ERROR", e);
     }
 
+    try
+    {
+        // This is only valid on the active BMC
+        data::remove(data::key::codeUpdateInProgress);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error(
+            "Failed while removing CodeUpdateInProgress saved value: {ERROR}",
+            "ERROR", e);
+    }
+
     co_return;
 }
 

--- a/redundant-bmc/src/pcie_storage.hpp
+++ b/redundant-bmc/src/pcie_storage.hpp
@@ -71,13 +71,6 @@ class PCIeStorage
     PCIeStorage& operator=(PCIeStorage&&) = delete;
 
     /**
-     * @brief Write the complete redundancy state to PCIe storage
-     *
-     * @param[in] state - The redundancy state to write
-     */
-    virtual void writeState(const RedundancyState& state) = 0;
-
-    /**
      * @brief Read the complete redundancy state from PCIe storage
      *
      * @return The redundancy state
@@ -135,13 +128,15 @@ class PCIeStorageImpl : public PCIeStorage
     PCIeStorageImpl(const std::string& devPath, size_t offset);
     ~PCIeStorageImpl() override;
 
-    void writeState(const RedundancyState& state) override;
     RedundancyState readState() override;
 
     void updateRole(uint8_t role) override;
     void updateRedundancyEnabled(bool enabled) override;
     void updateFailoverInProgress(bool inProgress) override;
     void updateFailoversAllowed(bool allowed) override;
+
+  private:
+    void writeState(const RedundancyState& state);
 };
 
 } // namespace pcie_data

--- a/redundant-bmc/src/persistent_data.hpp
+++ b/redundant-bmc/src/persistent_data.hpp
@@ -57,6 +57,7 @@ constexpr auto redundancyOffAtRuntime = "RedundancyOffAtRuntime";
 constexpr auto failoverInProgress = "FailoverInProgress";
 constexpr auto externalRedundancyInputs = "ExternalRedundancyInputs";
 constexpr auto hostOff = "HostOff";
+constexpr auto codeUpdateInProgress = "CodeUpdateInProgress";
 } // namespace key
 
 namespace util

--- a/redundant-bmc/src/progress_tracker.hpp
+++ b/redundant-bmc/src/progress_tracker.hpp
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+namespace rbmc
+{
+
+enum class ProgressPoint
+{
+    activeHandlerStartComplete,
+    passiveHandlerStartComplete
+};
+
+/**
+ * @class ProgressTracker
+ */
+class ProgressTracker
+{
+  public:
+    ProgressTracker() = default;
+    virtual ~ProgressTracker() = default;
+
+    ProgressTracker(const ProgressTracker&) = delete;
+    ProgressTracker& operator=(const ProgressTracker&) = delete;
+    ProgressTracker(ProgressTracker&&) = delete;
+    ProgressTracker& operator=(ProgressTracker&&) = delete;
+
+    /**
+     * @brief Track a progress point
+     *
+     * @param[in] event - The point to track
+     */
+    virtual void track(ProgressPoint /* point */) {}
+
+    /**
+     * @brief Check if the progress point has been reached
+     *
+     * @param[in] point - The point to check
+     * @return true if it has been reached
+     */
+    virtual bool hasReached(ProgressPoint /* point */) const
+    {
+        return false;
+    }
+};
+
+} // namespace rbmc

--- a/redundant-bmc/src/providers.hpp
+++ b/redundant-bmc/src/providers.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "pcie_storage.hpp"
+#include "progress_tracker.hpp"
 #include "services.hpp"
 #include "sibling.hpp"
 #include "sibling_reset.hpp"
@@ -51,6 +52,11 @@ class Providers
      * @brief Returns the PCIeStorage provider if configured
      */
     virtual pcie_data::PCIeStorage* getPCIeStorage() = 0;
+
+    /**
+     * @brief Returns the ProgressTracker provider
+     */
+    virtual ProgressTracker& getTracker() = 0;
 
     /**
      * @brief Returns the WaitTracker

--- a/redundant-bmc/src/providers_impl.hpp
+++ b/redundant-bmc/src/providers_impl.hpp
@@ -86,6 +86,14 @@ class ProvidersImpl : public Providers
         return &*pcieStorage;
     }
 
+    /**
+     * @brief Returns the ProgressTracker provider
+     */
+    ProgressTracker& getTracker() override
+    {
+        return progTracker;
+    }
+
   private:
     /**
      * @brief Create PCIeStorage if config is present
@@ -136,6 +144,11 @@ class ProvidersImpl : public Providers
      * @brief The PCIeStorage implementation (optional)
      */
     std::optional<pcie_data::PCIeStorageImpl> pcieStorage;
+
+    /**
+     * @brief The ProgressTracker implementation
+     */
+    ProgressTracker progTracker;
 };
 
 }; // namespace rbmc

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -259,7 +259,12 @@ sdbusplus::async::task<> getLocalBMCInfo(sdbusplus::async::context& ctx,
         catch (const std::exception& e)
         {
             output["Paired"] = e.what();
-            output["PeerConnected"] = e.what();
+            output["Peer Connected"] = e.what();
+        }
+
+        if (data::read<bool>(data::key::codeUpdateInProgress).value_or(false))
+        {
+            output["In Code Update"] = true;
         }
 
         if (role != "Unknown")

--- a/redundant-bmc/src/redundancy_mgr.cpp
+++ b/redundant-bmc/src/redundancy_mgr.cpp
@@ -17,10 +17,16 @@ using RedundancyInput = sdbusplus::common::xyz::openbmc_project::state::bmc::
     Redundancy::RedundancyInput;
 
 RedundancyMgr::RedundancyMgr(sdbusplus::async::context& ctx,
-                             Providers& providers, RedundancyInterface& iface) :
+                             Providers& providers, RedundancyInterface& iface,
+                             CodeUpdateActivation& codeUpdateActivation) :
     ctx(ctx), providers(providers), redundancyInterface(iface),
+    codeUpdateActivation(codeUpdateActivation),
     manualDisable(iface.disable_redundancy_override())
-{}
+{
+    providers.getServices().addCodeUpdateCallback(
+        Role::Active,
+        std::bind_front(&RedundancyMgr::codeUpdateActivationChanged, this));
+}
 
 void RedundancyMgr::determineAndSetRedundancy()
 {
@@ -39,17 +45,38 @@ void RedundancyMgr::determineAndSetRedundancy()
 
     determineAndSetFailoversAllowed();
 
+    auto codeUpdateInProgress = codeUpdateActivation.codeUpdateInProgress();
+    if (codeUpdateInProgress)
+    {
+        // If a code update was in progress, but both BMCs were updated so
+        // the versions are the same again, consider it complete.
+        if (redundancyInterface.redundancy_enabled() ||
+            !std::ranges::contains(reasons,
+                                   ReasonForNoRedundancy::CodeVersionMismatch))
+        {
+            lg2::info("Clearing code-update-in-progress indication");
+            codeUpdateActivation.clearCodeUpdateInProgress();
+        }
+    }
+
     if (!redundancyInterface.redundancy_enabled())
     {
         auto wasManuallyDisabled = std::ranges::contains(
             oldReasons, ReasonForNoRedundancy::ManuallyDisabled);
+
+        auto mismatchOnly =
+            reasons.size() == 1 &&
+            *reasons.begin() == ReasonForNoRedundancy::CodeVersionMismatch;
 
         // Log an error when redundancy isn't enabled if:
         // 1. Redundancy was previously enabled.
         // 2. This is the first time checking redundancy.
         // 3. The manual override to disable redundancy is now off but
         //    was previously on, meaning there is some other reason.
-        if (oldEnabled || firstTime || (!manualDisable && wasManuallyDisabled))
+        // 4. An in progress code update didn't cause it.
+        if ((oldEnabled || firstTime ||
+             (!manualDisable && wasManuallyDisabled)) &&
+            !(codeUpdateInProgress && mismatchOnly))
         {
             using namespace errors;
             std::string error{error_msg::noRedundancy};
@@ -265,6 +292,20 @@ void RedundancyMgr::initSystemState()
     }
 }
 
+void RedundancyMgr::codeUpdateActivationChanged(bool started)
+{
+    if (started)
+    {
+        lg2::info("Detected a code update starting");
+        codeUpdateActivation.setCodeUpdateInProgress();
+    }
+    else
+    {
+        lg2::warning("Code update failed, clearing code update indication");
+        codeUpdateActivation.clearCodeUpdateInProgress();
+    }
+}
+
 void RedundancyMgr::systemStateChange(SystemState newState)
 {
     lg2::info("System state change to {NEW}", "NEW",
@@ -299,6 +340,18 @@ void RedundancyMgr::systemStateChange(SystemState newState)
                 "ENABLED", redundancyInterface.redundancy_enabled());
             setRedundancyOffAtRuntimeValue(
                 !redundancyInterface.redundancy_enabled());
+        }
+    }
+    else if (newState == SystemState::booting)
+    {
+        // Consider a boot the end of allowing special treatment
+        // for code updates, as that must have been deemed more
+        // important than finishing the code update completely.
+        if (codeUpdateActivation.codeUpdateInProgress())
+        {
+            lg2::warning(
+                "Clearing in-progress code update indication on boot start");
+            codeUpdateActivation.clearCodeUpdateInProgress();
         }
     }
 

--- a/redundant-bmc/src/redundancy_mgr.hpp
+++ b/redundant-bmc/src/redundancy_mgr.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "code_update_activation.hpp"
 #include "providers.hpp"
 #include "redundancy.hpp"
 #include "redundancy_interface.hpp"
@@ -28,9 +29,11 @@ class RedundancyMgr
      * @param[in] ctx - The async context object
      * @param[in] providers - The Providers access object
      * @param[in] iface - The redundancy D-Bus interface object
+     * @param[in] codeUpdateActivation - The CodeUpdateActivation object
      */
     RedundancyMgr(sdbusplus::async::context& ctx, Providers& providers,
-                  RedundancyInterface& iface);
+                  RedundancyInterface& iface,
+                  CodeUpdateActivation& codeUpdateActivation);
 
     /**
      * @brief Destructor
@@ -38,6 +41,7 @@ class RedundancyMgr
     ~RedundancyMgr()
     {
         providers.getServices().removeSystemStateCallback(Role::Active);
+        providers.getServices().removeCodeUpdateCallback(Role::Active);
     }
 
     /**
@@ -125,6 +129,13 @@ class RedundancyMgr
     void initSystemState();
 
     /**
+     * @brief Called when a BMC code update activation state changes
+     *
+     * @param[in] started - true if the update started, false if it failed
+     */
+    void codeUpdateActivationChanged(bool started);
+
+    /**
      * @brief Update the 'redundancy off at runtime' data.
      *
      * @param[in] valid - If the value is valid or not.
@@ -192,6 +203,12 @@ class RedundancyMgr
      * @brief The Redundancy D-Bus interface
      */
     RedundancyInterface& redundancyInterface;
+
+    /**
+     * @brief The code update Activation D-Bus interface
+     *        to track if code update is in progress.
+     */
+    CodeUpdateActivation& codeUpdateActivation;
 
     /**
      * @brief If determineAndSetRedundancy() has ran yet or not.

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -48,6 +48,7 @@ class Services
     using SystemStateCallback = std::function<void(SystemState)>;
     using PeerConnectedCallback = std::function<void(bool)>;
     using PairedCallback = std::function<void(bool)>;
+    using CodeUpdateCallback = std::move_only_function<void(bool)>;
 
     /**
      * @brief Sets up the D-Bus matches
@@ -229,6 +230,29 @@ class Services
     }
 
     /**
+     * @brief Add a function that gets called when a BMC code update
+     *        starts or fails.
+     *
+     *
+     * @param[in] role - The role to register with
+     * @param[in] callback - The function to call
+     */
+    void addCodeUpdateCallback(Role role, CodeUpdateCallback&& callback)
+    {
+        codeUpdateCBs.emplace(role, std::move(callback));
+    }
+
+    /**
+     * @brief Remove a specific code update callback by role.
+     *
+     * @param[in] role - The role of the callback to remove
+     */
+    void removeCodeUpdateCallback(Role role)
+    {
+        codeUpdateCBs.erase(role);
+    }
+
+    /**
      * @brief On the system inventory object, check that its Progress
      *        Status property is 'Completed'.
      *
@@ -277,6 +301,11 @@ class Services
      * @brief The functions to call when the paired status changes
      */
     std::map<Role, PairedCallback> pairedCBs;
+
+    /**
+     * @brief The functions to call when a code update starts or fails
+     */
+    std::map<Role, CodeUpdateCallback> codeUpdateCBs;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -13,6 +13,8 @@
 #include <xyz/openbmc_project/Logging/Create/client.hpp>
 #include <xyz/openbmc_project/ObjectMapper/client.hpp>
 #include <xyz/openbmc_project/Provisioning/Provisioning/client.hpp>
+#include <xyz/openbmc_project/Software/Activation/client.hpp>
+#include <xyz/openbmc_project/Software/Version/client.hpp>
 #include <xyz/openbmc_project/State/BMC/client.hpp>
 #include <xyz/openbmc_project/State/Boot/Progress/client.hpp>
 #include <xyz/openbmc_project/State/Host/client.hpp>
@@ -34,6 +36,9 @@ using SidebandBus =
     sdbusplus::client::xyz::openbmc_project::control::SideBandBus<>;
 using Pairing =
     sdbusplus::client::xyz::openbmc_project::provisioning::Provisioning<>;
+using Activation =
+    sdbusplus::common::xyz::openbmc_project::software::Activation;
+using Version = sdbusplus::client::xyz::openbmc_project::software::Version<>;
 using PeerConnectionStatus = sdbusplus::common::xyz::openbmc_project::
     provisioning::Provisioning::PeerConnectionStatus;
 
@@ -43,6 +48,8 @@ using HostProperties =
                  BootProgress::ProgressStages>;
 using HostPropMap = std::unordered_map<std::string, HostProperties>;
 using HostInterfaceMap = std::map<std::string, HostPropMap>;
+using ActivationPropMap =
+    std::unordered_map<std::string, Activation::PropertiesVariant>;
 
 namespace rules = sdbusplus::bus::match::rules;
 
@@ -53,6 +60,7 @@ constexpr auto systemd = "/org/freedesktop/systemd1";
 // host0 represents the overall host state
 const std::string hostState = std::string{HostState::namespace_path::value} +
                               '/' + HostState::namespace_path::host + '0';
+constexpr auto software = "/xyz/openbmc_project/software";
 } // namespace object_path
 
 namespace interface
@@ -197,13 +205,14 @@ sdbusplus::async::task<int> runAsyncCmd(sdbusplus::async::context& ctx,
 
 sdbusplus::async::task<> ServicesImpl::init()
 {
-    auto barrier = std::make_shared<sdbusplus::async::barrier>(6);
+    auto barrier = std::make_shared<sdbusplus::async::barrier>(7);
 
     ctx.spawn(watchHostInterfacesAdded(barrier));
     ctx.spawn(watchHostStatePropertiesChanged(barrier));
     ctx.spawn(watchBootProgressPropertiesChanged(barrier));
     ctx.spawn(watchPairingInterfacesAdded(barrier));
     ctx.spawn(watchPairingPropertiesChanged(barrier));
+    ctx.spawn(watchCodeUpdatePropertiesChanged(barrier));
 
     co_await barrier->wait();
 
@@ -467,6 +476,83 @@ sdbusplus::async::task<> ServicesImpl::watchPairingPropertiesChanged(
         auto [_,
               properties] = co_await match.next<std::string, PairingPropMap>();
         loadPairingProps(properties);
+    }
+}
+
+sdbusplus::async::task<bool> ServicesImpl::isBMCCodeUpdate(
+    const std::string& path) const
+{
+    try
+    {
+        auto service = co_await util::getService(ctx, path, Version::interface);
+        auto purpose =
+            co_await Version(ctx).service(service).path(path).purpose();
+        co_return purpose == Version::VersionPurpose::BMC;
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        lg2::debug(
+            "Failed reading software version purpose for path {PATH}: {ERROR}",
+            "PATH", path, "ERROR", e);
+    }
+
+    co_return false;
+}
+
+sdbusplus::async::task<> ServicesImpl::watchCodeUpdatePropertiesChanged(
+    std::shared_ptr<sdbusplus::async::barrier> barrier)
+{
+    sdbusplus::async::match match(
+        ctx, rules::propertiesChangedNamespace(object_path::software,
+                                               Activation::interface));
+
+    co_await barrier->wait();
+
+    std::optional<std::string> activatingPath;
+
+    while (!ctx.stop_requested())
+    {
+        auto msg = co_await match.next();
+
+        std::string path{msg.get_path()};
+        auto [_, properties] = msg.unpack<std::string, ActivationPropMap>();
+
+        auto it = properties.find("Activation");
+        if (it == properties.end())
+        {
+            continue;
+        }
+
+        if (!co_await isBMCCodeUpdate(path))
+        {
+            continue;
+        }
+
+        auto activation = std::get<Activation::Activations>(it->second);
+
+        if (activation == Activation::Activations::Activating)
+        {
+            lg2::info("Detected BMC code update start on path {PATH}", "PATH",
+                      path);
+
+            activatingPath = path;
+            std::ranges::for_each(codeUpdateCBs, [](auto& entry) {
+                entry.second(true);
+            });
+        }
+        else if (activation == Activation::Activations::Failed &&
+                 activatingPath == path)
+        {
+            lg2::warning("BMC code update failed on path {PATH}", "PATH", path);
+            activatingPath.reset();
+            std::ranges::for_each(codeUpdateCBs, [](auto& entry) {
+                entry.second(false);
+            });
+        }
+        else if (activatingPath == path)
+        {
+            activatingPath.reset();
+        }
     }
 }
 

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -282,6 +282,25 @@ class ServicesImpl : public Services
     void loadPairingProps(const PairingPropMap& propertyMap);
 
     /**
+     * @brief Starts the PropertiesChanged watch the Activation interface
+     *
+     * @param[in] barrier - Initialization barrier
+     */
+    sdbusplus::async::task<> watchCodeUpdatePropertiesChanged(
+        std::shared_ptr<sdbusplus::async::barrier> barrier);
+
+    /**
+     * @brief Returns if the software object path is for a BMC image
+     *
+     * Checks the Purpose property on the Version interface.
+     *
+     * @param[in] path - The software object path
+     *
+     * @return true if the image purpose is BMC, false otherwise
+     */
+    sdbusplus::async::task<bool> isBMCCodeUpdate(const std::string& path) const;
+
+    /**
      * @brief Called when either the host state or boot progress property
      *        changes value to calculate the system state.
      */

--- a/redundant-bmc/test/manager_test.cpp
+++ b/redundant-bmc/test/manager_test.cpp
@@ -1,23 +1,454 @@
 // SPDX-License-Identifier: Apache-2.0
+#include "manager.hpp"
+#include "mocks/async_helpers.hpp"
 #include "mocks/mock_providers.hpp"
+#include "persistent_data_test_fixture.hpp"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 using namespace rbmc;
+using namespace testing;
+using namespace test_helpers;
 
-class ManagerTest
+using Redundancy =
+    sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy;
+
+constexpr std::chrono::milliseconds hbInterval{5};
+
+class ManagerTest : public rbmc::test::PersistentDataTestFixture
 {
   protected:
-    void SetUp()
+    struct TestScenarioConfig
+    {
+        bool paired = true;
+        std::optional<size_t> bmcPosition = 0;
+        bool systemInventoryAvailable = true;
+        bool siblingServiceRunning = true;
+        bool siblingPresent = true;
+        bool siblingAlive = true;
+        Role siblingRole = Role::Passive;
+        bool siblingPaired = true;
+        bool siblingFailoverInProgress = false;
+    };
+
+    ~ManagerTest() noexcept override = default;
+
+    void SetUp() override
     {
         mockProviders = std::make_unique<MockProviders>();
+
+        ON_CALL(mockProviders->getMockServices(), getPersistentDataPath())
+            .WillByDefault(Return(dataDir));
     }
 
-    void TearDown()
+    void TearDown() override
     {
+        manager.reset();
         mockProviders.reset();
     }
 
+    /**
+     * @brief Set what the functions should return for a
+     *        specific test scenario.
+     */
+    void setupTestScenario(const TestScenarioConfig& config)
+    {
+        auto& services = mockProviders->getMockServices();
+        auto& sibling = mockProviders->getMockSibling();
+
+        ON_CALL(services, getPaired()).WillByDefault(Return(config.paired));
+
+        ON_CALL(services, getBMCPosition())
+            .WillByDefault(Return(config.bmcPosition));
+
+        ON_CALL(services, checkSystemInventoryStatus())
+            .WillByDefault([available = config.systemInventoryAvailable]() {
+                return makeCompletedTask(available);
+            });
+
+        if (config.siblingServiceRunning)
+        {
+            siblingServiceName =
+                "xyz.openbmc_project.State.BMC.Redundancy.Sibling";
+        }
+        else
+        {
+            siblingServiceName = "";
+        }
+
+        ON_CALL(sibling, getServiceName())
+            .WillByDefault(ReturnRef(siblingServiceName));
+
+        ON_CALL(sibling, isBMCPresent())
+            .WillByDefault(Return(config.siblingPresent));
+
+        ON_CALL(sibling, alive()).WillByDefault(Return(config.siblingAlive));
+
+        ON_CALL(sibling, getRole()).WillByDefault(Return(config.siblingRole));
+
+        ON_CALL(sibling, getPaired())
+            .WillByDefault(Return(config.siblingPaired));
+
+        ON_CALL(sibling, getFailoverInProgress())
+            .WillByDefault(Return(config.siblingFailoverInProgress));
+    }
+
+    struct RedundancyProps
+    {
+        Role role{};
+        bool redEnabled{};
+        bool failoverInProgress{};
+        bool failoversAllowed{};
+        bool failoverImminent{};
+        std::vector<Redundancy::ReasonForNoRedundancy> reasonsForNoRedundancy;
+        FailoversNotAllowedReason failoversNotAllowedReason;
+    };
+
+    static void verifyRedundancyProps(const RedundancyInterface& iface,
+                                      const RedundancyProps& expected)
+    {
+        EXPECT_EQ(iface.role(), expected.role);
+        EXPECT_EQ(iface.redundancy_enabled(), expected.redEnabled);
+        EXPECT_EQ(iface.failover_in_progress(), expected.failoverInProgress);
+        EXPECT_EQ(iface.failovers_allowed(), expected.failoversAllowed);
+        EXPECT_EQ(iface.failover_imminent(), expected.failoverImminent);
+        EXPECT_EQ(iface.reasons_for_no_redundancy(),
+                  expected.reasonsForNoRedundancy);
+        EXPECT_EQ(iface.failovers_not_allowed_reason(),
+                  expected.failoversNotAllowedReason);
+    }
+
+    void setupPCIeStorageExpects(const RedundancyProps& vals)
+    {
+        auto& storage = mockProviders->getMockPCIeStorage();
+
+        // Initialized to Unknown first
+        EXPECT_CALL(storage, updateRole(static_cast<uint8_t>(Role::Unknown)))
+            .Times(1);
+
+        EXPECT_CALL(storage, updateRole(static_cast<uint8_t>(vals.role)))
+            .Times(1);
+        EXPECT_CALL(storage, updateRedundancyEnabled(vals.redEnabled));
+        EXPECT_CALL(storage, updateFailoverInProgress(vals.failoverInProgress));
+        EXPECT_CALL(storage, updateFailoversAllowed(vals.failoversAllowed));
+    }
+
+    /**
+     * @brief Create the Manager and let it run until a progress point is hit.
+     */
+    void createManagerAndRun(ProgressPoint point)
+    {
+        // Spawns Manager::startup()
+        manager = std::make_unique<Manager>(ctx, std::move(mockProviders),
+                                            hbInterval);
+
+        ctx.spawn(waitForProgressPoint(point));
+
+        ctx.run();
+    }
+
+    /**
+     * @brief Let the context run until a progress point has been reached
+     *
+     * @param[in] point - The point to wait for
+     * @param[in] timeout - The timeout, default is 1s
+     * @param[in] stopWhenDone - If the context should be stopped afterwards.
+     */
+    sdbusplus::async::task<> waitForProgressPoint(ProgressPoint point,
+                                                  bool stopWhenDone = true)
+    {
+        using namespace std::chrono_literals;
+        auto deadline = std::chrono::steady_clock::now() + 1s;
+
+        while (std::chrono::steady_clock::now() < deadline)
+        {
+            if (manager->getProviders().getTracker().hasReached(point))
+            {
+                if (stopWhenDone)
+                {
+                    ctx.request_stop();
+                }
+                co_return;
+            }
+            co_await sdbusplus::async::sleep_for(ctx, 10ms);
+        }
+
+        ADD_FAILURE() << "Timed out waiting for progress point "
+                      << std::to_underlying(point);
+
+        // If timed out, stop regardless
+        ctx.request_stop();
+    }
+
+    /**
+     * @brief Verify 3 values in the persistent data.
+     */
+    static void verifyPersistentData(Role expectedRole,
+                                     const std::string& expectedRoleReason,
+                                     bool expectPassiveError = false)
+    {
+        // Verify role was saved
+        auto savedRole = data::read<Role>(data::key::role);
+        ASSERT_TRUE(savedRole.has_value())
+            << "Role should be saved to persistent data";
+        EXPECT_EQ(savedRole.value(), expectedRole);
+
+        // Verify passiveError flag was saved
+        auto savedPassiveError = data::read<bool>(data::key::passiveError);
+        ASSERT_TRUE(savedPassiveError.has_value())
+            << "PassiveError flag should be saved to persistent data";
+        EXPECT_EQ(savedPassiveError.value(), expectPassiveError);
+
+        // Verify role reason description was saved
+        auto savedRoleReason = data::read<std::string>(data::key::roleReason);
+        ASSERT_TRUE(savedRoleReason.has_value())
+            << "RoleReason should be saved to persistent data";
+        EXPECT_EQ(savedRoleReason.value(), expectedRoleReason);
+    }
+
     std::unique_ptr<MockProviders> mockProviders;
+    std::unique_ptr<Manager> manager;
+    std::string siblingServiceName;
+    std::chrono::seconds passiveTargetTimeout{300};
+    sdbusplus::async::context ctx;
 };
+
+/**
+ * @brief Test: BMC becomes passive when not paired
+ */
+TEST_F(ManagerTest, BecomesPassive_NotPaired)
+{
+    // Configure scenario: BMC is not paired
+    TestScenarioConfig config{.paired = false};
+    setupTestScenario(config);
+
+    auto& services = mockProviders->getMockServices();
+
+    EXPECT_CALL(services, logError(errors::error_msg::bmcIsPassiveDueToError,
+                                   errors::Level::Error, _))
+        .Times(1);
+
+    EXPECT_CALL(services,
+                startUnit("obmc-bmc-passive.target", passiveTargetTimeout))
+        .Times(1);
+
+    RedundancyProps expectedProps{
+        .role = Role::Passive,
+        .redEnabled = false,
+        .failoverInProgress = false,
+        .failoversAllowed = false,
+        .failoverImminent = false,
+        .reasonsForNoRedundancy =
+            {Redundancy::ReasonForNoRedundancy::SiblingCannotBeActive},
+        .failoversNotAllowedReason = FailoversNotAllowedReason::None};
+
+    setupPCIeStorageExpects(expectedProps);
+
+    createManagerAndRun(ProgressPoint::passiveHandlerStartComplete);
+
+    verifyRedundancyProps(manager->getRedundancyInterface(), expectedProps);
+    verifyPersistentData(expectedProps.role, "BMC is not paired", true);
+}
+
+/**
+ * @brief Test: BMC becomes passive when BMC position is unknown
+ */
+TEST_F(ManagerTest, BecomesPassive_NoBMCPosition)
+{
+    // Configure scenario: BMC position is unknown
+    TestScenarioConfig config{.bmcPosition = std::nullopt};
+    setupTestScenario(config);
+
+    auto& services = mockProviders->getMockServices();
+
+    EXPECT_CALL(services, logError(errors::error_msg::bmcIsPassiveDueToError,
+                                   errors::Level::Error, _))
+        .Times(1);
+
+    EXPECT_CALL(services,
+                startUnit("obmc-bmc-passive.target", passiveTargetTimeout))
+        .Times(1);
+
+    RedundancyProps expectedProps{
+        .role = Role::Passive,
+        .redEnabled = false,
+        .failoverInProgress = false,
+        .failoversAllowed = false,
+        .failoverImminent = false,
+        .reasonsForNoRedundancy =
+            {Redundancy::ReasonForNoRedundancy::SiblingCannotBeActive},
+        .failoversNotAllowedReason = FailoversNotAllowedReason::None};
+
+    setupPCIeStorageExpects(expectedProps);
+
+    createManagerAndRun(ProgressPoint::passiveHandlerStartComplete);
+
+    verifyRedundancyProps(manager->getRedundancyInterface(), expectedProps);
+    verifyPersistentData(expectedProps.role, "Cannot determine BMC position",
+                         true);
+}
+
+/**
+ * @brief Test: BMC becomes passive when system inventory is not available
+ */
+TEST_F(ManagerTest, BecomesPassive_SystemInventoryNotAvailable)
+{
+    // Configure scenario: System inventory is not available
+    TestScenarioConfig config{.systemInventoryAvailable = false};
+    setupTestScenario(config);
+
+    auto& services = mockProviders->getMockServices();
+
+    // Verify error log is created for passive due to error
+    EXPECT_CALL(services, logError(errors::error_msg::bmcIsPassiveDueToError,
+                                   errors::Level::Error, _))
+        .Times(1);
+
+    EXPECT_CALL(services,
+                startUnit("obmc-bmc-passive.target", passiveTargetTimeout))
+        .Times(1);
+
+    RedundancyProps expectedProps{
+        .role = Role::Passive,
+        .redEnabled = false,
+        .failoverInProgress = false,
+        .failoversAllowed = false,
+        .failoverImminent = false,
+        .reasonsForNoRedundancy =
+            {Redundancy::ReasonForNoRedundancy::SiblingCannotBeActive},
+        .failoversNotAllowedReason = FailoversNotAllowedReason::None};
+
+    setupPCIeStorageExpects(expectedProps);
+
+    createManagerAndRun(ProgressPoint::passiveHandlerStartComplete);
+
+    verifyRedundancyProps(manager->getRedundancyInterface(), expectedProps);
+    verifyPersistentData(expectedProps.role,
+                         "System inventory is not available", true);
+}
+
+/**
+ * @brief Test: BMC becomes passive when sibling service is not running
+ */
+TEST_F(ManagerTest, BecomesPassive_SiblingServiceNotRunning)
+{
+    // Configure scenario: Sibling service is not running
+    TestScenarioConfig config{.siblingServiceRunning = false};
+    setupTestScenario(config);
+
+    auto& services = mockProviders->getMockServices();
+
+    // Verify error log is created for passive due to error
+    EXPECT_CALL(services, logError(errors::error_msg::bmcIsPassiveDueToError,
+                                   errors::Level::Error, _))
+        .Times(1);
+
+    EXPECT_CALL(services,
+                startUnit("obmc-bmc-passive.target", passiveTargetTimeout))
+        .Times(1);
+
+    RedundancyProps expectedProps{
+        .role = Role::Passive,
+        .redEnabled = false,
+        .failoverInProgress = false,
+        .failoversAllowed = false,
+        .failoverImminent = false,
+        .reasonsForNoRedundancy =
+            {Redundancy::ReasonForNoRedundancy::SiblingCannotBeActive},
+        .failoversNotAllowedReason = FailoversNotAllowedReason::None};
+
+    setupPCIeStorageExpects(expectedProps);
+
+    createManagerAndRun(ProgressPoint::passiveHandlerStartComplete);
+
+    verifyRedundancyProps(manager->getRedundancyInterface(), expectedProps);
+    verifyPersistentData(expectedProps.role,
+                         "Sibling BMC service is not running", true);
+}
+
+/**
+ * @brief Test: BMC becomes passive when sibling is already active
+ */
+TEST_F(ManagerTest, BecomesPassive_SiblingAlreadyActive)
+{
+    // Configure scenario: Sibling is active, this BMC should be passive
+    TestScenarioConfig config{.bmcPosition = 1, .siblingRole = Role::Active};
+    setupTestScenario(config);
+
+    auto& services = mockProviders->getMockServices();
+
+    // No errors
+    EXPECT_CALL(services, logError(errors::error_msg::bmcIsPassiveDueToError,
+                                   errors::Level::Error, _))
+        .Times(0);
+
+    EXPECT_CALL(services,
+                startUnit("obmc-bmc-passive.target", passiveTargetTimeout))
+        .Times(1);
+
+    RedundancyProps expectedProps{
+        .role = Role::Passive,
+        .redEnabled = false,
+        .failoverInProgress = false,
+        .failoversAllowed = false,
+        .failoverImminent = false,
+        .reasonsForNoRedundancy = {},
+        .failoversNotAllowedReason = FailoversNotAllowedReason::None};
+
+    setupPCIeStorageExpects(expectedProps);
+
+    createManagerAndRun(ProgressPoint::passiveHandlerStartComplete);
+
+    verifyRedundancyProps(manager->getRedundancyInterface(), expectedProps);
+    verifyPersistentData(expectedProps.role, "Sibling is already active",
+                         false);
+}
+
+/**
+ * @brief Test: Manager reads previous role from persistent storage on startup
+ */
+TEST_F(ManagerTest, ReadsPreviousRole_OnStartup)
+{
+    using namespace std::chrono_literals;
+
+    // Write previous role to persistent storage before creating Manager
+    data::write(data::key::role, Role::Passive);
+
+    // Configure scenario: Sibling role is Unknown so role determination
+    // falls through to resumePrevious logic
+    TestScenarioConfig config{.bmcPosition = 0, .siblingRole = Role::Unknown};
+    setupTestScenario(config);
+
+    auto& services = mockProviders->getMockServices();
+    auto& sibling = mockProviders->getMockSibling();
+
+    // No errors
+    EXPECT_CALL(services, logError(errors::error_msg::bmcIsPassiveDueToError,
+                                   errors::Level::Error, _))
+        .Times(0);
+
+    // Since previous role was Passive, manager should wait
+    // for sibling role during startup
+    EXPECT_CALL(sibling, waitForSiblingRole()).Times(1);
+
+    EXPECT_CALL(services,
+                startUnit("obmc-bmc-passive.target", passiveTargetTimeout))
+        .Times(1);
+
+    RedundancyProps expectedProps{
+        .role = Role::Passive,
+        .redEnabled = false,
+        .failoverInProgress = false,
+        .failoversAllowed = false,
+        .failoverImminent = false,
+        .reasonsForNoRedundancy = {},
+        .failoversNotAllowedReason = FailoversNotAllowedReason::None};
+
+    setupPCIeStorageExpects(expectedProps);
+
+    createManagerAndRun(ProgressPoint::passiveHandlerStartComplete);
+
+    verifyRedundancyProps(manager->getRedundancyInterface(), expectedProps);
+    verifyPersistentData(expectedProps.role, "Resuming previous role", false);
+}

--- a/redundant-bmc/test/mocks/async_helpers.hpp
+++ b/redundant-bmc/test/mocks/async_helpers.hpp
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <sdbusplus/async.hpp>
+
+namespace test_helpers
+{
+
+/**
+ * @brief Helper to create a completed coroutine task with no return value
+ *
+ * Use this for mocking methods that return sdbusplus::async::task<>
+ */
+inline sdbusplus::async::task<> makeCompletedTask()
+{
+    co_return;
+}
+
+/**
+ * @brief Generic helper to create a completed coroutine task for any type
+ *
+ * @tparam T - The return type
+ * @param value - The value to return
+ * @return Completed task with the specified value
+ */
+template <typename T>
+inline sdbusplus::async::task<T> makeCompletedTask(T value)
+{
+    co_return value;
+}
+
+} // namespace test_helpers

--- a/redundant-bmc/test/mocks/mock_pcie_storage.hpp
+++ b/redundant-bmc/test/mocks/mock_pcie_storage.hpp
@@ -13,7 +13,7 @@ namespace rbmc
  *
  * Mock implementation of PCIeStorage for testing.
  */
-class MockPCIeStorage : public pcie_data::PCIeStorage
+class MockPCIeStorage : public testing::NiceMock<pcie_data::PCIeStorage>
 {
   public:
     MOCK_METHOD(pcie_data::RedundancyState, readState, (), (override));

--- a/redundant-bmc/test/mocks/mock_pcie_storage.hpp
+++ b/redundant-bmc/test/mocks/mock_pcie_storage.hpp
@@ -16,8 +16,6 @@ namespace rbmc
 class MockPCIeStorage : public pcie_data::PCIeStorage
 {
   public:
-    MOCK_METHOD(void, writeState, (const pcie_data::RedundancyState&),
-                (override));
     MOCK_METHOD(pcie_data::RedundancyState, readState, (), (override));
     MOCK_METHOD(void, updateRole, (uint8_t), (override));
     MOCK_METHOD(void, updateRedundancyEnabled, (bool), (override));

--- a/redundant-bmc/test/mocks/mock_providers.hpp
+++ b/redundant-bmc/test/mocks/mock_providers.hpp
@@ -7,6 +7,7 @@
 #include "mock_sibling_reset.hpp"
 #include "mock_sync_interface.hpp"
 #include "providers.hpp"
+#include "test_progress_tracker.hpp"
 
 #include <gmock/gmock.h>
 
@@ -50,6 +51,11 @@ class MockProviders : public Providers
         return &mockPCIeStorage;
     }
 
+    ProgressTracker& getTracker() override
+    {
+        return testProgressTracker;
+    }
+
     // Helpers to get the Mock versions
     MockServices& getMockServices()
     {
@@ -76,12 +82,18 @@ class MockProviders : public Providers
         return mockPCIeStorage;
     }
 
+    TestProgressTracker& getTestTracker()
+    {
+        return testProgressTracker;
+    }
+
   private:
     MockServices mockServices;
     MockSibling mockSibling;
     MockSyncInterface mockSyncInterface;
     MockSiblingReset mockSiblingReset;
     MockPCIeStorage mockPCIeStorage;
+    TestProgressTracker testProgressTracker;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/test/mocks/mock_providers.hpp
+++ b/redundant-bmc/test/mocks/mock_providers.hpp
@@ -23,7 +23,14 @@ namespace rbmc
 class MockProviders : public Providers
 {
   public:
-    MockProviders() = default;
+    MockProviders()
+    {
+        mockServices.setupDefaultBehavior();
+        mockSibling.setupDefaultBehavior();
+        mockSyncInterface.setupDefaultBehavior();
+        mockSiblingReset.setupDefaultBehavior();
+    }
+
     ~MockProviders() override = default;
 
     Services& getServices() override

--- a/redundant-bmc/test/mocks/mock_services.hpp
+++ b/redundant-bmc/test/mocks/mock_services.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "async_helpers.hpp"
 #include "services.hpp"
 
 #include <gmock/gmock.h>
@@ -68,6 +69,61 @@ class MockServices : public testing::NiceMock<Services>
     MOCK_METHOD(void, setRedundancyDetermined, (), (override));
 
     MOCK_METHOD(sdbusplus::async::task<>, waitForSelfPairing, (), (override));
+
+    /**
+     * @brief Setup default behaviors for common test scenarios to save
+     *        setup in the testcases.
+     */
+    void setupDefaultBehavior()
+    {
+        using ::testing::_;
+        using ::testing::Return;
+
+        ON_CALL(*this, init()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, logError(_, _, _)).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, getSystemState())
+            .WillByDefault(Return(SystemState::off));
+
+        ON_CALL(*this, getPeerConnected()).WillByDefault(Return(true));
+
+        ON_CALL(*this, waitForPeerConnection(_)).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, startUnit(_, _)).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, acquireFullHardwareAccess()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, getBMCState()).WillByDefault([]() {
+            using BMCState =
+                sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState;
+            return test_helpers::makeCompletedTask(BMCState::Ready);
+        });
+
+        ON_CALL(*this, doFailoverImminentDelay()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, flushJournal()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, getFWVersion()).WillByDefault(Return("12345678"));
+
+        ON_CALL(*this, waitForSelfPairing()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+    }
 };
 
 } // namespace rbmc

--- a/redundant-bmc/test/mocks/mock_sibling.hpp
+++ b/redundant-bmc/test/mocks/mock_sibling.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "async_helpers.hpp"
 #include "sibling.hpp"
 
 #include <gmock/gmock.h>
@@ -57,6 +58,62 @@ class MockSibling : public testing::NiceMock<Sibling>
         (sdbusplus::common::xyz::openbmc_project::control::Failover::Requester,
          const FailoverOptions&),
         (override));
+
+    /**
+     * @brief Setup default behaviors for common test scenarios to save
+     *        setup in the testcases.
+     */
+    void setupDefaultBehavior()
+    {
+        using ::testing::_;
+        using ::testing::Return;
+        using ::testing::ReturnRef;
+
+        ON_CALL(*this, init()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, getServiceName()).WillByDefault(ReturnRef(serviceName));
+
+        ON_CALL(*this, waitForSiblingUp()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, waitForSiblingRole()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, waitForBMCSteadyState()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, pauseForHeartbeatChange()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, pauseForDataPropagation()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, getBMCState()).WillByDefault([this]() {
+            if (this->alive())
+            {
+                return std::make_optional(BMCState::Ready);
+            }
+            return std::optional<BMCState>{};
+        });
+
+        ON_CALL(*this, getFWVersion()).WillByDefault([this]() {
+            if (this->alive())
+            {
+                return std::make_optional<std::string>("12345678");
+            }
+            return std::optional<std::string>{};
+        });
+    }
+
+  private:
+    std::string serviceName{"xyz.openbmc_project.State.BMC.Redundancy.Sibling"};
 };
 
 } // namespace rbmc

--- a/redundant-bmc/test/mocks/mock_sibling_reset.hpp
+++ b/redundant-bmc/test/mocks/mock_sibling_reset.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "async_helpers.hpp"
 #include "sibling_reset.hpp"
 
 #include <gmock/gmock.h>
@@ -22,6 +23,17 @@ class MockSiblingReset : public testing::NiceMock<SiblingReset>
     MOCK_METHOD(void, assertReset, (), (override));
     MOCK_METHOD(void, releaseReset, (), (override));
     MOCK_METHOD(sdbusplus::async::task<>, toggleReset, (), (override));
+
+    /**
+     * @brief Setup default behaviors for common test scenarios to save
+     *        setup in the testcases.
+     */
+    void setupDefaultBehavior()
+    {
+        ON_CALL(*this, toggleReset()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+    }
 };
 
 } // namespace rbmc

--- a/redundant-bmc/test/mocks/mock_sync_interface.hpp
+++ b/redundant-bmc/test/mocks/mock_sync_interface.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "async_helpers.hpp"
 #include "sync_interface.hpp"
 
 #include <gmock/gmock.h>
@@ -22,6 +23,24 @@ class MockSyncInterface : public testing::NiceMock<SyncInterface>
     MOCK_METHOD(sdbusplus::async::task<bool>, doFullSync, (), (override));
     MOCK_METHOD(sdbusplus::async::task<>, disableBackgroundSync, (),
                 (override));
+
+    /**
+     * @brief Setup default behaviors for common test scenarios to save
+     *        setup in the testcases.
+     */
+    void setupDefaultBehavior()
+    {
+        ON_CALL(*this, doFullSync()).WillByDefault([this]() {
+            fullSyncComplete = true;
+            return test_helpers::makeCompletedTask(true);
+        });
+
+        ON_CALL(*this, disableBackgroundSync()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+    }
+
+    bool fullSyncComplete{false};
 };
 
 } // namespace rbmc

--- a/redundant-bmc/test/mocks/test_progress_tracker.hpp
+++ b/redundant-bmc/test/mocks/test_progress_tracker.hpp
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "progress_tracker.hpp"
+
+#include <set>
+
+namespace rbmc
+{
+
+/**
+ * @class TestProgressTracker
+ */
+class TestProgressTracker : public ProgressTracker
+{
+  public:
+    TestProgressTracker() = default;
+    ~TestProgressTracker() override = default;
+
+    TestProgressTracker(const TestProgressTracker&) = delete;
+    TestProgressTracker& operator=(const TestProgressTracker&) = delete;
+    TestProgressTracker(TestProgressTracker&&) = delete;
+    TestProgressTracker& operator=(TestProgressTracker&&) = delete;
+
+    /**
+     * @brief Track a progress point
+     *
+     * @param[in] event - The point to track
+     */
+    void track(ProgressPoint point) override
+    {
+        progress.insert(point);
+    }
+
+    /**
+     * @brief Check if the progress point has been reached
+     *
+     * @param[in] point - The point to check
+     * @return true if it has been reached
+     */
+    bool hasReached(ProgressPoint point) const override
+    {
+        return progress.contains(point);
+    }
+
+  private:
+    /**
+     * @brief The reached progress points
+     */
+    std::set<ProgressPoint> progress;
+};
+
+} // namespace rbmc


### PR DESCRIPTION
Add testcases for the Manager class where the BMC becomes passive on startup.

The mock classes all have a new setupDefaultBehaviors function to handle returning default values for their coroutine functions so the testcases themselves don't have to specify them unless they want a different one.

Change-Id: I904b66138dc12c89f9afda9925192d162bd9eff3