### PR TITLE
RBMC:  Add getActiveFailoverBlockedReason

### DIFF
--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -2,11 +2,15 @@
 #include "active_role_handler.hpp"
 
 #include "persistent_data.hpp"
+#include "util.hpp"
 
 #include <phosphor-logging/lg2.hpp>
+#include <xyz/openbmc_project/Control/Failover/common.hpp>
 
 namespace rbmc
 {
+
+using Failover = sdbusplus::common::xyz::openbmc_project::control::Failover;
 
 constexpr auto bmcActiveTarget = "obmc-bmc-active.target";
 const std::chrono::minutes siblingHealthTimeout{5};
@@ -255,15 +259,20 @@ sdbusplus::async::task<> ActiveRoleHandler::syncHealthCritical()
     }
 }
 
-// NOLINTNEXTLINE
-auto ActiveRoleHandler::getFailoverBlockedReason(
-    [[maybe_unused]] const FailoverOptions& options)
+auto ActiveRoleHandler::getFailoverBlockedReason(const FailoverOptions& options)
     -> sdbusplus::async::task<fo_blocked::Reason>
 {
-    // At some point in the future we may allow triggering
-    // a failover from the active BMC, but not at the moment.
-    lg2::error("Active BMC cannot trigger a failover now");
-    co_return fo_blocked::Reason::bmcNotPassive;
+    auto force =
+        util::getFailoverOption<bool>(Failover::Options::Force, options)
+            .value_or(false);
+
+    fo_blocked::ActiveInput input{
+        .redundancyEnabled = redundancyInterface.redundancy_enabled(),
+        .failoversAllowed = redundancyInterface.failovers_allowed(),
+        .failoverInProgress = redundancyInterface.failover_in_progress(),
+        .forceOption = force};
+
+    co_return fo_blocked::getActiveFailoverBlockedReason(input);
 }
 
 // NOLINTNEXTLINE

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -343,7 +343,7 @@ auto PassiveRoleHandler::getFailoverBlockedReason(
 
     auto& sibling = providers.getSibling();
 
-    fo_blocked::Input input{
+    fo_blocked::PassiveInput input{
         .siblingAlive = sibling.alive(),
         .siblingState = sibling.getBMCState().value_or(BMCState::NotReady),
         .redundancyEnabled = sibling.getRedundancyEnabled().value_or(false),
@@ -359,7 +359,7 @@ auto PassiveRoleHandler::getFailoverBlockedReason(
         // data from the active BMC.
         .lastKnownRedundancyEnabled = redundancyInterface.redundancy_enabled()};
 
-    co_return fo_blocked::getFailoverBlockedReason(input);
+    co_return fo_blocked::getPassiveFailoverBlockedReason(input);
 }
 
 void PassiveRoleHandler::peerConnectedChange([[maybe_unused]] bool connected)

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -18,38 +18,6 @@ using Failover = sdbusplus::common::xyz::openbmc_project::control::Failover;
 using Redundancy =
     sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy;
 
-namespace util
-{
-
-/**
- * @brief Look for the specified failover option in the
- *   contents of the Options parameter from the StartFailover method.
- *
- * @tparam - The type of the option's value.
- * @param[in] option - The option to look for
- * @param[in] options - The options that were passed into StartFailover
- *
- * @return std::optional<type> - The value, or nullopt if not present
- */
-template <typename T>
-std::optional<T> getFailoverOption(Failover::Options option,
-                                   const FailoverOptions& options)
-{
-    std::optional<T> value;
-    auto it = options.find(Failover::convertOptionsToString(option));
-    if (it != options.end())
-    {
-        if (const T* o = std::get_if<T>(&it->second); o != nullptr)
-        {
-            value = *o;
-        }
-    }
-
-    return value;
-}
-
-} // namespace util
-
 PassiveRoleHandler::PassiveRoleHandler(sdbusplus::async::context& ctx,
                                        Providers& providers,
                                        RedundancyInterface& iface) :

--- a/redundant-bmc/src/redundancy.cpp
+++ b/redundant-bmc/src/redundancy.cpp
@@ -150,7 +150,7 @@ std::string getFailoversNotAllowedDescription(FailoversNotAllowedReason reason)
 namespace fo_blocked
 {
 
-Reason getFailoverBlockedReason(const Input& input)
+Reason getPassiveFailoverBlockedReason(const PassiveInput& input)
 {
     if (input.siblingAlive)
     {

--- a/redundant-bmc/src/redundancy.cpp
+++ b/redundant-bmc/src/redundancy.cpp
@@ -166,14 +166,14 @@ Reason getPassiveFailoverBlockedReason(const PassiveInput& input)
             if (input.forceOption)
             {
                 // Trace it but don't block it.
-                lg2::info(
+                lg2::warning(
                     "The failover 'Force' option is set while failovers are not allowed");
             }
             else if (input.siblingState == BMCState::Quiesced)
             {
                 // If the active BMC is quiesced, it may be stuck in
                 // failovers-not-allowed so don't block it, just trace it.
-                lg2::info(
+                lg2::warning(
                     "The sibling BMC is quiesced while failovers are not allowed");
             }
             else
@@ -214,6 +214,35 @@ Reason getPassiveFailoverBlockedReason(const PassiveInput& input)
     if (input.state != BMCState::Ready)
     {
         return Reason::notAtReady;
+    }
+
+    return Reason::none;
+}
+
+Reason getActiveFailoverBlockedReason(const ActiveInput& input)
+{
+    if (!input.redundancyEnabled)
+    {
+        return Reason::redundancyNotEnabled;
+    }
+
+    if (!input.failoversAllowed)
+    {
+        if (input.forceOption)
+        {
+            // Trace it but don't block it.
+            lg2::warning(
+                "The failover 'Force' option is set while failovers are not allowed");
+        }
+        else
+        {
+            return Reason::failoversNotAllowed;
+        }
+    }
+
+    if (input.failoverInProgress)
+    {
+        return Reason::failoverAlreadyInProgress;
     }
 
     return Reason::none;

--- a/redundant-bmc/src/redundancy.hpp
+++ b/redundant-bmc/src/redundancy.hpp
@@ -89,9 +89,9 @@ namespace fo_blocked
 {
 
 /**
- * @brief Inputs to the is failover blocked  function
+ * @brief Inputs to the passive failover blocked function
  */
-struct Input
+struct PassiveInput
 {
     bool siblingAlive;
     BMCState siblingState;
@@ -125,7 +125,7 @@ enum class Reason
  *
  * @return Reason::none if blocked, else the reason it is.
  */
-Reason getFailoverBlockedReason(const Input& input);
+Reason getPassiveFailoverBlockedReason(const PassiveInput& input);
 
 /**
  * @brief Return the string description of the reason

--- a/redundant-bmc/src/redundancy.hpp
+++ b/redundant-bmc/src/redundancy.hpp
@@ -104,6 +104,17 @@ struct PassiveInput
 };
 
 /**
+ * @brief Inputs to the active failover blocked function
+ */
+struct ActiveInput
+{
+    bool redundancyEnabled;
+    bool failoversAllowed;
+    bool failoverInProgress;
+    bool forceOption;
+};
+
+/**
  * @brief Reasons why a failover is blocked
  */
 enum class Reason
@@ -126,6 +137,15 @@ enum class Reason
  * @return Reason::none if blocked, else the reason it is.
  */
 Reason getPassiveFailoverBlockedReason(const PassiveInput& input);
+
+/**
+ * @brief Returns the reason a failover is blocked by the active BMC
+ *
+ * @param[in] input - The current system states that will be checked.
+ *
+ * @return Reason::none if blocked, else the reason it is.
+ */
+Reason getActiveFailoverBlockedReason(const ActiveInput& input);
 
 /**
  * @brief Return the string description of the reason

--- a/redundant-bmc/src/util.hpp
+++ b/redundant-bmc/src/util.hpp
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "types.hpp"
+
+#include <xyz/openbmc_project/Control/Failover/common.hpp>
 #include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
 
+#include <optional>
 #include <set>
 
 namespace rbmc::util
@@ -58,5 +62,34 @@ void writeExternalRedundancyInput(RedundancyInput input, bool set);
  * @return bool - True if inputs were cleared, false otherwise
  */
 bool clearExternalRedundancyInputs();
+
+/**
+ * @brief Look for the specified failover option in the contents of
+ *        the Options parameter from the StartFailover method.
+ *
+ * @tparam - The type of the option's value.
+ * @param[in] option - The option to look for
+ * @param[in] options - The options that were passed into StartFailover
+ *
+ * @return std::optional<type> - The value, or nullopt if not present
+ */
+template <typename T>
+std::optional<T> getFailoverOption(
+    sdbusplus::common::xyz::openbmc_project::control::Failover::Options option,
+    const FailoverOptions& options)
+{
+    using Failover = sdbusplus::common::xyz::openbmc_project::control::Failover;
+    std::optional<T> value;
+    auto it = options.find(Failover::convertOptionsToString(option));
+    if (it != options.end())
+    {
+        if (const T* o = std::get_if<T>(&it->second); o != nullptr)
+        {
+            value = *o;
+        }
+    }
+
+    return value;
+}
 
 } // namespace rbmc::util

--- a/redundant-bmc/test/redundancy_test.cpp
+++ b/redundant-bmc/test/redundancy_test.cpp
@@ -332,6 +332,50 @@ TEST(RedundancyTest, PassiveFailoverBlockedTest)
     }
 }
 
+TEST(RedundancyTest, ActiveFailoverBlockedTest)
+{
+    rbmc::fo_blocked::ActiveInput golden{.redundancyEnabled = true,
+                                         .failoversAllowed = true,
+                                         .failoverInProgress = false,
+                                         .forceOption = false};
+
+    EXPECT_EQ(rbmc::fo_blocked::getActiveFailoverBlockedReason(golden),
+              rbmc::fo_blocked::Reason::none);
+
+    // Redundancy not enabled
+    {
+        auto input = golden;
+        input.redundancyEnabled = false;
+        EXPECT_EQ(rbmc::fo_blocked::getActiveFailoverBlockedReason(input),
+                  rbmc::fo_blocked::Reason::redundancyNotEnabled);
+    }
+
+    // Failovers not allowed
+    {
+        auto input = golden;
+        input.failoversAllowed = false;
+        EXPECT_EQ(rbmc::fo_blocked::getActiveFailoverBlockedReason(input),
+                  rbmc::fo_blocked::Reason::failoversNotAllowed);
+    }
+
+    // Failovers not allowed but force option set
+    {
+        auto input = golden;
+        input.failoversAllowed = false;
+        input.forceOption = true;
+        EXPECT_EQ(rbmc::fo_blocked::getActiveFailoverBlockedReason(input),
+                  rbmc::fo_blocked::Reason::none);
+    }
+
+    // Failover in progress
+    {
+        auto input = golden;
+        input.failoverInProgress = true;
+        EXPECT_EQ(rbmc::fo_blocked::getActiveFailoverBlockedReason(input),
+                  rbmc::fo_blocked::Reason::failoverAlreadyInProgress);
+    }
+}
+
 TEST(RedundancyTest, GetNoFailoverDescTest)
 {
     EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedDescription(

--- a/redundant-bmc/test/redundancy_test.cpp
+++ b/redundant-bmc/test/redundancy_test.cpp
@@ -239,9 +239,9 @@ TEST(RedundancyTest, GetFailoversNotAllowedDescTest)
               "System state is not off or runtime");
 }
 
-TEST(RedundancyTest, FailoverBlockedTest)
+TEST(RedundancyTest, PassiveFailoverBlockedTest)
 {
-    rbmc::fo_blocked::Input golden{
+    rbmc::fo_blocked::PassiveInput golden{
         .siblingAlive = true,
         .siblingState = rbmc::BMCState::Ready,
         .redundancyEnabled = true,
@@ -251,14 +251,14 @@ TEST(RedundancyTest, FailoverBlockedTest)
         .failoverInProgress = false,
         .lastKnownRedundancyEnabled = true};
 
-    EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(golden),
+    EXPECT_EQ(rbmc::fo_blocked::getPassiveFailoverBlockedReason(golden),
               rbmc::fo_blocked::Reason::none);
 
     // Redundancy not enabled
     {
         auto input = golden;
         input.redundancyEnabled = false;
-        EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
+        EXPECT_EQ(rbmc::fo_blocked::getPassiveFailoverBlockedReason(input),
                   rbmc::fo_blocked::Reason::redundancyNotEnabled);
     }
 
@@ -266,7 +266,7 @@ TEST(RedundancyTest, FailoverBlockedTest)
     {
         auto input = golden;
         input.failoversNotAllowed = true;
-        EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
+        EXPECT_EQ(rbmc::fo_blocked::getPassiveFailoverBlockedReason(input),
                   rbmc::fo_blocked::Reason::failoversNotAllowed);
     }
 
@@ -275,7 +275,7 @@ TEST(RedundancyTest, FailoverBlockedTest)
         auto input = golden;
         input.failoversNotAllowed = true;
         input.forceOption = true;
-        EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
+        EXPECT_EQ(rbmc::fo_blocked::getPassiveFailoverBlockedReason(input),
                   rbmc::fo_blocked::Reason::none);
     }
 
@@ -284,7 +284,7 @@ TEST(RedundancyTest, FailoverBlockedTest)
         auto input = golden;
         input.failoversNotAllowed = true;
         input.siblingState = rbmc::BMCState::Quiesced;
-        EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
+        EXPECT_EQ(rbmc::fo_blocked::getPassiveFailoverBlockedReason(input),
                   rbmc::fo_blocked::Reason::none);
     }
 
@@ -292,7 +292,7 @@ TEST(RedundancyTest, FailoverBlockedTest)
     {
         auto input = golden;
         input.siblingAlive = false;
-        EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
+        EXPECT_EQ(rbmc::fo_blocked::getPassiveFailoverBlockedReason(input),
                   rbmc::fo_blocked::Reason::none);
     }
 
@@ -301,7 +301,7 @@ TEST(RedundancyTest, FailoverBlockedTest)
         auto input = golden;
         input.siblingAlive = false;
         input.failoversNotAllowed = true;
-        EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
+        EXPECT_EQ(rbmc::fo_blocked::getPassiveFailoverBlockedReason(input),
                   rbmc::fo_blocked::Reason::none);
     }
 
@@ -310,7 +310,7 @@ TEST(RedundancyTest, FailoverBlockedTest)
         auto input = golden;
         input.siblingAlive = false;
         input.state = rbmc::BMCState::Quiesced;
-        EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
+        EXPECT_EQ(rbmc::fo_blocked::getPassiveFailoverBlockedReason(input),
                   rbmc::fo_blocked::Reason::notAtReady);
     }
 
@@ -319,7 +319,7 @@ TEST(RedundancyTest, FailoverBlockedTest)
         auto input = golden;
         input.siblingAlive = false;
         input.lastKnownRedundancyEnabled = false;
-        EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
+        EXPECT_EQ(rbmc::fo_blocked::getPassiveFailoverBlockedReason(input),
                   rbmc::fo_blocked::Reason::siblingDeadButRedundancyNotEnabled);
     }
 
@@ -327,7 +327,7 @@ TEST(RedundancyTest, FailoverBlockedTest)
     {
         auto input = golden;
         input.failoverInProgress = true;
-        EXPECT_EQ(rbmc::fo_blocked::getFailoverBlockedReason(input),
+        EXPECT_EQ(rbmc::fo_blocked::getPassiveFailoverBlockedReason(input),
                   rbmc::fo_blocked::Reason::failoverAlreadyInProgress);
     }
 }

--- a/redundant-bmc/test/util_test.cpp
+++ b/redundant-bmc/test/util_test.cpp
@@ -1,10 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
 #include "persistent_data_test_fixture.hpp"
+#include "types.hpp"
 #include "util.hpp"
 
 #include <gtest/gtest.h>
 
 using namespace rbmc::util;
 using namespace rbmc::test;
+using Failover = sdbusplus::common::xyz::openbmc_project::control::Failover;
 
 class UtilTest : public PersistentDataTestFixture
 {};
@@ -94,4 +97,45 @@ TEST_F(UtilTest, ExternalRedundancyInputTest)
     // Clearing when already empty should return false
     cleared = clearExternalRedundancyInputs();
     EXPECT_FALSE(cleared);
+}
+
+TEST_F(UtilTest, GetFailoverOption_EmptyOptions)
+{
+    // Test with empty FailoverOptions
+    rbmc::FailoverOptions options;
+
+    auto result = getFailoverOption<bool>(Failover::Options::Force, options);
+
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(UtilTest, GetFailoverOption_OptionNotPresent)
+{
+    // Test when the requested option is not in the map
+    rbmc::FailoverOptions options{{"SomeOtherOption", true}};
+
+    auto result = getFailoverOption<bool>(Failover::Options::Force, options);
+
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(UtilTest, GetFailoverOption_MultipleOptions)
+{
+    rbmc::FailoverOptions options{
+        {Failover::convertOptionsToString(Failover::Options::Force), true},
+        {Failover::convertOptionsToString(
+             Failover::Options::UseRedundancyInput),
+         "PassiveBMCHardwareProblem"}};
+
+    auto forceResult =
+        getFailoverOption<bool>(Failover::Options::Force, options);
+
+    auto hwProblemResult = getFailoverOption<std::string>(
+        Failover::Options::UseRedundancyInput, options);
+
+    ASSERT_TRUE(forceResult.has_value());
+    EXPECT_TRUE(forceResult.value());
+
+    ASSERT_TRUE(hwProblemResult.has_value());
+    EXPECT_EQ(hwProblemResult.value(), "PassiveBMCHardwareProblem");
 }


### PR DESCRIPTION
Add a new getActiveFailoverBlockedReason function so that the active BMC
can check if a failover should now be blocked, and start calling it from
the ActiveRoleHandler's getFailoverBlockedReason.  This is in
preparation for failovers being started on the active BMC.

While the failover would still be forwarded to the passive BMC and its
getBlockedReason function would run, this gives an earlier, better,
failure.

Move getFailoverOptions into a util.hpp file since multiple places now
need to use it.  Also add some testcases for it.

Tested:
- New unit tests pass
- The active BMC can now block failovers

Change-Id: Ib94023960fe561c3873036b906cc563d9ef695bc
Signed-off-by: Matt Spinler <spinler@us.ibm.com>