### PR TITLE
RBMC: Keep track of in-progress waits

### DIFF
--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -110,7 +110,8 @@ void ActiveRoleHandler::siblingHealthChange(bool alive)
                 peerConnectionTimer.stop();
             }
 
-            siblingHealthTimer.start(siblingHealthTimeout);
+            siblingHealthTimer.start(siblingHealthTimeout,
+                                     WaitOperation::siblingHealthTimer);
 
             // Background sync won't work without a healthy sibling
             ctx.spawn(providers.getSyncInterface().disableBackgroundSync());
@@ -192,7 +193,8 @@ void ActiveRoleHandler::peerConnectionChange(bool connected)
             lg2::warning(
                 "Disabling redundancy in {TIME} minutes if peer connection doesn't come back",
                 "TIME", siblingHealthTimeout.count());
-            peerConnectionTimer.start(siblingHealthTimeout);
+            peerConnectionTimer.start(siblingHealthTimeout,
+                                      WaitOperation::peerConnectionTimer);
         }
     }
 }

--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -32,10 +32,10 @@ class ActiveRoleHandler : public RoleHandler
                       RedundancyInterface& iface) :
         RoleHandler(ctx, providers, iface), redMgr(ctx, providers, iface),
         siblingHealthTimer(
-            ctx,
+            ctx, providers.getWaitTracker(),
             std::bind_front(&ActiveRoleHandler::siblingHealthCritical, this)),
         peerConnectionTimer(
-            ctx,
+            ctx, providers.getWaitTracker(),
             std::bind_front(&ActiveRoleHandler::peerConnectionCritical, this))
     {}
 

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -434,7 +434,8 @@ sdbusplus::async::task<> Manager::method_call(start_failover_t /* unused */,
             // doesn't happen something went very wrong so give it 30 seconds
             // and log an error.
             using namespace std::chrono_literals;
-            resetTimer = std::make_unique<Timer>(ctx, [this, data]() {
+            resetTimer = std::make_unique<
+                Timer>(ctx, providers->getWaitTracker(), [this, data]() {
                 lg2::error(
                     "Timed out waiting for passive BMC to reset this BMC after failover request");
 
@@ -442,7 +443,7 @@ sdbusplus::async::task<> Manager::method_call(start_failover_t /* unused */,
                     errors::error_msg::failoverFailed, errors::Level::Error,
                     data));
             });
-            resetTimer->start(30s);
+            resetTimer->start(30s, WaitOperation::bmcResetTimer);
         }
         catch (const std::exception& e)
         {

--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -34,6 +34,7 @@ rbmc_lib = static_library(
     'sync_interface_impl.cpp',
     'system_state.cpp',
     'util.cpp',
+    'wait_tracker.cpp',
     dependencies: rbmc_deps,
 )
 

--- a/redundant-bmc/src/providers.hpp
+++ b/redundant-bmc/src/providers.hpp
@@ -6,6 +6,7 @@
 #include "sibling.hpp"
 #include "sibling_reset.hpp"
 #include "sync_interface.hpp"
+#include "wait_tracker.hpp"
 
 namespace rbmc
 {
@@ -50,6 +51,20 @@ class Providers
      * @brief Returns the PCIeStorage provider if configured
      */
     virtual pcie_data::PCIeStorage* getPCIeStorage() = 0;
+
+    /**
+     * @brief Returns the WaitTracker
+     */
+    WaitTracker& getWaitTracker()
+    {
+        return waitTracker;
+    }
+
+  protected:
+    /**
+     * @brief The wait tracker for monitoring wait operations
+     */
+    WaitTracker waitTracker;
 };
 
 }; // namespace rbmc

--- a/redundant-bmc/src/providers_impl.hpp
+++ b/redundant-bmc/src/providers_impl.hpp
@@ -37,8 +37,9 @@ class ProvidersImpl : public Providers
      */
     explicit ProvidersImpl(sdbusplus::async::context& ctx) :
         config(config_parser::readConfig()), services(ctx, waitTracker),
-        sibling(ctx, config, services, waitTracker), syncInterface(ctx),
-        siblingReset(ctx, config), pcieStorage(createPCIeStorage())
+        sibling(ctx, config, services, waitTracker),
+        syncInterface(ctx, waitTracker), siblingReset(ctx, config),
+        pcieStorage(createPCIeStorage())
     {}
 
     /**

--- a/redundant-bmc/src/providers_impl.hpp
+++ b/redundant-bmc/src/providers_impl.hpp
@@ -36,7 +36,7 @@ class ProvidersImpl : public Providers
      * @param[in] ctx - The async context object
      */
     explicit ProvidersImpl(sdbusplus::async::context& ctx) :
-        config(config_parser::readConfig()), services(ctx),
+        config(config_parser::readConfig()), services(ctx, waitTracker),
         sibling(ctx, config, services), syncInterface(ctx),
         siblingReset(ctx, config), pcieStorage(createPCIeStorage())
     {}

--- a/redundant-bmc/src/providers_impl.hpp
+++ b/redundant-bmc/src/providers_impl.hpp
@@ -37,7 +37,7 @@ class ProvidersImpl : public Providers
      */
     explicit ProvidersImpl(sdbusplus::async::context& ctx) :
         config(config_parser::readConfig()), services(ctx, waitTracker),
-        sibling(ctx, config, services), syncInterface(ctx),
+        sibling(ctx, config, services, waitTracker), syncInterface(ctx),
         siblingReset(ctx, config), pcieStorage(createPCIeStorage())
     {}
 

--- a/redundant-bmc/src/rbmc_manager_main.cpp
+++ b/redundant-bmc/src/rbmc_manager_main.cpp
@@ -16,6 +16,9 @@ int main()
     std::unique_ptr<rbmc::Providers> providers =
         std::make_unique<rbmc::ProvidersImpl>(ctx);
 
+    providers->getWaitTracker().enableTracking(
+        providers->getServices().getPersistentDataPath());
+
     data::setDataDirectory(providers->getServices().getPersistentDataPath());
 
     rbmc::Manager manager{ctx, std::move(providers)};

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -203,7 +203,8 @@ sdbusplus::async::task<> getLocalBMCInfo(sdbusplus::async::context& ctx,
         auto role = getPDIEnumString(props.role);
         output["Role"] = role;
 
-        rbmc::ServicesImpl services{ctx};
+        rbmc::WaitTracker waitTracker;
+        rbmc::ServicesImpl services{ctx, waitTracker};
         auto pos = services.getBMCPosition();
         auto bmcPos = pos.has_value() ? std::to_string(pos.value()) : "Unknown";
         output["BMC Position"] = bmcPos;

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -8,6 +8,7 @@
 #include "sibling_reset_impl.hpp"
 #include "types.hpp"
 #include "util.hpp"
+#include "wait_tracker.hpp"
 
 #include <CLI/CLI.hpp>
 #include <nlohmann/json.hpp>
@@ -18,6 +19,7 @@
 #include <xyz/openbmc_project/State/BMC/Redundancy/client.hpp>
 #include <xyz/openbmc_project/State/BMC/client.hpp>
 
+#include <algorithm>
 #include <format>
 #include <print>
 
@@ -184,6 +186,21 @@ void addLastFailoverDetails(const std::filesystem::path& dataPath,
     }
 }
 
+void addActiveWaits(nlohmann::ordered_json& output)
+{
+    auto waits = rbmc::WaitTracker::readWaits(data::dataDirPath);
+
+    if (!waits.empty())
+    {
+        nlohmann::json::array_t waitList;
+        for (const auto& wait : waits)
+        {
+            waitList.emplace_back(rbmc::waitOperationToString(wait.operation));
+        }
+        output["Active Waits"] = std::move(waitList);
+    }
+}
+
 // NOLINTNEXTLINE
 sdbusplus::async::task<> getLocalBMCInfo(sdbusplus::async::context& ctx,
                                          bool extended,
@@ -273,6 +290,8 @@ sdbusplus::async::task<> getLocalBMCInfo(sdbusplus::async::context& ctx,
             addExternalRedundancyInputs(output);
         }
 
+        addActiveWaits(output);
+
         if ((role == "Active") && pos.has_value())
         {
             addLastFailoverDetails(services.getPersistentDataPath(),
@@ -344,6 +363,43 @@ void displayBMCInfo(const nlohmann::ordered_json& bmcInfo)
     {
         printJSONParam(name, value);
     }
+}
+
+void displayWaitStatusDetailed()
+{
+    auto waits = rbmc::WaitTracker::readWaits(data::dataDirPath);
+
+    std::println();
+
+    if (waits.empty())
+    {
+        std::println("No active wait operations");
+    }
+    else
+    {
+        std::println("Active Wait Operations");
+        std::println("-----------------------------");
+
+        for (const auto& wait : waits)
+        {
+            std::println();
+            printParam("Operation",
+                       rbmc::waitOperationToString(wait.operation));
+
+            // Calculate elapsed time
+            auto now = std::chrono::steady_clock::now();
+            auto nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                             now.time_since_epoch())
+                             .count();
+            auto elapsedMs = nowMs - wait.startTimeMs;
+            auto elapsedSec = elapsedMs / 1000;
+
+            printParam("Elapsed (s)", elapsedSec);
+            printParam("Timeout (s)", wait.timeoutSeconds);
+        }
+    }
+
+    std::println();
 }
 
 // NOLINTNEXTLINE
@@ -546,6 +602,7 @@ int main(int argc, char** argv)
     CLI::App app{"RBMC Tool"};
     bool info{};
     bool extended{};
+    bool waitStatus{};
     bool resetSibling{};
     bool disableRedundancy{};
     bool enableRedundancy{};
@@ -590,6 +647,10 @@ int main(int argc, char** argv)
     pcieGroup->add_flag("-p, --read-pcie", readPCIe,
                         "Read redundancy state from PCIe MMIO");
 
+    auto* waitGroup = app.add_option_group("Display wait status");
+    waitGroup->add_flag("-w, --wait-status", waitStatus,
+                        "Display detailed active wait operations");
+
     app.require_option(1);
 
     CLI11_PARSE(app, argc, argv);
@@ -601,6 +662,11 @@ int main(int argc, char** argv)
     else if (readPCIe)
     {
         displayPCIeState();
+        return 0;
+    }
+    else if (waitStatus)
+    {
+        displayWaitStatusDetailed();
         return 0;
     }
     else if (resetSibling)

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -662,6 +662,9 @@ sdbusplus::async::task<> ServicesImpl::startUnit(
     std::string state;
     auto end = std::chrono::steady_clock::now() + timeout;
 
+    WaitTracker::WaitGuard guard(waitTracker, WaitOperation::startUnit,
+                                 timeout);
+
     while ((state != "active") && (state != "failed"))
     {
         if (std::chrono::steady_clock::now() > end)
@@ -793,7 +796,13 @@ sdbusplus::async::task<> ServicesImpl::flushJournal() const
 sdbusplus::async::task<> ServicesImpl::waitForSystemInventoryPath()
 {
     using namespace std::chrono_literals;
-    auto end = std::chrono::steady_clock::now() + 3min;
+    constexpr auto timeout = 3min;
+
+    WaitTracker::WaitGuard guard(
+        waitTracker, WaitOperation::systemInventoryPath,
+        std::chrono::duration_cast<std::chrono::seconds>(timeout));
+
+    auto end = std::chrono::steady_clock::now() + timeout;
     bool traced = false;
 
     while (std::chrono::steady_clock::now() < end)
@@ -834,11 +843,16 @@ sdbusplus::async::task<bool> ServicesImpl::checkSystemInventoryStatus()
         co_return false;
     }
 
+    using namespace std::chrono_literals;
+    constexpr auto timeout = 3min;
+
+    WaitTracker::WaitGuard guard(
+        waitTracker, WaitOperation::systemInventoryStatus,
+        std::chrono::duration_cast<std::chrono::seconds>(timeout));
+
     bool tracedWait = false;
     std::string service;
-
-    using namespace std::chrono_literals;
-    auto end = std::chrono::steady_clock::now() + 3min;
+    auto end = std::chrono::steady_clock::now() + timeout;
 
     while (std::chrono::steady_clock::now() < end)
     {
@@ -937,7 +951,7 @@ sdbusplus::async::task<> ServicesImpl::waitForPeerConnection(
     AbortPredicate shouldAbort)
 {
     using namespace std::chrono_literals;
-    std::chrono::minutes timeout{10};
+    constexpr auto timeout = 10min;
 
     lg2::info("waitForPeerConnection initial peerConnected value = {STATUS}",
               "STATUS", peerConnected);
@@ -946,6 +960,10 @@ sdbusplus::async::task<> ServicesImpl::waitForPeerConnection(
     {
         co_return;
     }
+
+    WaitTracker::WaitGuard guard(
+        waitTracker, WaitOperation::peerConnection,
+        std::chrono::duration_cast<std::chrono::seconds>(timeout));
 
     auto end = std::chrono::steady_clock::now() + timeout;
     bool tracedWait = false;
@@ -981,7 +999,13 @@ sdbusplus::async::task<> ServicesImpl::waitForPeerConnection(
 sdbusplus::async::task<> ServicesImpl::waitForSelfPairing()
 {
     using namespace std::chrono_literals;
-    auto end = std::chrono::steady_clock::now() + 30s;
+    constexpr auto timeout = 30s;
+
+    WaitTracker::WaitGuard guard(
+        waitTracker, WaitOperation::selfPairing,
+        std::chrono::duration_cast<std::chrono::seconds>(timeout));
+
+    auto end = std::chrono::steady_clock::now() + timeout;
     bool traced = false;
 
     while (std::chrono::steady_clock::now() < end)

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "services.hpp"
+#include "wait_tracker.hpp"
 
 #include <sdbusplus/async/barrier.hpp>
 #include <xyz/openbmc_project/Provisioning/Provisioning/common.hpp>
@@ -43,8 +44,11 @@ class ServicesImpl : public Services
      * @brief Constructor
      *
      * @param[in] ctx - The async context object
+     * @param[in] waitTracker - The wait tracker
      */
-    explicit ServicesImpl(sdbusplus::async::context& ctx) : ctx(ctx) {}
+    ServicesImpl(sdbusplus::async::context& ctx, WaitTracker& waitTracker) :
+        ctx(ctx), waitTracker(waitTracker)
+    {}
 
     /**
      * @brief Sets up watches on the host state
@@ -293,6 +297,11 @@ class ServicesImpl : public Services
      * @brief The async context object
      */
     sdbusplus::async::context& ctx;
+
+    /**
+     * @brief The wait tracker
+     */
+    WaitTracker& waitTracker;
 
     /**
      * @brief The host state value

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -27,8 +27,9 @@ using PairingIntf =
     sdbusplus::common::xyz::openbmc_project::provisioning::Provisioning;
 
 SiblingImpl::SiblingImpl(sdbusplus::async::context& ctx,
-                         const RedundantBMCConfig& config, Services& services) :
-    ctx(ctx), config(config), services(services),
+                         const RedundantBMCConfig& config, Services& services,
+                         WaitTracker& waitTracker) :
+    ctx(ctx), config(config), services(services), waitTracker(waitTracker),
     objectPath(std::string{RedIntf::namespace_path::value} + '/' +
                RedIntf::namespace_path::sibling_bmc)
 {}
@@ -439,8 +440,13 @@ void SiblingImpl::loadFromPropertyMap(const std::string& interface,
 sdbusplus::async::task<> SiblingImpl::waitForSiblingUp()
 {
     using namespace std::chrono_literals;
+    constexpr auto timeout = 6min;
+
+    WaitTracker::WaitGuard guard(
+        waitTracker, WaitOperation::siblingAlive,
+        std::chrono::duration_cast<std::chrono::seconds>(timeout));
+
     auto start = std::chrono::steady_clock::now();
-    std::chrono::minutes timeout{6};
     auto waiting = false;
 
     while (!alive() && ((std::chrono::steady_clock::now() - start) < timeout))
@@ -463,7 +469,7 @@ sdbusplus::async::task<> SiblingImpl::waitForSiblingUp()
 sdbusplus::async::task<> SiblingImpl::waitForSiblingRole()
 {
     using namespace std::chrono_literals;
-    std::chrono::seconds timeout{10};
+    constexpr auto timeout = 10s;
     bool waiting = false;
 
     auto noRole = [this]() {
@@ -495,8 +501,9 @@ sdbusplus::async::task<> SiblingImpl::waitForSiblingRole()
 sdbusplus::async::task<> SiblingImpl::waitForBMCSteadyState() const
 {
     using namespace std::chrono_literals;
+    constexpr auto timeout = 10min;
+
     auto start = std::chrono::steady_clock::now();
-    std::chrono::minutes timeout{10};
     bool waiting = false;
 
     // If sibling isn't alive don't bother waiting
@@ -508,6 +515,10 @@ sdbusplus::async::task<> SiblingImpl::waitForBMCSteadyState() const
     auto steadyState = [](BMCState state) {
         return (state == BMCState::Ready) || (state == BMCState::Quiesced);
     };
+
+    WaitTracker::WaitGuard guard(
+        waitTracker, WaitOperation::siblingBMCSteadyState,
+        std::chrono::duration_cast<std::chrono::seconds>(timeout));
 
     while (!steadyState(bmcState.state) &&
            ((std::chrono::steady_clock::now() - start) < timeout))

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -3,6 +3,7 @@
 #include "config_data.hpp"
 #include "services.hpp"
 #include "sibling.hpp"
+#include "wait_tracker.hpp"
 
 #include <sdbusplus/async/barrier.hpp>
 
@@ -42,9 +43,11 @@ class SiblingImpl : public Sibling
      * @param[in] ctx - The async context object
      * @param[in] config - The redundant BMC configuration
      * @param[in] services - The Services provider for BMC position lookup
+     * @param[in] waitTracker - The wait tracker
      */
-    explicit SiblingImpl(sdbusplus::async::context& ctx,
-                         const RedundantBMCConfig& config, Services& services);
+    SiblingImpl(sdbusplus::async::context& ctx,
+                const RedundantBMCConfig& config, Services& services,
+                WaitTracker& waitTracker);
 
     /**
      * @brief Returns if the sibling BMC has a good heartbeat
@@ -395,6 +398,11 @@ class SiblingImpl : public Sibling
      * @brief The Services provider for system information
      */
     Services& services;
+
+    /**
+     * @brief The wait tracker
+     */
+    WaitTracker& waitTracker;
 
     /**
      * @brief The sibling's D-Bus service name.

--- a/redundant-bmc/src/sync_interface_impl.cpp
+++ b/redundant-bmc/src/sync_interface_impl.cpp
@@ -14,8 +14,11 @@ using Mapper = sdbusplus::client::xyz::openbmc_project::ObjectMapper<>;
 // NOLINTNEXTLINE
 sdbusplus::async::task<bool> SyncInterfaceImpl::doFullSync()
 {
+    using namespace std::chrono_literals;
     using SyncStatus = SyncBMCData::FullSyncStatus;
     SyncStatus status = SyncStatus::Unknown;
+
+    constexpr auto timeout = 60min;
 
     try
     {
@@ -52,8 +55,11 @@ sdbusplus::async::task<bool> SyncInterfaceImpl::doFullSync()
 
         status = co_await sync.full_sync_status();
 
+        auto end = std::chrono::steady_clock::now() + timeout;
+
         while ((status == SyncStatus::FullSyncInProgress) &&
-               !ctx.stop_requested())
+               !ctx.stop_requested() &&
+               (std::chrono::steady_clock::now() < end))
         {
             using PropertyMap =
                 std::unordered_map<std::string, SyncBMCData::PropertiesVariant>;
@@ -65,6 +71,15 @@ sdbusplus::async::task<bool> SyncInterfaceImpl::doFullSync()
             {
                 status = std::get<SyncStatus>(it->second);
             }
+        }
+
+        if (status == SyncStatus::FullSyncInProgress &&
+            std::chrono::steady_clock::now() >= end)
+        {
+            lg2::error("Full sync timed out after {TIMEOUT} minutes", "TIMEOUT",
+                       timeout.count());
+            fullSyncInProgress = false;
+            co_return false;
         }
     }
     catch (const std::exception& e)

--- a/redundant-bmc/src/sync_interface_impl.cpp
+++ b/redundant-bmc/src/sync_interface_impl.cpp
@@ -57,6 +57,10 @@ sdbusplus::async::task<bool> SyncInterfaceImpl::doFullSync()
 
         auto end = std::chrono::steady_clock::now() + timeout;
 
+        WaitTracker::WaitGuard guard(
+            waitTracker, WaitOperation::fullSync,
+            std::chrono::duration_cast<std::chrono::seconds>(timeout));
+
         while ((status == SyncStatus::FullSyncInProgress) &&
                !ctx.stop_requested() &&
                (std::chrono::steady_clock::now() < end))

--- a/redundant-bmc/src/sync_interface_impl.hpp
+++ b/redundant-bmc/src/sync_interface_impl.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "sync_interface.hpp"
+#include "wait_tracker.hpp"
 
 namespace rbmc
 {
@@ -24,8 +25,11 @@ class SyncInterfaceImpl : public SyncInterface
      * @brief Constructor
      *
      * @param[in] ctx - The async context object
+     * @param[in] waitTracker - The wait tracker
      */
-    explicit SyncInterfaceImpl(sdbusplus::async::context& ctx) : ctx(ctx)
+    explicit SyncInterfaceImpl(sdbusplus::async::context& ctx,
+                               WaitTracker& waitTracker) :
+        ctx(ctx), waitTracker(waitTracker)
     {
         ctx.spawn(watchSyncEventsHealthPropertyChanged());
     }
@@ -63,6 +67,11 @@ class SyncInterfaceImpl : public SyncInterface
      * @brief The name of the sync daemon's D-Bus service.
      */
     std::string syncService;
+
+    /**
+     * @brief The wait tracker
+     */
+    WaitTracker& waitTracker;
 };
 
 }; // namespace rbmc

--- a/redundant-bmc/src/timer.hpp
+++ b/redundant-bmc/src/timer.hpp
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "wait_tracker.hpp"
+
 #include <sdbusplus/async.hpp>
+
+#include <memory>
 
 namespace rbmc
 {
@@ -20,10 +24,12 @@ class Timer :
      * @brief Constructor
      *
      * @param[in] ctx - The async context object
+     * @param[in] tracker - WaitTracker for tracking timer waits
      * @param[in] callback - Function to call on expiration
      */
-    Timer(sdbusplus::async::context& ctx, std::function<void()>&& callback) :
-        context_ref(ctx), callback(std::move(callback))
+    Timer(sdbusplus::async::context& ctx, WaitTracker& tracker,
+          std::function<void()>&& callback) :
+        context_ref(ctx), waitTracker(tracker), callback(std::move(callback))
     {}
 
     /**
@@ -36,6 +42,7 @@ class Timer :
         Timer* t = static_cast<Timer*>(userdata);
         t->callback();
         t->source.reset();
+        t->waitGuard.reset();
         return 0;
     }
 
@@ -43,14 +50,22 @@ class Timer :
      * @brief Starts the timer
      *
      * @param[in] timeout - The timeout value
+     * @param[in] operation - Wait operation for tracking
      */
-    void start(const std::chrono::microseconds& timeout)
+    void start(const std::chrono::microseconds& timeout,
+               WaitOperation operation)
     {
         source.reset();
+        waitGuard.reset();
 
         auto s = get_event_loop(ctx).add_oneshot_timer(Timer::handler, this,
                                                        timeout);
         source = std::make_unique<Source>(std::move(s));
+
+        auto timeoutSec =
+            std::chrono::duration_cast<std::chrono::seconds>(timeout);
+        waitGuard = std::make_unique<WaitTracker::WaitGuard>(
+            waitTracker, operation, timeoutSec);
     }
 
     /**
@@ -59,6 +74,7 @@ class Timer :
     void stop()
     {
         source.reset();
+        waitGuard.reset();
     }
 
     /**
@@ -84,6 +100,11 @@ class Timer :
     };
 
     /**
+     * @brief The wait tracker object
+     */
+    WaitTracker& waitTracker;
+
+    /**
      * @brief Function to run on timeout
      */
     std::function<void()> callback;
@@ -92,6 +113,11 @@ class Timer :
      * @brief Event source object
      */
     std::unique_ptr<Source> source;
+
+    /**
+     * @brief RAII guard for wait tracking
+     */
+    std::unique_ptr<WaitTracker::WaitGuard> waitGuard;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/wait_tracker.cpp
+++ b/redundant-bmc/src/wait_tracker.cpp
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "wait_tracker.hpp"
+
+#include <nlohmann/json.hpp>
+#include <phosphor-logging/lg2.hpp>
+
+#include <fstream>
+
+namespace rbmc
+{
+
+constexpr auto waitStatusFileName = "wait_status.json";
+
+std::string waitOperationToString(WaitOperation op)
+{
+    std::string str{"Unknown"};
+    switch (op)
+    {
+        case WaitOperation::systemInventoryPath:
+            str = "SystemInventoryPath";
+            break;
+        case WaitOperation::systemInventoryStatus:
+            str = "SystemInventoryStatus";
+            break;
+        case WaitOperation::peerConnection:
+            str = "PeerConnection";
+            break;
+        case WaitOperation::selfPairing:
+            str = "SelfPairing";
+            break;
+        case WaitOperation::startUnit:
+            str = "StartUnit";
+            break;
+        case WaitOperation::siblingAlive:
+            str = "SiblingAlive";
+            break;
+        case WaitOperation::siblingBMCSteadyState:
+            str = "SiblingBMCSteadyState";
+            break;
+        case WaitOperation::siblingHealthTimer:
+            str = "SiblingHealthTimer";
+            break;
+        case WaitOperation::peerConnectionTimer:
+            str = "PeerConnectionTimer";
+            break;
+        case WaitOperation::bmcResetTimer:
+            str = "BMCResetTimer";
+            break;
+        case WaitOperation::fullSync:
+            str = "FullSync";
+            break;
+    }
+
+    return str;
+}
+
+WaitTracker::WaitTracker(const std::filesystem::path& dirPath) :
+    filePath(dirPath.empty() ? std::filesystem::path{}
+                             : dirPath / waitStatusFileName),
+    enabled(!filePath.empty())
+{
+    // Clear any stale wait data
+    if (enabled)
+    {
+        updateFile();
+    }
+}
+
+void WaitTracker::enableTracking(const std::filesystem::path& dirPath)
+{
+    if (enabled)
+    {
+        return;
+    }
+
+    if (dirPath.empty())
+    {
+        lg2::warning("Cannot enable WaitTracker with empty directory path");
+        return;
+    }
+
+    filePath = dirPath / waitStatusFileName;
+    enabled = true;
+
+    // Clear any stale wait data
+    updateFile();
+}
+
+uint64_t WaitTracker::registerWait(WaitOperation operation,
+                                   std::chrono::seconds timeout)
+{
+    if (!enabled)
+    {
+        return 0;
+    }
+
+    uint64_t id = counter++;
+
+    // Handle a rollover
+    if (counter == 0)
+    {
+        counter = 1;
+    }
+
+    auto now = std::chrono::steady_clock::now().time_since_epoch();
+    auto nowMs =
+        std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
+
+    activeWaits[id] = WaitInfo{operation, static_cast<uint64_t>(nowMs),
+                               static_cast<uint32_t>(timeout.count())};
+    updateFile();
+
+    return id;
+}
+
+void WaitTracker::unregisterWait(uint64_t id)
+{
+    if (!enabled || id == 0)
+    {
+        return;
+    }
+
+    activeWaits.erase(id);
+    updateFile();
+}
+
+void WaitTracker::updateFile()
+{
+    try
+    {
+        // If no active waits, just remove the file
+        if (activeWaits.empty())
+        {
+            if (std::filesystem::exists(filePath))
+            {
+                std::filesystem::remove(filePath);
+            }
+            return;
+        }
+
+        nlohmann::json j;
+        nlohmann::json::array_t waitsArray;
+
+        for (const auto& [id, info] : activeWaits)
+        {
+            nlohmann::json waitObj;
+            waitObj["id"] = id;
+            waitObj["operationEnum"] = static_cast<int>(info.operation);
+            waitObj["startTimeMs"] = info.startTimeMs;
+            waitObj["timeoutSeconds"] = info.timeoutSeconds;
+            waitsArray.push_back(waitObj);
+        }
+
+        j["waits"] = waitsArray;
+
+        // Create parent directory if it doesn't exist
+        std::filesystem::create_directories(filePath.parent_path());
+
+        std::ofstream ofs(filePath);
+        if (!ofs)
+        {
+            lg2::warning("Failed to open wait tracker file {PATH}", "PATH",
+                         filePath);
+            return;
+        }
+
+        ofs << j.dump(4);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::warning("Failed to update wait tracker file: {ERROR}", "ERROR", e);
+    }
+}
+
+std::vector<WaitTracker::WaitInfo> WaitTracker::readWaits(
+    const std::filesystem::path& dirPath)
+{
+    std::vector<WaitInfo> result;
+
+    auto filePath = dirPath / waitStatusFileName;
+
+    try
+    {
+        if (!std::filesystem::exists(filePath))
+        {
+            return result;
+        }
+
+        std::ifstream ifs(filePath);
+        if (!ifs)
+        {
+            lg2::error("Could not open wait tracking file {FILE}", "FILE",
+                       filePath);
+            return result;
+        }
+
+        nlohmann::json j;
+        ifs >> j;
+
+        if (!j.contains("waits") || !j["waits"].is_array())
+        {
+            return result;
+        }
+
+        for (const auto& waitObj : j["waits"])
+        {
+            WaitInfo info;
+            info.operation =
+                static_cast<WaitOperation>(waitObj["operationEnum"].get<int>());
+            info.startTimeMs = waitObj["startTimeMs"].get<uint64_t>();
+            info.timeoutSeconds = waitObj["timeoutSeconds"].get<uint32_t>();
+            result.push_back(info);
+        }
+    }
+    catch (const std::exception& e)
+    {
+        lg2::warning("Failed to read wait tracker file: {ERROR}", "ERROR", e);
+    }
+
+    return result;
+}
+
+} // namespace rbmc

--- a/redundant-bmc/src/wait_tracker.hpp
+++ b/redundant-bmc/src/wait_tracker.hpp
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <chrono>
+#include <filesystem>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace rbmc
+{
+
+enum class WaitOperation
+{
+    systemInventoryPath,
+    systemInventoryStatus,
+    peerConnection,
+    selfPairing,
+    startUnit,
+    siblingAlive,
+    siblingBMCSteadyState,
+    siblingHealthTimer,
+    peerConnectionTimer,
+    bmcResetTimer,
+    fullSync
+};
+
+/**
+ * @brief Convert the enum to a human readable string
+ *
+ * @param[in] op - The operation
+ *
+ * @return std::string - The string version
+ */
+std::string waitOperationToString(WaitOperation op);
+
+class WaitTracker
+{
+  public:
+    struct WaitInfo
+    {
+        WaitOperation operation;
+        uint64_t startTimeMs; // epoch milliseconds
+        uint32_t timeoutSeconds;
+    };
+
+    /**
+     * @brief Constructor
+     *
+     * Tracking isn't enabled if an empty path is passed in, and can
+     * then be enabled later with enableTracking.
+     *
+     * @param dirPath Directory path where wait_status.json will be created.
+     */
+    explicit WaitTracker(const std::filesystem::path& dirPath = "");
+
+    /**
+     * @brief Enable tracking by setting the directory path
+     *
+     * Necessary if the path wasn't used during construction.
+     *
+     * @param dirPath Directory path where wait_status.json will be created
+     */
+    void enableTracking(const std::filesystem::path& dirPath);
+
+    /**
+     * @brief RAII guard that auto-registers/unregisters waits around
+     *        its lifetime.
+     */
+    class WaitGuard
+    {
+      public:
+        /**
+         * @brief Constructor
+         *
+         * @param[in] tracker - The WaitTracker object
+         * @param[in] operation - The wait operation
+         * @param[in] timeout - The timeout for this wait
+         */
+        WaitGuard(WaitTracker& tracker, WaitOperation operation,
+                  std::chrono::seconds timeout) :
+            tracker(tracker), id(tracker.registerWait(operation, timeout))
+        {}
+
+        /**
+         * @brief Unregisters the wait on destruction
+         */
+        ~WaitGuard()
+        {
+            tracker.unregisterWait(id);
+        }
+
+        WaitGuard(const WaitGuard&) = delete;
+        WaitGuard& operator=(const WaitGuard&) = delete;
+        WaitGuard(WaitGuard&&) = delete;
+        WaitGuard& operator=(WaitGuard&&) = delete;
+
+      private:
+        WaitTracker& tracker;
+        uint64_t id;
+    };
+
+    /**
+     * @brief Read current waits from file
+     *
+     * Used by rbmctool.
+     *
+     * @param dirPath Directory path where wait_status.json is located
+     *
+     * @return Vector of active waits
+     */
+    static std::vector<WaitInfo> readWaits(
+        const std::filesystem::path& dirPath);
+
+  private:
+    /**
+     * @brief Registers the start of a wait
+     *
+     * @param[in] operation - The wait operation
+     * @param[in] timeout - The wait timeout
+     * @return The wait ID (0 if tracking disabled)
+     */
+    uint64_t registerWait(WaitOperation operation,
+                          std::chrono::seconds timeout);
+
+    /**
+     * @brief Unregisters the wait (it's complete)
+     *
+     * @param[in] id - The ID of the wait to unregister
+     */
+    void unregisterWait(uint64_t id);
+
+    /**
+     * @brief Updates the underlying file with all active waits
+     */
+    void updateFile();
+
+    /**
+     * @brief The file where waits are persisted
+     */
+    std::filesystem::path filePath;
+
+    /**
+     * @brief The active waits
+     *
+     * The key is just an incrementing ID
+     */
+    std::map<uint64_t, WaitInfo> activeWaits;
+
+    /**
+     * @brief If wait tracking is enabled
+     */
+    bool enabled{false};
+
+    /**
+     * @brief Used for generating the IDs.
+     */
+    uint64_t counter{1};
+};
+
+} // namespace rbmc

--- a/redundant-bmc/test/meson.build
+++ b/redundant-bmc/test/meson.build
@@ -12,6 +12,7 @@ test(
         'role_determination_test.cpp',
         'system_state_test.cpp',
         'util_test.cpp',
+        'wait_tracker_test.cpp',
         dependencies: [
             gtest,
             gmock,

--- a/redundant-bmc/test/wait_tracker_test.cpp
+++ b/redundant-bmc/test/wait_tracker_test.cpp
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "wait_tracker.hpp"
+
+#include <nlohmann/json.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+namespace rbmc
+{
+
+class WaitTrackerTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        std::string templatePath = (std::filesystem::temp_directory_path() /
+                                    "wait_tracker_test_XXXXXX")
+                                       .string();
+        char* tempDir = mkdtemp(templatePath.data());
+        if (tempDir == nullptr)
+        {
+            throw std::runtime_error("Failed to create temp directory");
+        }
+        testDir = tempDir;
+        testFile = testDir / "wait_status.json";
+    }
+
+    void TearDown() override
+    {
+        std::filesystem::remove_all(testDir);
+    }
+
+    std::filesystem::path testDir;
+    std::filesystem::path testFile;
+};
+
+TEST_F(WaitTrackerTest, DisabledWhenPathEmpty)
+{
+    WaitTracker tracker("");
+
+    // Should not create any files
+    EXPECT_FALSE(std::filesystem::exists(testFile));
+
+    // Guard should work but not write anything
+    {
+        WaitTracker::WaitGuard guard(tracker, WaitOperation::peerConnection,
+                                     std::chrono::seconds{10});
+    }
+
+    EXPECT_FALSE(std::filesystem::exists(testFile));
+}
+
+TEST_F(WaitTrackerTest, SingleWaitRegistration)
+{
+    WaitTracker tracker(testDir);
+
+    {
+        WaitTracker::WaitGuard guard(tracker, WaitOperation::peerConnection,
+                                     std::chrono::seconds{60});
+
+        // File should exist
+        ASSERT_TRUE(std::filesystem::exists(testFile));
+
+        // Read and verify
+        auto waits = WaitTracker::readWaits(testDir);
+        ASSERT_EQ(waits.size(), 1);
+        EXPECT_EQ(waits[0].operation, WaitOperation::peerConnection);
+        EXPECT_EQ(waits[0].timeoutSeconds, 60);
+        EXPECT_GT(waits[0].startTimeMs, 0);
+    }
+
+    // After guard destroyed, wait should be removed
+    auto waits = WaitTracker::readWaits(testDir);
+    EXPECT_EQ(waits.size(), 0);
+}
+
+TEST_F(WaitTrackerTest, MultipleParallelWaits)
+{
+    WaitTracker tracker(testDir);
+
+    WaitTracker::WaitGuard guard1(tracker, WaitOperation::peerConnection,
+                                  std::chrono::seconds{60});
+    WaitTracker::WaitGuard guard2(tracker, WaitOperation::siblingAlive,
+                                  std::chrono::seconds{360});
+    WaitTracker::WaitGuard guard3(tracker, WaitOperation::systemInventoryPath,
+                                  std::chrono::seconds{180});
+
+    auto waits = WaitTracker::readWaits(testDir);
+    ASSERT_EQ(waits.size(), 3);
+
+    // Verify all three operations are present
+    std::set<WaitOperation> ops;
+    for (const auto& wait : waits)
+    {
+        ops.insert(wait.operation);
+    }
+
+    EXPECT_TRUE(ops.contains(WaitOperation::peerConnection));
+    EXPECT_TRUE(ops.contains(WaitOperation::siblingAlive));
+    EXPECT_TRUE(ops.contains(WaitOperation::systemInventoryPath));
+}
+
+TEST_F(WaitTrackerTest, WaitOperationToString)
+{
+    EXPECT_EQ(waitOperationToString(WaitOperation::peerConnection),
+              "PeerConnection");
+    EXPECT_EQ(waitOperationToString(WaitOperation::siblingAlive),
+              "SiblingAlive");
+    EXPECT_EQ(waitOperationToString(WaitOperation::systemInventoryPath),
+              "SystemInventoryPath");
+    EXPECT_EQ(waitOperationToString(WaitOperation::siblingHealthTimer),
+              "SiblingHealthTimer");
+}
+
+TEST_F(WaitTrackerTest, ReadNonexistentFile)
+{
+    auto waits = WaitTracker::readWaits(testDir);
+    EXPECT_EQ(waits.size(), 0);
+}
+
+TEST_F(WaitTrackerTest, ReadCorruptedFile)
+{
+    // Write invalid JSON
+    std::ofstream ofs(testFile);
+    ofs << "not valid json{{{";
+    ofs.close();
+
+    auto waits = WaitTracker::readWaits(testDir);
+    EXPECT_EQ(waits.size(), 0);
+}
+
+TEST_F(WaitTrackerTest, ElapsedTimeCalculation)
+{
+    WaitTracker tracker(testDir);
+
+    {
+        WaitTracker::WaitGuard guard(tracker, WaitOperation::peerConnection,
+                                     std::chrono::seconds{60});
+
+        // Wait a bit
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+        auto waits = WaitTracker::readWaits(testDir);
+        ASSERT_EQ(waits.size(), 1);
+
+        auto now = std::chrono::steady_clock::now().time_since_epoch();
+        auto nowMs =
+            std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
+        auto elapsedMs = nowMs - waits[0].startTimeMs;
+
+        // Should be at least 10ms
+        EXPECT_GE(elapsedMs, 10);
+    }
+}
+
+TEST_F(WaitTrackerTest, SequentialWaits)
+{
+    WaitTracker tracker(testDir);
+
+    // First wait
+    {
+        WaitTracker::WaitGuard guard(tracker, WaitOperation::peerConnection,
+                                     std::chrono::seconds{60});
+        auto waits = WaitTracker::readWaits(testDir);
+        EXPECT_EQ(waits.size(), 1);
+    }
+
+    // After first wait completes, should be empty
+    auto waits = WaitTracker::readWaits(testDir);
+    EXPECT_EQ(waits.size(), 0);
+
+    // Second wait
+    {
+        WaitTracker::WaitGuard guard(tracker, WaitOperation::siblingAlive,
+                                     std::chrono::seconds{360});
+        waits = WaitTracker::readWaits(testDir);
+        EXPECT_EQ(waits.size(), 1);
+        EXPECT_EQ(waits[0].operation, WaitOperation::siblingAlive);
+    }
+
+    // After second wait completes, should be empty again
+    waits = WaitTracker::readWaits(testDir);
+    EXPECT_EQ(waits.size(), 0);
+}
+
+TEST_F(WaitTrackerTest, FileContainsCorrectJSON)
+{
+    WaitTracker tracker(testDir);
+
+    {
+        WaitTracker::WaitGuard guard(tracker, WaitOperation::peerConnection,
+                                     std::chrono::seconds{120});
+
+        // Read file directly and verify JSON structure
+        std::ifstream ifs(testFile);
+        ASSERT_TRUE(ifs.is_open());
+
+        nlohmann::json j;
+        ifs >> j;
+
+        ASSERT_TRUE(j.contains("waits"));
+        ASSERT_TRUE(j["waits"].is_array());
+        ASSERT_EQ(j["waits"].size(), 1);
+
+        auto& wait = j["waits"][0];
+        EXPECT_TRUE(wait.contains("id"));
+        EXPECT_TRUE(wait.contains("operationEnum"));
+        EXPECT_TRUE(wait.contains("startTimeMs"));
+        EXPECT_TRUE(wait.contains("timeoutSeconds"));
+
+        EXPECT_EQ(wait["timeoutSeconds"].get<uint32_t>(), 120);
+    }
+}
+
+TEST_F(WaitTrackerTest, ConstructorClearsStaleData)
+{
+    // Simulate stale data from a previous run by creating a file with waits
+    {
+        WaitTracker tracker1(testDir);
+        WaitTracker::WaitGuard guard(tracker1, WaitOperation::peerConnection,
+                                     std::chrono::seconds{60});
+
+        // Verify wait is registered
+        auto waits = WaitTracker::readWaits(testDir);
+        ASSERT_EQ(waits.size(), 1);
+    }
+    // Guard destroyed but file still has data
+
+    // Create new tracker - should clear stale data
+    WaitTracker tracker2(testDir);
+
+    // File should be removed when no active waits
+    EXPECT_FALSE(std::filesystem::exists(testFile));
+    auto waits = WaitTracker::readWaits(testDir);
+    EXPECT_EQ(waits.size(), 0);
+}
+
+TEST_F(WaitTrackerTest, EnableTrackingAfterConstruction)
+{
+    WaitTracker tracker("");
+
+    EXPECT_FALSE(std::filesystem::exists(testFile));
+
+    {
+        WaitTracker::WaitGuard guard(tracker, WaitOperation::peerConnection,
+                                     std::chrono::seconds{60});
+        EXPECT_FALSE(std::filesystem::exists(testFile));
+    }
+
+    tracker.enableTracking(testDir);
+
+    {
+        WaitTracker::WaitGuard guard(tracker, WaitOperation::siblingAlive,
+                                     std::chrono::seconds{120});
+        EXPECT_TRUE(std::filesystem::exists(testFile));
+
+        auto waits = WaitTracker::readWaits(testDir);
+        ASSERT_EQ(waits.size(), 1);
+        EXPECT_EQ(waits[0].operation, WaitOperation::siblingAlive);
+        EXPECT_EQ(waits[0].timeoutSeconds, 120);
+    }
+}
+
+TEST_F(WaitTrackerTest, EnableTrackingWithEmptyPath)
+{
+    WaitTracker tracker("");
+
+    tracker.enableTracking("");
+
+    {
+        WaitTracker::WaitGuard guard(tracker, WaitOperation::peerConnection,
+                                     std::chrono::seconds{60});
+        EXPECT_FALSE(std::filesystem::exists(testFile));
+    }
+}
+
+} // namespace rbmc


### PR DESCRIPTION
Introduce the ability to keep track of when the code is waiting for something to happen, which happens a lot while dealing with redundant BMCs.

The active waits are then stored in a separate file so rbmctool can display them.

This is done with a new 'WaitTracker' class, and a WaitGuard class that uses RAII to have an active wait while it is in scope.

rbmctool can then show them like:

```
Local BMC
-----------------------------
Role:                 Active
BMC Position:         0
Redundancy Enabled:   false
BMC State:            NotReady
Failovers Allowed:    false
Failover In Progress: false
FW Version Hash:      31BE0048
Peer Connected:       NotDetermined
Role Reason:          Resuming previous role
Reasons for no BMC redundancy:
    In transition
Active Waits:  <--------------------------------- 
    StartUnit
Last failover driven by this BMC:
    Requester: Tool
    Timestamp: 2026-06-24 15:59:11 UTC

```