### PR TITLE
RBMC: On passive, wait for full sync before F.O.

### DIFF
--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -121,6 +121,23 @@ class ActiveRoleHandler : public RoleHandler
      */
     sdbusplus::async::task<> failoverDetermineRedundancy();
 
+    /**
+     * @brief Stops all property watches/callbacks
+     */
+    void stopAllWatches() override
+    {
+        // Stop sibling watches
+        siblingHealthTimer.stop();
+        providers.getSibling().clearCallbacks(Role::Active);
+
+        // Stop sync health watch
+        providers.getSyncInterface().stopSyncHealthWatch(Role::Active);
+
+        // Stop peer connected watch
+        peerConnectionTimer.stop();
+        providers.getServices().removePeerConnectedCallback(Role::Active);
+    }
+
   private:
     /**
      * @brief Starts all property watches/callbacks
@@ -149,23 +166,6 @@ class ActiveRoleHandler : public RoleHandler
         providers.getServices().addPeerConnectedCallback(
             Role::Active,
             std::bind_front(&ActiveRoleHandler::peerConnectionChange, this));
-    }
-
-    /**
-     * @brief Stops all property watches/callbacks
-     */
-    inline void stopAllWatches()
-    {
-        // Stop sibling watches
-        siblingHealthTimer.stop();
-        providers.getSibling().clearCallbacks(Role::Active);
-
-        // Stop sync health watch
-        providers.getSyncInterface().stopSyncHealthWatch(Role::Active);
-
-        // Stop peer connected watch
-        peerConnectionTimer.stop();
-        providers.getServices().removePeerConnectedCallback(Role::Active);
     }
 
     using BMCState =

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -452,6 +452,25 @@ sdbusplus::async::task<> Manager::method_call(start_failover_t /* unused */,
     }
 }
 
+sdbusplus::async::task<> Manager::preFailoverFullSyncCheck()
+{
+    if (!providers->getSyncInterface().isFullSyncInProgress())
+    {
+        co_return;
+    }
+
+    lg2::info(
+        "Waiting for in progress full sync to complete before continuing failover");
+
+    using namespace std::chrono_literals;
+    while (providers->getSyncInterface().isFullSyncInProgress())
+    {
+        co_await sdbusplus::async::sleep_for(ctx, 500ms);
+    }
+
+    lg2::info("Full sync completed, proceeding with failover");
+}
+
 // NOLINTNEXTLINE
 sdbusplus::async::task<> Manager::doFailoverFromPassive(Requester requester)
 {
@@ -461,9 +480,8 @@ sdbusplus::async::task<> Manager::doFailoverFromPassive(Requester requester)
     // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
     co_await providers->getSyncInterface().disableBackgroundSync();
 
-    // Stop handling as a passive BMC. This BMC no longer needs to
-    // watch for any changes from the one we're about to reset.
-    handler.reset();
+    // Tell PassiveRoleHandler to stop watching the active BMC
+    handler->stopAllWatches();
 
     redundancyInterface.failover_imminent(true);
 
@@ -471,7 +489,14 @@ sdbusplus::async::task<> Manager::doFailoverFromPassive(Requester requester)
     // failover imminent before continuing.
     co_await providers->getServices().doFailoverImminentDelay();
 
+    // If somehow the full sync is still running now, let it complete.
+    // Cannot delete PassiveRoleHandler until it does, or it can crash us.
+    co_await preFailoverFullSyncCheck();
+
     redundancyInterface.failover_imminent(false);
+
+    // Stop handling as a passive BMC.
+    handler.reset();
 
     // Reset the active so it can come back as passive.
     // If this were to throw, let it restart the app.

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -150,6 +150,12 @@ class Manager :
         Requester requester, const FailoverOptions& options);
 
     /**
+     * @brief Waits for an in-progress full sync to complete
+     *        before proceeding with a failover.
+     */
+    sdbusplus::async::task<> preFailoverFullSyncCheck();
+
+    /**
      * @brief Clears 'failover in progress' if it is on and
      *        removes the persisted value.
      */

--- a/redundant-bmc/src/passive_role_handler.hpp
+++ b/redundant-bmc/src/passive_role_handler.hpp
@@ -37,6 +37,14 @@ class PassiveRoleHandler : public RoleHandler
      */
     ~PassiveRoleHandler() override
     {
+        stopAllWatches();
+    }
+
+    /**
+     * @brief Stops all watches/callbacks registered by this handler.
+     */
+    void stopAllWatches() override
+    {
         providers.getSibling().clearCallbacks(Role::Passive);
         providers.getSyncInterface().stopSyncHealthWatch(Role::Passive);
         providers.getServices().removePeerConnectedCallback(Role::Passive);

--- a/redundant-bmc/src/role_handler.hpp
+++ b/redundant-bmc/src/role_handler.hpp
@@ -63,6 +63,11 @@ class RoleHandler
     virtual void externalRedundancyInputChanged() = 0;
 
     /**
+     * @brief Stops all watches/callbacks registered by this handler.
+     */
+    virtual void stopAllWatches() = 0;
+
+    /**
      * @brief Called when a failover is requested, this will return
      *        Reason::none if a failover is allowed right now, or the
      *        reason that it isn't.


### PR DESCRIPTION
Manager::doFailoverFromPassive will delete the PassiveRoleHandler object as part of its transition to being active as part of a failover.

If a full sync was in progress then, PassiveRoleHandler::startSync would still be running, and eventually when the sync completes there is a call to watchSyncHealth() which takes a 'this' pointer, causing a use after free crash.

To avoid this, do the following:

1. Don't delete the PassiveRoleHandler object until after the failover imminent delay is done.  Instead, just stop its watches on the active BMC.  With just this change that should help avoid the situation.

2. While FailoverImminent is still active, check if the full sync is still in progress and wait for it to complete before continuing. This way, the delay, which is already expected, may just be extended for a bit, and no other behavior is changed.

The wait can't happen after the other BMC is reset, because if it does somehow take a long time, it can complete its reboot and just come back and take the active role again, since this BMC is alive and passive.

Tested:

Continuous failover testing completes.

Change-Id: I5aacaab71dc3538341fd0deb78b95268fa908d7c