### PR TITLE
 RBMC: Start failover on active BMC

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -258,6 +258,11 @@ not be re-enabled afterwards, depending on if something is preventing it or not.
 The failover is always driven by the original passive BMC, which then takes over
 as active.
 
+Though driven by the passive BMC, a failover can still be initiated on the
+active BMC by calling its `StartFailover` D-Bus method. After checking for
+itself if the failover should be [rejected](#rejecting-a-failover-request) it
+will forward the request to the passive BMC.
+
 ### Allowing Failovers
 
 Even when redundancy is enabled, there are periods when failovers will not be
@@ -272,14 +277,7 @@ Failovers aren't allowed when:
 4. A failover is in progress.
 5. More coming.
 
-When failovers aren't allowed, rbmctool can be used to display the reasons why.
-
-Future work to be done:
-
-- Put the reasons on D-Bus and in Redfish so the HMC can get them.
-- Determine if the other BMC needs the reasons, or just if FOs aren't allowed.
-- When writing the failover code, reject the failover if it isn't allowed,
-  though there still needs to be a method to force it for use by field support.
+When failovers aren't allowed, rbmctool can be used to display the reason why.
 
 ### Rejecting a failover request
 
@@ -291,7 +289,6 @@ the request if any of the following are true.
 1. FailoversAllowed is false. Exceptions are:
    - The `force` option was passed into the `StartFailover` method.
    - The active BMC is in the `Quiesced` state.
-1. A full sync on the passive BMC is in progress.
 1. The active BMC has no heartbeat and redundancy wasn't last known to be
    enabled. If it was last known to be enabled, a failover is allowed so that
    the remaining BMC can become active.

--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -351,7 +351,6 @@ void ActiveRoleHandler::siblingFailoverImminent(bool imminent)
     {
         lg2::warning("A failover is imminent");
 
-        ctx.spawn(providers.getSyncInterface().disableBackgroundSync());
         ctx.spawn(providers.getServices().flushJournal());
     }
 }

--- a/redundant-bmc/src/errors.hpp
+++ b/redundant-bmc/src/errors.hpp
@@ -35,6 +35,9 @@ const std::string bmcIsPassiveDueToError =
 const std::string noRedundancy =
     "xyz.openbmc_project.State.BMC.Redundancy.NoRedundancy";
 
+const std::string failoverFailed =
+    "xyz.openbmc_project.State.BMC.Redundancy.FailoverFailed";
+
 } // namespace error_msg
 
 } // namespace errors

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -426,9 +426,29 @@ sdbusplus::async::task<> Manager::method_call(start_failover_t /* unused */,
     }
     else
     {
-        // Shouldn't get here, would have failed in validateFailoverRequest
-        lg2::error("StartFailover on active BMC not supported yet");
-        throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
+        try
+        {
+            co_await doFailoverFromActive(requester, options);
+
+            // This BMC should be reset as part of the failover.  If that
+            // doesn't happen something went very wrong so give it 30 seconds
+            // and log an error.
+            using namespace std::chrono_literals;
+            resetTimer = std::make_unique<Timer>(ctx, [this, data]() {
+                lg2::error(
+                    "Timed out waiting for passive BMC to reset this BMC after failover request");
+
+                ctx.spawn(providers->getServices().logError(
+                    errors::error_msg::failoverFailed, errors::Level::Error,
+                    data));
+            });
+            resetTimer->start(30s);
+        }
+        catch (const std::exception& e)
+        {
+            lg2::error("Could not start failover: {ERROR}", "ERROR", e);
+            throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
+        }
     }
 }
 
@@ -538,6 +558,16 @@ sdbusplus::async::task<> Manager::handlePairedChange(bool paired)
             role_determination::getRoleReasonDescription(
                 passiveRoleInfo->reason));
     }
+}
+
+sdbusplus::async::task<> Manager::doFailoverFromActive(
+    Requester requester, const FailoverOptions& options)
+{
+    lg2::info("Failover being started from the active BMC");
+
+    // Forward the failover request to the sibling BMC
+    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
+    co_await providers->getSibling().startFailover(requester, options);
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -5,6 +5,7 @@
 #include "redundancy_interface.hpp"
 #include "role_determination.hpp"
 #include "role_handler.hpp"
+#include "timer.hpp"
 #include "types.hpp"
 
 #include <sdbusplus/async.hpp>
@@ -137,6 +138,18 @@ class Manager :
     sdbusplus::async::task<> doFailoverFromPassive(Requester requester);
 
     /**
+     * @brief When the BMC is active, forwards a failover request
+     *        to the passive BMC so it can drive the failover.
+     *
+     * @param[in] requester - The failover requester passed into the
+     *                        StartFailover D-Bus method.
+     * @param[in] options - The failover options passed into the
+     *                      StartFailover D-Bus method.
+     */
+    sdbusplus::async::task<> doFailoverFromActive(
+        Requester requester, const FailoverOptions& options);
+
+    /**
      * @brief Clears 'failover in progress' if it is on and
      *        removes the persisted value.
      */
@@ -209,6 +222,14 @@ class Manager :
      * Read from the filesystem in the constructor.
      */
     bool chosePassiveDueToError{false};
+
+    /**
+     * @brief Timer started by the active BMC after requesting a failover.
+     *
+     * If the passive BMC does not reset this BMC within the expected time,
+     * the timer callback logs an error.
+     */
+    std::unique_ptr<Timer> resetTimer;
 
     /**
      * @brief The reason the active/passive role was chosen.

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -1,6 +1,9 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 #pragma once
+#include "types.hpp"
+
 #include <sdbusplus/async.hpp>
+#include <xyz/openbmc_project/Control/Failover/common.hpp>
 #include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
 #include <xyz/openbmc_project/State/BMC/common.hpp>
 
@@ -167,6 +170,25 @@ class Sibling
      * Returns an empty string if it isn't on D-Bus.
      */
     virtual const std::string& getServiceName() const = 0;
+
+    /**
+     * @brief Initiates a failover on the sibling BMC
+     *
+     * Calls the StartFailover D-Bus method on the sibling BMC's
+     * Failover interface, passing through the failover options.
+     *
+     * Meant to be called on the active BMC to start a failover
+     * on the passive.
+     *
+     * @param[in] requester - Who is requesting the failover
+     * @param[in] options - The failover options to pass through
+     *
+     * @return The task object
+     */
+    virtual sdbusplus::async::task<> startFailover(
+        sdbusplus::common::xyz::openbmc_project::control::Failover::Requester
+            requester,
+        const FailoverOptions& options) = 0;
 
     /**
      * @brief Clears callbacks held based on role

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -4,6 +4,7 @@
 #include "gpio.hpp"
 
 #include <phosphor-logging/lg2.hpp>
+#include <xyz/openbmc_project/Control/Failover/client.hpp>
 #include <xyz/openbmc_project/ObjectMapper/client.hpp>
 #include <xyz/openbmc_project/Provisioning/Provisioning/common.hpp>
 #include <xyz/openbmc_project/Software/Version/common.hpp>
@@ -610,6 +611,20 @@ sdbusplus::async::task<> SiblingImpl::pauseForDataPropagation() const
     using namespace std::chrono_literals;
     // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
     co_return co_await sdbusplus::async::sleep_for(ctx, 4s);
+}
+
+sdbusplus::async::task<> SiblingImpl::startFailover(
+    sdbusplus::common::xyz::openbmc_project::control::Failover::Requester
+        requester,
+    const FailoverOptions& options)
+{
+    using Failover =
+        sdbusplus::client::xyz::openbmc_project::control::Failover<>;
+
+    co_await Failover(ctx)
+        .service(serviceName)
+        .path(objectPath)
+        .start_failover(requester, options);
 }
 
 } // namespace rbmc

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -253,6 +253,25 @@ class SiblingImpl : public Sibling
         return serviceName;
     }
 
+    /**
+     * @brief Initiates a failover on the sibling (passive) BMC
+     *
+     * Calls the StartFailover D-Bus method on the sibling BMC's
+     * Failover interface, passing through the failover options.
+     *
+     * Meant to be called on the active BMC to start a failover
+     * on the passive.
+     *
+     * @param[in] requester - Who is requesting the failover
+     * @param[in] options - The failover options to pass through
+     *
+     * @return The task object
+     */
+    sdbusplus::async::task<> startFailover(
+        sdbusplus::common::xyz::openbmc_project::control::Failover::Requester
+            requester,
+        const FailoverOptions& options) override;
+
   private:
     /**
      * @brief Starts a Sibling InterfacesAdded watch

--- a/redundant-bmc/test/mocks/mock_sibling.hpp
+++ b/redundant-bmc/test/mocks/mock_sibling.hpp
@@ -51,6 +51,12 @@ class MockSibling : public testing::NiceMock<Sibling>
                 (const, override));
     MOCK_METHOD(sdbusplus::async::task<>, pauseForDataPropagation, (),
                 (const, override));
+
+    MOCK_METHOD(
+        sdbusplus::async::task<>, startFailover,
+        (sdbusplus::common::xyz::openbmc_project::control::Failover::Requester,
+         const FailoverOptions&),
+        (override));
 };
 
 } // namespace rbmc


### PR DESCRIPTION
Add support for the StartFailover method call to work on the active BMC.
When called on the active, after it gets by the failover blocked checks,
it will call the StartFailover method on the Failover interface that is
on the '/xyz/openbmc_project/state/bmc1' object path hosted by the
sibling daemon.

This will forward the failover request to the passive BMC to do a normal
failover from there.

The active BMC should get reset as part of the failover, if that doesn't
happen and the BMC stays up, an error log will be created.  That's done
by starting a 30 second timer after the failover request was made.

Tested:
Failover starts successfully:

```
phosphor-rbmc-state-manager[869]: Failover requester is Tool
phosphor-rbmc-state-manager[869]: Failover being started from the active BMC
phosphor-rbmc-state-manager[869]: Sibling property FailoverImminent changed
phosphor-rbmc-state-manager[869]: A failover is imminent
phosphor-rbmc-state-manager[869]: Starting journal flush
phosphor-rbmc-state-manager[869]: Completed journal flush with rc 0
```

And then the BMC Resets.