### PR TITLE
RBMC: Failover with a redundancy input

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -321,6 +321,17 @@ The failover sequence is:
    issues a full sync. Otherwise it sets `RedundancyEnabled` to false.
 1. When the full sync is complete, `FailoversAllowed` is now set to true.
 
+### Disabling redundancy after the failover
+
+The `StartFailover` D-Bus method accepts an optional `UseRedundancyInput`
+parameter that can set any of the [redundancy inputs]
+(#another-application-needs-to-disable-redundancy) when the new active BMC
+calculates redundancy.
+
+This is used in scenarios where something is wrong with hardware around the
+original active BMC such that it cannot be active and a failover is necessary.
+Since it cannot be active, redundancy has to be disabled after the failover.
+
 ### Failover History
 
 The BMC driving the failover logs the requester and timestamp of each failover

--- a/redundant-bmc/src/error_data.cpp
+++ b/redundant-bmc/src/error_data.cpp
@@ -227,20 +227,28 @@ void addFailoverOptsToData(const FailoverOptions& options,
     {
         std::string adKey = failoverOptPrefix + key;
 
-        data.emplace(adKey, std::visit(
-                                [](auto&& val) -> std::string {
-                                    using T = std::decay_t<decltype(val)>;
-                                    if constexpr (std::is_same_v<T, bool>)
-                                    {
-                                        return val ? "true" : "false";
-                                    }
-                                    else
-                                    {
-                                        // FailoverOptions can only hold bools
-                                        return "Unsupported option type";
-                                    }
-                                },
-                                value));
+        data.emplace(adKey,
+                     std::visit(
+                         [](auto&& val) -> std::string {
+                             using T = std::decay_t<decltype(val)>;
+                             if constexpr (std::is_same_v<T, bool>)
+                             {
+                                 return val ? "true" : "false";
+                             }
+                             else if constexpr (std::is_same_v<T, std::string>)
+                             {
+                                 return val;
+                             }
+                             else if constexpr (std::is_enum_v<T>)
+                             {
+                                 return getPDIEnumString(val);
+                             }
+                             else
+                             {
+                                 return "Unsupported option type";
+                             }
+                         },
+                         value));
     }
 }
 

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -14,6 +14,44 @@
 namespace rbmc
 {
 
+namespace
+{
+/**
+ * @brief Persists the UseRedundancyInput failover option
+ *        if there is one.
+ *
+ * @param[in] options - The options passed to StartFailover
+ */
+void persistFailoverRedundancyInput(const FailoverOptions& options)
+{
+    using Failover = sdbusplus::common::xyz::openbmc_project::control::Failover;
+
+    auto redInputString = util::getFailoverOption<std::string>(
+        Failover::Options::UseRedundancyInput, options);
+
+    if (!redInputString.has_value())
+    {
+        return;
+    }
+
+    auto redInput = RedundancyInterface::convertStringToRedundancyInput(
+        redInputString.value());
+
+    if (!redInput.has_value())
+    {
+        lg2::error(
+            "Invalid redundancy input {INPUT} passed in as failover option",
+            "INPUT", redInputString.value());
+        return;
+    }
+
+    lg2::info("Failover called with redundancy input {INPUT}", "INPUT",
+              redInput.value());
+
+    util::writeExternalRedundancyInput(redInput.value(), true);
+}
+} // namespace
+
 const std::string failoverPath =
     std::string{RedundancyInterface::namespace_path::value} + '/' +
     RedundancyInterface::namespace_path::bmc;
@@ -365,6 +403,11 @@ void Manager::setExternalRedundancyInput(
 sdbusplus::async::task<fo_blocked::Reason> Manager::validateFailoverRequest(
     const FailoverOptions& options)
 {
+    if (!util::validateFailoverRedundancyInput(options))
+    {
+        co_return fo_blocked::Reason::invalidFailoverOption;
+    }
+
     if (!handler)
     {
         co_return fo_blocked::Reason::tooEarly;
@@ -421,6 +464,10 @@ sdbusplus::async::task<> Manager::method_call(start_failover_t /* unused */,
         co_await providers->getServices().logError(
             errors::error_msg::failoverStarted, errors::Level::Informational,
             data);
+
+        // If any redundancy inputs were passed in with the
+        // failover options, persist them for later use.
+        persistFailoverRedundancyInput(options);
 
         ctx.spawn(doFailoverFromPassive(requester));
     }

--- a/redundant-bmc/src/redundancy.cpp
+++ b/redundant-bmc/src/redundancy.cpp
@@ -278,6 +278,10 @@ std::string getFailoverBlockedDescription(Reason reason)
             break;
         case Reason::tooEarly:
             desc = "It is too early in the BMC boot to start a failover"s;
+            break;
+        case Reason::invalidFailoverOption:
+            desc = "Invalid failover option provided"s;
+            break;
     }
     return desc;
 }

--- a/redundant-bmc/src/redundancy.hpp
+++ b/redundant-bmc/src/redundancy.hpp
@@ -126,7 +126,8 @@ enum class Reason
     notAtReady,
     bmcNotPassive,
     failoverAlreadyInProgress,
-    tooEarly
+    tooEarly,
+    invalidFailoverOption
 };
 
 /**

--- a/redundant-bmc/src/util.cpp
+++ b/redundant-bmc/src/util.cpp
@@ -112,4 +112,32 @@ bool clearExternalRedundancyInputs()
     return false;
 }
 
+bool validateFailoverRedundancyInput(const FailoverOptions& options)
+{
+    using Failover = sdbusplus::common::xyz::openbmc_project::control::Failover;
+    using RedundancyInterface =
+        sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy;
+
+    auto redInputString = getFailoverOption<std::string>(
+        Failover::Options::UseRedundancyInput, options);
+
+    if (!redInputString.has_value())
+    {
+        return true;
+    }
+
+    auto redInput = RedundancyInterface::convertStringToRedundancyInput(
+        redInputString.value());
+
+    if (!redInput.has_value())
+    {
+        lg2::error(
+            "Invalid redundancy input {INPUT} passed in as failover option",
+            "INPUT", redInputString.value());
+        return false;
+    }
+
+    return true;
+}
+
 } // namespace rbmc::util

--- a/redundant-bmc/src/util.hpp
+++ b/redundant-bmc/src/util.hpp
@@ -92,4 +92,14 @@ std::optional<T> getFailoverOption(
     return value;
 }
 
+/**
+ * @brief Validates the UseRedundancyInput failover option if present
+ *
+ * @param[in] options - The options passed to StartFailover
+ *
+ * @return bool - True if option not present or has valid value, false if
+ *                invalid
+ */
+bool validateFailoverRedundancyInput(const FailoverOptions& options);
+
 } // namespace rbmc::util

--- a/redundant-bmc/test/error_data_test.cpp
+++ b/redundant-bmc/test/error_data_test.cpp
@@ -61,3 +61,40 @@ TEST(ErrorDataTest, AddFailoverOptsToData_EmptyKeyString)
     ASSERT_EQ(data.size(), 1);
     EXPECT_EQ(data["FOOpt:"], "true");
 }
+
+TEST(ErrorDataTest, AddFailoverOptsToData_String)
+{
+    FailoverOptions options{{"stringOption", std::string("test_value")}};
+    AdditionalData data;
+
+    addFailoverOptsToData(options, data);
+
+    ASSERT_EQ(data.size(), 1);
+    EXPECT_EQ(data["FOOpt:stringOption"], "test_value");
+}
+
+TEST(ErrorDataTest, AddFailoverOptsToData_MixedBoolAndString)
+{
+    FailoverOptions options{{"boolOption", true},
+                            {"stringOption", std::string("test_string")},
+                            {"anotherBool", false}};
+    AdditionalData data;
+
+    addFailoverOptsToData(options, data);
+
+    ASSERT_EQ(data.size(), 3);
+    EXPECT_EQ(data["FOOpt:boolOption"], "true");
+    EXPECT_EQ(data["FOOpt:stringOption"], "test_string");
+    EXPECT_EQ(data["FOOpt:anotherBool"], "false");
+}
+
+TEST(ErrorDataTest, AddFailoverOptsToData_EmptyString)
+{
+    FailoverOptions options{{"emptyString", std::string("")}};
+    AdditionalData data;
+
+    addFailoverOptsToData(options, data);
+
+    ASSERT_EQ(data.size(), 1);
+    EXPECT_EQ(data["FOOpt:emptyString"], "");
+}

--- a/redundant-bmc/test/util_test.cpp
+++ b/redundant-bmc/test/util_test.cpp
@@ -139,3 +139,39 @@ TEST_F(UtilTest, GetFailoverOption_MultipleOptions)
     ASSERT_TRUE(hwProblemResult.has_value());
     EXPECT_EQ(hwProblemResult.value(), "PassiveBMCHardwareProblem");
 }
+
+TEST_F(UtilTest, ValidateFailoverRedundancyInput_OptionNotPassed)
+{
+    rbmc::FailoverOptions options;
+
+    bool result = validateFailoverRedundancyInput(options);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UtilTest, ValidateFailoverRedundancyInput_ValidValue)
+{
+    using RedundancyInterface =
+        sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy;
+
+    rbmc::FailoverOptions options{
+        {Failover::convertOptionsToString(
+             Failover::Options::UseRedundancyInput),
+         RedundancyInterface::convertRedundancyInputToString(
+             RedundancyInterface::RedundancyInput::PassiveBMCHardwareProblem)}};
+
+    bool result = validateFailoverRedundancyInput(options);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UtilTest, ValidateFailoverRedundancyInput_InvalidValue)
+{
+    rbmc::FailoverOptions options{{Failover::convertOptionsToString(
+                                       Failover::Options::UseRedundancyInput),
+                                   "InvalidRedundancyInputValue"}};
+
+    bool result = validateFailoverRedundancyInput(options);
+
+    EXPECT_FALSE(result);
+}


### PR DESCRIPTION
Look for the 'UseRedundancyInput' option in the failover options on a
failover, and if set then save the input as if someone had called
'SetRedundancyInput <input> true' so that when this BMC becomes active
as part of the failover, redundancy will be disabled for that reason.

If a failover is started with this option on the active BMC, it will be
contained in the failover request to the passive BMC and used there.

Tested:

Using that failover option:
```
phosphor-rbmc-state-manager[1021]: Failover called with redundancy input \
xyz.openbmc_project.State.BMC.Redundancy.RedundancyInput.PassiveBMCHardwareProblem
```

And then when the redundancy code runs later in the failover:
```
phosphor-rbmc-state-manager[1013]: No redundancy because: SystemHWConfigIssue
```

Change-Id: I87be181e9b69f9587044db17015b0ab835ea8fa9
Signed-off-by: Matt Spinler <spinler@us.ibm.com>