### PR TITLE
RBMC: fix RBMC PCIe redundancy offset to avoid MCTP collision

### DIFF
--- a/redundant-bmc/config_files/README.md
+++ b/redundant-bmc/config_files/README.md
@@ -34,7 +34,7 @@ It is then installed into
   ],
   "pcie_config": {
     "device_path": "/dev/bmc-device0",
-    "redundancy_offset": "0x3F00000"
+    "redundancy_offset": "0x3EFFF80"
   }
 }
 ```
@@ -68,7 +68,7 @@ It is then installed into
 - **device_path** (string, required): Path to the PCIe device (e.g.,
   '/dev/bmc-device0').
 - **redundancy_offset** (string, required): Offset in the PCIe device for
-  redundancy data as a hex string (e.g., '0x3F000000').
+  redundancy data as a hex string (e.g., '0x3EFFF80').
 
 ### Validating Config Files
 

--- a/redundant-bmc/config_files/default.json
+++ b/redundant-bmc/config_files/default.json
@@ -5,6 +5,6 @@
     },
     "pcie_config": {
         "device_path": "/dev/bmc-device0",
-        "redundancy_offset": "0x3F00000"
+        "redundancy_offset": "0x3EFFF80"
     }
 }

--- a/redundant-bmc/config_files/huygens.json
+++ b/redundant-bmc/config_files/huygens.json
@@ -21,6 +21,6 @@
     ],
     "pcie_config": {
         "device_path": "/dev/bmc-device0",
-        "redundancy_offset": "0x3F00000"
+        "redundancy_offset": "0x3EFFF80"
     }
 }

--- a/redundant-bmc/config_files/rbmc-prototype.json
+++ b/redundant-bmc/config_files/rbmc-prototype.json
@@ -5,6 +5,6 @@
     },
     "pcie_config": {
         "device_path": "/dev/bmc-device0",
-        "redundancy_offset": "0x3F00000"
+        "redundancy_offset": "0x3EFFF80"
     }
 }

--- a/redundant-bmc/config_files/schema/schema.json
+++ b/redundant-bmc/config_files/schema/schema.json
@@ -73,7 +73,7 @@
                 },
                 "redundancy_offset": {
                     "type": "string",
-                    "description": "Offset in the PCIe device for redundancy data as a hex string (e.g., '0x3F000000')",
+                    "description": "Offset in the PCIe device for redundancy data as a hex string (e.g., '0x3EFFF80')",
                     "minLength": 1
                 }
             },

--- a/redundant-bmc/config_files/skiboards.json
+++ b/redundant-bmc/config_files/skiboards.json
@@ -5,6 +5,6 @@
     },
     "pcie_config": {
         "device_path": "/dev/bmc-device0",
-        "redundancy_offset": "0x3F00000"
+        "redundancy_offset": "0x3EFFF80"
     }
 }

--- a/redundant-bmc/src/pcie_storage.cpp
+++ b/redundant-bmc/src/pcie_storage.cpp
@@ -26,20 +26,31 @@ PCIeStorageImpl::PCIeStorageImpl(const std::string& devPath, size_t offset) :
             return;
         }
 
-        mmioBase = mmap(nullptr, redundancySize, PROT_READ | PROT_WRITE,
-                        MAP_SHARED, fd, static_cast<off_t>(redundancyOffset));
-        if (mmioBase == MAP_FAILED)
+        const size_t pageSize = static_cast<size_t>(getpagesize());
+        const size_t pageAlignedOffset =
+            (redundancyOffset / pageSize) * pageSize;
+        const size_t pageOffsetDelta = redundancyOffset - pageAlignedOffset;
+        mmapSize = pageOffsetDelta + redundancySize;
+
+        mmapBase = mmap(nullptr, mmapSize, PROT_READ | PROT_WRITE, MAP_SHARED,
+                        fd, static_cast<off_t>(pageAlignedOffset));
+        if (mmapBase == MAP_FAILED)
         {
             close(fd);
             fd = -1;
-            lg2::error("PCIe mmap failed at offset {OFFSET}", "OFFSET",
-                       redundancyOffset);
+            lg2::error(
+                "PCIe mmap failed at page-aligned offset {OFFSET} (requested offset {REQ})",
+                "OFFSET", lg2::hex, pageAlignedOffset, "REQ", lg2::hex,
+                redundancyOffset);
             return;
         }
 
+        // Advance past the in-page delta to reach the actual target byte
+        mmioBase = static_cast<uint8_t*>(mmapBase) + pageOffsetDelta;
+
         lg2::debug(
             "PCIe storage initialized successfully at {PATH} offset {OFFSET}",
-            "PATH", devicePath, "OFFSET", redundancyOffset);
+            "PATH", devicePath, "OFFSET", lg2::hex, redundancyOffset);
     }
     catch (const std::exception& e)
     {
@@ -49,9 +60,9 @@ PCIeStorageImpl::PCIeStorageImpl(const std::string& devPath, size_t offset) :
 
 PCIeStorageImpl::~PCIeStorageImpl()
 {
-    if (mmioBase != nullptr && mmioBase != MAP_FAILED)
+    if (mmapBase != nullptr && mmapBase != MAP_FAILED)
     {
-        munmap(mmioBase, redundancySize);
+        munmap(mmapBase, mmapSize);
     }
     if (fd != -1)
     {

--- a/redundant-bmc/src/pcie_storage.hpp
+++ b/redundant-bmc/src/pcie_storage.hpp
@@ -10,7 +10,7 @@ namespace pcie_data
 {
 // Default values for PCIe configuration
 constexpr auto defaultDevicePath = "/dev/bmc-device0";
-constexpr auto defaultRedundancyOffset = 0x3F00000;
+constexpr auto defaultRedundancyOffset = 0x3EFFF80;
 constexpr size_t redundancySize = 1;
 
 constexpr uint8_t redundancyDataVersion = 1;
@@ -122,7 +122,9 @@ class PCIeStorageImpl : public PCIeStorage
 {
   private:
     int fd{-1};
-    void* mmioBase{nullptr};
+    void* mmapBase{nullptr}; // page-aligned base returned by mmap
+    void* mmioBase{nullptr}; // actual byte address (mmapBase + page offset)
+    size_t mmapSize{0};      // total mapped size (for munmap)
     std::mutex stateMutex;
     std::string devicePath;
     size_t redundancyOffset;

--- a/redundant-bmc/test/config_parser_test.cpp
+++ b/redundant-bmc/test/config_parser_test.cpp
@@ -60,7 +60,7 @@ TEST_F(ConfigParserTest, ParseValidConfig)
         ],
         "pcie_config": {
             "device_path": "/dev/bmc-device0",
-            "redundancy_offset": "66060288"
+            "redundancy_offset": "66060160"
         }
     })";
 
@@ -98,7 +98,7 @@ TEST_F(ConfigParserTest, ParseOptionalBMCConfigs)
         },
         "pcie_config": {
             "device_path": "/dev/bmc-device0",
-            "redundancy_offset": "66060288"
+            "redundancy_offset": "66060160"
         }
     })";
 
@@ -119,7 +119,7 @@ TEST_F(ConfigParserTest, ParseEmptyBMCConfigsArray)
         "bmc_configs": [],
         "pcie_config": {
             "device_path": "/dev/bmc-device0",
-            "redundancy_offset": "66060288"
+            "redundancy_offset": "66060160"
         }
     })";
 
@@ -382,7 +382,7 @@ TEST_F(ConfigParserTest, ParsePCIeConfig)
         "bmc_configs": [],
         "pcie_config": {
             "device_path": "/dev/bmc-device0",
-            "redundancy_offset": "0x3F00000"
+            "redundancy_offset": "0x3EFFF80"
         }
     })";
 
@@ -392,7 +392,7 @@ TEST_F(ConfigParserTest, ParsePCIeConfig)
 
     ASSERT_TRUE(result.pcieConfig.has_value());
     EXPECT_EQ(result.pcieConfig->devicePath, "/dev/bmc-device0");
-    EXPECT_EQ(result.pcieConfig->redundancyOffset, "0x3F00000");
+    EXPECT_EQ(result.pcieConfig->redundancyOffset, "0x3EFFF80");
 }
 
 TEST_F(ConfigParserTest, ParseOptionalPCIeConfig)
@@ -421,7 +421,7 @@ TEST_F(ConfigParserTest, ParsePCIeConfigMissingDevicePath)
         },
         "bmc_configs": [],
         "pcie_config": {
-            "redundancy_offset": "0x3F00000"
+            "redundancy_offset": "0x3EFFF80"
         }
     })";
 


### PR DESCRIPTION
The redundancy data offset was set to 0x3F00000, which collides with the MCTP base offset. Move it to 0x3EFFF80 instead.

MCTPBASE (0x3F00000) - CACHELINE SIZE(0x80) = 0x3EFFF80

Update all config files, tests, schema, and documentation accordingly.

Since now the address is not page aligned, need to also page alignment magic for the mmap to succeed.

Tested by :

```
root@huygens:/tmp# rbmctool --read-pcie
<7> PCIe storage initialized successfully at /dev/bmc-device0 offset 0x3efff80

PCIe MMIO Redundancy State
-----------------------------
Version:              1
Role:                 Active
Redundancy Enabled:   false
Failover In Progress: false
Failovers Allowed:    false
Raw Byte Value:       0b00001001 (0x09)

```