### PR TITLE
RBMC: Fix stale PCIe version field

### DIFF
--- a/redundant-bmc/src/pcie_storage.cpp
+++ b/redundant-bmc/src/pcie_storage.cpp
@@ -83,10 +83,7 @@ void PCIeStorageImpl::writeState(const RedundancyState& state)
     std::lock_guard<std::mutex> lock(stateMutex);
     validateMMIO();
 
-    RedundancyState modifiedState = state;
-    modifiedState.version = redundancyDataVersion;
-
-    std::memcpy(mmioBase, &modifiedState, sizeof(RedundancyState));
+    std::memcpy(mmioBase, &state, sizeof(RedundancyState));
     __sync_synchronize();
 }
 

--- a/redundant-bmc/src/pcie_storage.hpp
+++ b/redundant-bmc/src/pcie_storage.hpp
@@ -78,6 +78,13 @@ class PCIeStorage
     virtual RedundancyState readState() = 0;
 
     /**
+     * @brief Write the complete redundancy state to PCIe storage
+     *
+     * @param[in] state - The full redundancy state to write
+     */
+    virtual void writeState(const RedundancyState& state) = 0;
+
+    /**
      * @brief Update only the role field in PCIe storage
      *
      * @param[in] role - The role value to set
@@ -129,14 +136,12 @@ class PCIeStorageImpl : public PCIeStorage
     ~PCIeStorageImpl() override;
 
     RedundancyState readState() override;
+    void writeState(const RedundancyState& state) override;
 
     void updateRole(uint8_t role) override;
     void updateRedundancyEnabled(bool enabled) override;
     void updateFailoverInProgress(bool inProgress) override;
     void updateFailoversAllowed(bool allowed) override;
-
-  private:
-    void writeState(const RedundancyState& state);
 };
 
 } // namespace pcie_data

--- a/redundant-bmc/src/redundancy_interface.cpp
+++ b/redundant-bmc/src/redundancy_interface.cpp
@@ -60,10 +60,11 @@ RedundancyInterface::RedundancyInterface(sdbusplus::async::context& ctx,
     {
         try
         {
-            pcieStorage->updateFailoverInProgress(failover_in_progress_);
-            pcieStorage->updateRedundancyEnabled(redundancy_enabled_);
-            pcieStorage->updateFailoversAllowed(failovers_allowed_);
-            pcieStorage->updateRole(static_cast<uint8_t>(role_));
+            pcieStorage->writeState(
+                {pcie_data::redundancyDataVersion, static_cast<uint8_t>(role_),
+                 static_cast<uint8_t>(redundancy_enabled_),
+                 static_cast<uint8_t>(failover_in_progress_),
+                 static_cast<uint8_t>(failovers_allowed_)});
         }
         catch (const std::exception& e)
         {

--- a/redundant-bmc/test/manager_test.cpp
+++ b/redundant-bmc/test/manager_test.cpp
@@ -123,15 +123,21 @@ class ManagerTest : public rbmc::test::PersistentDataTestFixture
     {
         auto& storage = mockProviders->getMockPCIeStorage();
 
-        // Initialized to Unknown first
-        EXPECT_CALL(storage, updateRole(static_cast<uint8_t>(Role::Unknown)))
-            .Times(1);
+        // Constructor writes full initial state (role=Unknown) via writeState
+        EXPECT_CALL(storage, writeState(_)).Times(1);
 
+        // Role always changes from Unknown to the final role
         EXPECT_CALL(storage, updateRole(static_cast<uint8_t>(vals.role)))
             .Times(1);
-        EXPECT_CALL(storage, updateRedundancyEnabled(vals.redEnabled));
-        EXPECT_CALL(storage, updateFailoverInProgress(vals.failoverInProgress));
-        EXPECT_CALL(storage, updateFailoversAllowed(vals.failoversAllowed));
+
+        // Boolean properties only fire if the value differs from the default
+        // (false), so allow zero or one call each
+        EXPECT_CALL(storage, updateRedundancyEnabled(vals.redEnabled))
+            .Times(vals.redEnabled ? 1 : 0);
+        EXPECT_CALL(storage, updateFailoverInProgress(vals.failoverInProgress))
+            .Times(vals.failoverInProgress ? 1 : 0);
+        EXPECT_CALL(storage, updateFailoversAllowed(vals.failoversAllowed))
+            .Times(vals.failoversAllowed ? 1 : 0);
     }
 
     /**

--- a/redundant-bmc/test/mocks/mock_pcie_storage.hpp
+++ b/redundant-bmc/test/mocks/mock_pcie_storage.hpp
@@ -17,6 +17,8 @@ class MockPCIeStorage : public testing::NiceMock<pcie_data::PCIeStorage>
 {
   public:
     MOCK_METHOD(pcie_data::RedundancyState, readState, (), (override));
+    MOCK_METHOD(void, writeState, (const pcie_data::RedundancyState&),
+                (override));
     MOCK_METHOD(void, updateRole, (uint8_t), (override));
     MOCK_METHOD(void, updateRedundancyEnabled, (bool), (override));
     MOCK_METHOD(void, updateFailoverInProgress, (bool), (override));


### PR DESCRIPTION
Set version field explicitly in the initial PCIe state write to avoid stale data in PCIe MMIO on startup.