### PR TITLE
RBMC: Track code updates

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -178,6 +178,34 @@ If redundancy was enabled when called, it will immediately be disabled, and
 remain so until the next time the host is powered off, at which point this input
 will be cleared and redundancy calculated again.
 
+## Code Updates
+
+### Preventing error logs due to code updates
+
+The standard sequence of doing a code update on a redundant BMC system is:
+
+1. Update flash of active BMC and reboot it. Wait for it to come back online
+   with the new code level.
+2. Update flash of passive BMC and reboot it.
+
+After the active BMC comes back, the code levels won't match anymore so
+redundancy will be disabled. Normally, that would generate an error log. To
+avoid creating an error log in this case, since it is an expected case, the code
+on the active BMC will:
+
+1. Watch for the code update to start and save that indication persistently.
+2. Any time that redundancy is attempted and it can't be enabled, the code will
+   skip creating an error log if the code update indication is saved and the
+   only reason it can't be enabled is due to a code update.
+
+The indication will be cleared if:
+
+1. Redundancy is successfully enabled, meaning the passive BMC must have been
+   updated and rebooted into the same level.
+2. A boot is started. In this case, the user must have deemed booting more
+   important than finishing the code update, so the code won't treat it
+   differently anymore.
+
 ## Interacting with Data Sync on the Active BMC
 
 ### When Enabling Redundancy

--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "code_update_activation.hpp"
 #include "redundancy_mgr.hpp"
 #include "role_handler.hpp"
 #include "timer.hpp"
@@ -27,10 +28,13 @@ class ActiveRoleHandler : public RoleHandler
      * @param[in] ctx - The async context object
      * @param[in] providers - The Providers access object
      * @param[in] iface - The redundancy D-Bus interface object
+     * @param[in] codeUpdateActivation - The Activation D-Bus interface object
      */
     ActiveRoleHandler(sdbusplus::async::context& ctx, Providers& providers,
-                      RedundancyInterface& iface) :
-        RoleHandler(ctx, providers, iface), redMgr(ctx, providers, iface),
+                      RedundancyInterface& iface,
+                      CodeUpdateActivation& codeUpdateActivation) :
+        RoleHandler(ctx, providers, iface),
+        redMgr(ctx, providers, iface, codeUpdateActivation),
         siblingHealthTimer(
             ctx, providers.getWaitTracker(),
             std::bind_front(&ActiveRoleHandler::siblingHealthCritical, this)),

--- a/redundant-bmc/src/code_update_activation.cpp
+++ b/redundant-bmc/src/code_update_activation.cpp
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "code_update_activation.hpp"
+
+#include "persistent_data.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+#include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
+
+namespace rbmc
+{
+
+using Redundancy =
+    sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy;
+
+const std::string CodeUpdateActivation::objectPath =
+    std::string{Redundancy::namespace_path::value} + '/' +
+    Redundancy::namespace_path::bmc;
+
+CodeUpdateActivation::CodeUpdateActivation(sdbusplus::async::context& ctx) :
+    sdbusplus::aserver::xyz::openbmc_project::software::Activation<
+        CodeUpdateActivation>(ctx, objectPath.c_str())
+{
+    try
+    {
+        activation_ =
+            data::read<bool>(data::key::codeUpdateInProgress).value_or(false)
+                ? Activations::Activating
+                : Activations::Active;
+    }
+    catch (const std::exception& e)
+    {
+        activation_ = Activations::Active;
+        lg2::error("Failed reading code-update-in-progress state: {ERROR}",
+                   "ERROR", e);
+    }
+
+    if (activation_ == Activations::Activating)
+    {
+        lg2::info("Code update in progress on startup");
+    }
+
+    requested_activation_ = RequestedActivations::None;
+    emit_added();
+}
+
+bool CodeUpdateActivation::codeUpdateInProgress() const
+{
+    return activation_ == Activations::Activating;
+}
+
+void CodeUpdateActivation::setCodeUpdateInProgress()
+{
+    activation(Activations::Activating);
+}
+
+void CodeUpdateActivation::clearCodeUpdateInProgress()
+{
+    activation(Activations::Active);
+}
+
+bool CodeUpdateActivation::set_property([[maybe_unused]] activation_t type,
+                                        Activations activation)
+{
+    if (activation == activation_)
+    {
+        return false;
+    }
+
+    lg2::info("Activation property changing to {VALUE}", "VALUE", activation);
+
+    activation_ = activation;
+
+    // This needs to be saved through a reboot, so persist it.
+    try
+    {
+        data::write(data::key::codeUpdateInProgress,
+                    activation_ == Activations::Activating);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed serializing code-update-in-progress state: {ERROR}",
+                   "ERROR", e);
+    }
+
+    return true;
+}
+
+} // namespace rbmc

--- a/redundant-bmc/src/code_update_activation.hpp
+++ b/redundant-bmc/src/code_update_activation.hpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <sdbusplus/async.hpp>
+#include <xyz/openbmc_project/Software/Activation/aserver.hpp>
+
+namespace rbmc
+{
+
+/**
+ * @class CodeUpdateActivation
+ *
+ * Hosts the code-update-in-progress Activation interface on the
+ * RBMC state object path.
+ */
+class CodeUpdateActivation :
+    public sdbusplus::aserver::xyz::openbmc_project::software::Activation<
+        CodeUpdateActivation>
+{
+  public:
+    CodeUpdateActivation(const CodeUpdateActivation&) = delete;
+    CodeUpdateActivation& operator=(const CodeUpdateActivation&) = delete;
+    CodeUpdateActivation(CodeUpdateActivation&&) = delete;
+    CodeUpdateActivation& operator=(CodeUpdateActivation&&) = delete;
+
+    /**
+     * @brief Constructor
+     *
+     * @param[in] ctx - The async context object
+     */
+    explicit CodeUpdateActivation(sdbusplus::async::context& ctx);
+
+    /**
+     * @brief Returns if code update is in progress
+     */
+    bool codeUpdateInProgress() const;
+
+    /**
+     * @brief Marks a code update as in progress
+     */
+    void setCodeUpdateInProgress();
+
+    /**
+     * @brief Clears the code update in progress value
+     */
+    void clearCodeUpdateInProgress();
+
+    /**
+     * @brief Handles updates to the Activation property
+     *
+     * Updates the stored D-Bus value and persists the corresponding
+     * code-update-in-progress state.
+     *
+     * @param[in] type - The property tag type
+     * @param[in] activation - The requested value
+     *
+     * @return true if the property value changed
+     */
+    bool set_property(activation_t type, Activations activation);
+
+  private:
+    /**
+     * @brief The D-Bus object path for the interface
+     */
+    static const std::string objectPath;
+};
+
+} // namespace rbmc

--- a/redundant-bmc/src/error_data.cpp
+++ b/redundant-bmc/src/error_data.cpp
@@ -170,6 +170,12 @@ void addFileData(AdditionalData& data)
             }
         }
 
+        auto codeUpdate = data::read<bool>(data::key::codeUpdateInProgress);
+        if (codeUpdate.value_or(false))
+        {
+            data["CodeUpdate"] = boolToYesOrNo(true);
+        }
+
         auto inputs = util::readExternalRedundancyInputs();
         if (!inputs.empty())
         {

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -63,7 +63,7 @@ Manager::Manager(sdbusplus::async::context& ctx,
         ctx, failoverPath.c_str()),
     ctx(ctx), providers(std::move(providers)),
     redundancyInterface(ctx, *this, this->providers->getPCIeStorage()),
-    heartbeatInterval(heartbeatInterval)
+    codeUpdateActivation(ctx), heartbeatInterval(heartbeatInterval)
 {
     try
     {

--- a/redundant-bmc/src/manager.cpp
+++ b/redundant-bmc/src/manager.cpp
@@ -180,8 +180,8 @@ void Manager::spawnRoleHandler()
 {
     if (redundancyInterface.role() == Role::Active)
     {
-        handler = std::make_unique<ActiveRoleHandler>(ctx, *providers,
-                                                      redundancyInterface);
+        handler = std::make_unique<ActiveRoleHandler>(
+            ctx, *providers, redundancyInterface, codeUpdateActivation);
     }
     else if (redundancyInterface.role() == Role::Passive)
     {
@@ -564,7 +564,8 @@ sdbusplus::async::task<> Manager::doFailoverFromPassive(Requester requester)
     updateRole(role_determination::RoleInfo{
         Role::Active, role_determination::RoleReason::failover});
 
-    auto* active = new ActiveRoleHandler(ctx, *providers, redundancyInterface);
+    auto* active = new ActiveRoleHandler(ctx, *providers, redundancyInterface,
+                                         codeUpdateActivation);
     handler.reset(active);
 
     active->clearFailoversAllowedDuringFailover();

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 #pragma once
 
+#include "code_update_activation.hpp"
 #include "providers.hpp"
 #include "redundancy_interface.hpp"
 #include "role_determination.hpp"
@@ -209,6 +210,13 @@ class Manager :
      * @brief The Redundancy D-Bus interface
      */
     RedundancyInterface redundancyInterface;
+
+    /**
+     * @brief The code update Activation D-Bus interface.
+     *
+     * Used for tracking in progress code updates.
+     */
+    CodeUpdateActivation codeUpdateActivation;
 
     /**
      * @brief The role handler class

--- a/redundant-bmc/src/meson.build
+++ b/redundant-bmc/src/meson.build
@@ -17,6 +17,7 @@ rbmc_deps = [
 rbmc_lib = static_library(
     'rbmc',
     'active_role_handler.cpp',
+    'code_update_activation.cpp',
     'config_parser.cpp',
     'error_data.cpp',
     'gpio.cpp',

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -86,6 +86,18 @@ sdbusplus::async::task<> PassiveRoleHandler::start()
             "ERROR", e);
     }
 
+    try
+    {
+        // This is only valid on the active BMC
+        data::remove(data::key::codeUpdateInProgress);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error(
+            "Failed while removing CodeUpdateInProgress saved value: {ERROR}",
+            "ERROR", e);
+    }
+
     co_return;
 }
 

--- a/redundant-bmc/src/persistent_data.hpp
+++ b/redundant-bmc/src/persistent_data.hpp
@@ -57,6 +57,7 @@ constexpr auto redundancyOffAtRuntime = "RedundancyOffAtRuntime";
 constexpr auto failoverInProgress = "FailoverInProgress";
 constexpr auto externalRedundancyInputs = "ExternalRedundancyInputs";
 constexpr auto hostOff = "HostOff";
+constexpr auto codeUpdateInProgress = "CodeUpdateInProgress";
 } // namespace key
 
 namespace util

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -259,7 +259,12 @@ sdbusplus::async::task<> getLocalBMCInfo(sdbusplus::async::context& ctx,
         catch (const std::exception& e)
         {
             output["Paired"] = e.what();
-            output["PeerConnected"] = e.what();
+            output["Peer Connected"] = e.what();
+        }
+
+        if (data::read<bool>(data::key::codeUpdateInProgress).value_or(false))
+        {
+            output["In Code Update"] = true;
         }
 
         if (role != "Unknown")

--- a/redundant-bmc/src/redundancy_mgr.cpp
+++ b/redundant-bmc/src/redundancy_mgr.cpp
@@ -17,10 +17,16 @@ using RedundancyInput = sdbusplus::common::xyz::openbmc_project::state::bmc::
     Redundancy::RedundancyInput;
 
 RedundancyMgr::RedundancyMgr(sdbusplus::async::context& ctx,
-                             Providers& providers, RedundancyInterface& iface) :
+                             Providers& providers, RedundancyInterface& iface,
+                             CodeUpdateActivation& codeUpdateActivation) :
     ctx(ctx), providers(providers), redundancyInterface(iface),
+    codeUpdateActivation(codeUpdateActivation),
     manualDisable(iface.disable_redundancy_override())
-{}
+{
+    providers.getServices().addCodeUpdateCallback(
+        Role::Active,
+        std::bind_front(&RedundancyMgr::codeUpdateActivationChanged, this));
+}
 
 void RedundancyMgr::determineAndSetRedundancy()
 {
@@ -39,17 +45,38 @@ void RedundancyMgr::determineAndSetRedundancy()
 
     determineAndSetFailoversAllowed();
 
+    auto codeUpdateInProgress = codeUpdateActivation.codeUpdateInProgress();
+    if (codeUpdateInProgress)
+    {
+        // If a code update was in progress, but both BMCs were updated so
+        // the versions are the same again, consider it complete.
+        if (redundancyInterface.redundancy_enabled() ||
+            !std::ranges::contains(reasons,
+                                   ReasonForNoRedundancy::CodeVersionMismatch))
+        {
+            lg2::info("Clearing code-update-in-progress indication");
+            codeUpdateActivation.clearCodeUpdateInProgress();
+        }
+    }
+
     if (!redundancyInterface.redundancy_enabled())
     {
         auto wasManuallyDisabled = std::ranges::contains(
             oldReasons, ReasonForNoRedundancy::ManuallyDisabled);
+
+        auto codeMismatchOnly =
+            reasons.size() == 1 &&
+            *reasons.begin() == ReasonForNoRedundancy::CodeVersionMismatch;
 
         // Log an error when redundancy isn't enabled if:
         // 1. Redundancy was previously enabled.
         // 2. This is the first time checking redundancy.
         // 3. The manual override to disable redundancy is now off but
         //    was previously on, meaning there is some other reason.
-        if (oldEnabled || firstTime || (!manualDisable && wasManuallyDisabled))
+        // 4. An in progress code update didn't cause it.
+        if ((oldEnabled || firstTime ||
+             (!manualDisable && wasManuallyDisabled)) &&
+            !(codeUpdateInProgress && codeMismatchOnly))
         {
             using namespace errors;
             std::string error{error_msg::noRedundancy};
@@ -265,6 +292,20 @@ void RedundancyMgr::initSystemState()
     }
 }
 
+void RedundancyMgr::codeUpdateActivationChanged(bool started)
+{
+    if (started)
+    {
+        lg2::info("Detected a code update starting");
+        codeUpdateActivation.setCodeUpdateInProgress();
+    }
+    else
+    {
+        lg2::warning("Code update failed, clearing code update indication");
+        codeUpdateActivation.clearCodeUpdateInProgress();
+    }
+}
+
 void RedundancyMgr::systemStateChange(SystemState newState)
 {
     lg2::info("System state change to {NEW}", "NEW",
@@ -299,6 +340,18 @@ void RedundancyMgr::systemStateChange(SystemState newState)
                 "ENABLED", redundancyInterface.redundancy_enabled());
             setRedundancyOffAtRuntimeValue(
                 !redundancyInterface.redundancy_enabled());
+        }
+    }
+    else if (newState == SystemState::booting)
+    {
+        // Consider a boot the end of allowing special treatment
+        // for code updates, as that must have been deemed more
+        // important than finishing the code update completely.
+        if (codeUpdateActivation.codeUpdateInProgress())
+        {
+            lg2::info(
+                "Clearing in-progress code update indication on boot start");
+            codeUpdateActivation.clearCodeUpdateInProgress();
         }
     }
 

--- a/redundant-bmc/src/redundancy_mgr.hpp
+++ b/redundant-bmc/src/redundancy_mgr.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "code_update_activation.hpp"
 #include "providers.hpp"
 #include "redundancy.hpp"
 #include "redundancy_interface.hpp"
@@ -28,9 +29,11 @@ class RedundancyMgr
      * @param[in] ctx - The async context object
      * @param[in] providers - The Providers access object
      * @param[in] iface - The redundancy D-Bus interface object
+     * @param[in] codeUpdateActivation - The CodeUpdateActivation object
      */
     RedundancyMgr(sdbusplus::async::context& ctx, Providers& providers,
-                  RedundancyInterface& iface);
+                  RedundancyInterface& iface,
+                  CodeUpdateActivation& codeUpdateActivation);
 
     /**
      * @brief Destructor
@@ -38,6 +41,7 @@ class RedundancyMgr
     ~RedundancyMgr()
     {
         providers.getServices().removeSystemStateCallback(Role::Active);
+        providers.getServices().removeCodeUpdateCallback(Role::Active);
     }
 
     /**
@@ -125,6 +129,13 @@ class RedundancyMgr
     void initSystemState();
 
     /**
+     * @brief Called when a BMC code update activation state changes
+     *
+     * @param[in] started - true if the update started, false if it failed
+     */
+    void codeUpdateActivationChanged(bool started);
+
+    /**
      * @brief Update the 'redundancy off at runtime' data.
      *
      * @param[in] valid - If the value is valid or not.
@@ -192,6 +203,12 @@ class RedundancyMgr
      * @brief The Redundancy D-Bus interface
      */
     RedundancyInterface& redundancyInterface;
+
+    /**
+     * @brief The code update Activation D-Bus interface
+     *        to track if code update is in progress.
+     */
+    CodeUpdateActivation& codeUpdateActivation;
 
     /**
      * @brief If determineAndSetRedundancy() has ran yet or not.

--- a/redundant-bmc/src/services.hpp
+++ b/redundant-bmc/src/services.hpp
@@ -48,6 +48,7 @@ class Services
     using SystemStateCallback = std::function<void(SystemState)>;
     using PeerConnectedCallback = std::function<void(bool)>;
     using PairedCallback = std::function<void(bool)>;
+    using CodeUpdateCallback = std::move_only_function<void(bool)>;
 
     /**
      * @brief Sets up the D-Bus matches
@@ -229,6 +230,29 @@ class Services
     }
 
     /**
+     * @brief Add a function that gets called when a BMC code update
+     *        starts or fails.
+     *
+     *
+     * @param[in] role - The role to register with
+     * @param[in] callback - The function to call
+     */
+    void addCodeUpdateCallback(Role role, CodeUpdateCallback&& callback)
+    {
+        codeUpdateCBs.emplace(role, std::move(callback));
+    }
+
+    /**
+     * @brief Remove a specific code update callback by role.
+     *
+     * @param[in] role - The role of the callback to remove
+     */
+    void removeCodeUpdateCallback(Role role)
+    {
+        codeUpdateCBs.erase(role);
+    }
+
+    /**
      * @brief On the system inventory object, check that its Progress
      *        Status property is 'Completed'.
      *
@@ -277,6 +301,11 @@ class Services
      * @brief The functions to call when the paired status changes
      */
     std::map<Role, PairedCallback> pairedCBs;
+
+    /**
+     * @brief The functions to call when a code update starts or fails
+     */
+    std::map<Role, CodeUpdateCallback> codeUpdateCBs;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -13,6 +13,8 @@
 #include <xyz/openbmc_project/Logging/Create/client.hpp>
 #include <xyz/openbmc_project/ObjectMapper/client.hpp>
 #include <xyz/openbmc_project/Provisioning/Provisioning/client.hpp>
+#include <xyz/openbmc_project/Software/Activation/client.hpp>
+#include <xyz/openbmc_project/Software/Version/client.hpp>
 #include <xyz/openbmc_project/State/BMC/client.hpp>
 #include <xyz/openbmc_project/State/Boot/Progress/client.hpp>
 #include <xyz/openbmc_project/State/Host/client.hpp>
@@ -34,6 +36,9 @@ using SidebandBus =
     sdbusplus::client::xyz::openbmc_project::control::SideBandBus<>;
 using Pairing =
     sdbusplus::client::xyz::openbmc_project::provisioning::Provisioning<>;
+using Activation =
+    sdbusplus::common::xyz::openbmc_project::software::Activation;
+using Version = sdbusplus::client::xyz::openbmc_project::software::Version<>;
 using PeerConnectionStatus = sdbusplus::common::xyz::openbmc_project::
     provisioning::Provisioning::PeerConnectionStatus;
 
@@ -43,6 +48,8 @@ using HostProperties =
                  BootProgress::ProgressStages>;
 using HostPropMap = std::unordered_map<std::string, HostProperties>;
 using HostInterfaceMap = std::map<std::string, HostPropMap>;
+using ActivationPropMap =
+    std::unordered_map<std::string, Activation::PropertiesVariant>;
 
 namespace rules = sdbusplus::bus::match::rules;
 
@@ -53,6 +60,7 @@ constexpr auto systemd = "/org/freedesktop/systemd1";
 // host0 represents the overall host state
 const std::string hostState = std::string{HostState::namespace_path::value} +
                               '/' + HostState::namespace_path::host + '0';
+constexpr auto software = "/xyz/openbmc_project/software";
 } // namespace object_path
 
 namespace interface
@@ -197,13 +205,14 @@ sdbusplus::async::task<int> runAsyncCmd(sdbusplus::async::context& ctx,
 
 sdbusplus::async::task<> ServicesImpl::init()
 {
-    auto barrier = std::make_shared<sdbusplus::async::barrier>(6);
+    auto barrier = std::make_shared<sdbusplus::async::barrier>(7);
 
     ctx.spawn(watchHostInterfacesAdded(barrier));
     ctx.spawn(watchHostStatePropertiesChanged(barrier));
     ctx.spawn(watchBootProgressPropertiesChanged(barrier));
     ctx.spawn(watchPairingInterfacesAdded(barrier));
     ctx.spawn(watchPairingPropertiesChanged(barrier));
+    ctx.spawn(watchCodeUpdatePropertiesChanged(barrier));
 
     co_await barrier->wait();
 
@@ -467,6 +476,83 @@ sdbusplus::async::task<> ServicesImpl::watchPairingPropertiesChanged(
         auto [_,
               properties] = co_await match.next<std::string, PairingPropMap>();
         loadPairingProps(properties);
+    }
+}
+
+sdbusplus::async::task<bool> ServicesImpl::isBMCCodeUpdate(
+    const std::string& path) const
+{
+    try
+    {
+        auto service = co_await util::getService(ctx, path, Version::interface);
+        auto purpose =
+            co_await Version(ctx).service(service).path(path).purpose();
+        co_return purpose == Version::VersionPurpose::BMC;
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        lg2::error(
+            "Failed reading software version purpose for path {PATH}: {ERROR}",
+            "PATH", path, "ERROR", e);
+    }
+
+    co_return false;
+}
+
+sdbusplus::async::task<> ServicesImpl::watchCodeUpdatePropertiesChanged(
+    std::shared_ptr<sdbusplus::async::barrier> barrier)
+{
+    sdbusplus::async::match match(
+        ctx, rules::propertiesChangedNamespace(object_path::software,
+                                               Activation::interface));
+
+    co_await barrier->wait();
+
+    std::optional<std::string> activatingPath;
+
+    while (!ctx.stop_requested())
+    {
+        auto msg = co_await match.next();
+
+        std::string path{msg.get_path()};
+        auto [_, properties] = msg.unpack<std::string, ActivationPropMap>();
+
+        auto it = properties.find("Activation");
+        if (it == properties.end())
+        {
+            continue;
+        }
+
+        if (!co_await isBMCCodeUpdate(path))
+        {
+            continue;
+        }
+
+        auto activation = std::get<Activation::Activations>(it->second);
+
+        if (activation == Activation::Activations::Activating)
+        {
+            lg2::info("Detected BMC code update start on path {PATH}", "PATH",
+                      path);
+
+            activatingPath = path;
+            std::ranges::for_each(codeUpdateCBs, [](auto& entry) {
+                entry.second(true);
+            });
+        }
+        else if (activation == Activation::Activations::Failed &&
+                 activatingPath == path)
+        {
+            lg2::warning("BMC code update failed on path {PATH}", "PATH", path);
+            activatingPath.reset();
+            std::ranges::for_each(codeUpdateCBs, [](auto& entry) {
+                entry.second(false);
+            });
+        }
+        else if (activatingPath == path)
+        {
+            activatingPath.reset();
+        }
     }
 }
 

--- a/redundant-bmc/src/services_impl.hpp
+++ b/redundant-bmc/src/services_impl.hpp
@@ -282,6 +282,25 @@ class ServicesImpl : public Services
     void loadPairingProps(const PairingPropMap& propertyMap);
 
     /**
+     * @brief Starts the PropertiesChanged watch the Activation interface
+     *
+     * @param[in] barrier - Initialization barrier
+     */
+    sdbusplus::async::task<> watchCodeUpdatePropertiesChanged(
+        std::shared_ptr<sdbusplus::async::barrier> barrier);
+
+    /**
+     * @brief Returns if the software object path is for a BMC image
+     *
+     * Checks the Purpose property on the Version interface.
+     *
+     * @param[in] path - The software object path
+     *
+     * @return true if the image purpose is BMC, false otherwise
+     */
+    sdbusplus::async::task<bool> isBMCCodeUpdate(const std::string& path) const;
+
+    /**
      * @brief Called when either the host state or boot progress property
      *        changes value to calculate the system state.
      */


### PR DESCRIPTION
The plan is to do code updates in sequence, updating and rebooting the active BMC, following by updating and rebooting the passive BMC.  After the active BMC is rebooted into its new level, redundancy will be disabled because the code levels don't match.

Normally, an error log would be created for this.  This PR adds the functionality to know that it's in the middle of the code update process and then skip the error log.  It does this by:

1. Watch for the Activation property on any Software.Activation interface to go to 'Activating'.
2. Verify this is a BMC code update by checking the Purpose property on the Version interface on that path.
3. Persist the code update in progress indication
4. On a reboot, keep this indication
5. If set, then when determining redundancy if the only reason for no-redundancy is 'mismatched levels', then don't create an error.
6. If redundancy can be enabled, or if that reason isn't listed, clear the indication.
7. On a boot, also a clear the indication, this was a policy decision made that the customer is no longer interested in the updates and would rather boot.

In the future, the other BMC will also want to know this indication so that it can be more lenient on allowing failovers in the case of a bad code update.  To accommodate that, also put this indication on D-Bus using the Software.Activation interface on state/bmc0.  It will have two values only, Activating or Active.