### PR TITLE
RBMC: Move 2 functions into util.cpp

### DIFF
--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -2,6 +2,7 @@
 #include "services_impl.hpp"
 
 #include "system_state.hpp"
+#include "util.hpp"
 
 #include <openssl/evp.h>
 
@@ -786,31 +787,17 @@ std::string ServicesImpl::getFWVersion() const
         return hexVersionString;
     }
 
-    std::ifstream versionFile{"/etc/os-release"};
-    std::string line;
-    std::string keyPattern{"VERSION_ID="};
+    auto versionOpt = util::getOSReleaseValue("/etc/os-release", "VERSION_ID");
     std::string version;
 
-    while (std::getline(versionFile, line))
-    {
-        // Handle either quotes or no quotes around the value
-        if (line.substr(0, keyPattern.size()).find(keyPattern) !=
-            std::string::npos)
-        {
-            // If the value isn't surrounded by quotes, then pos will be
-            // npos + 1 = 0, and the 2nd arg to substr() will be npos
-            // which means get the rest of the string.
-            auto value = line.substr(keyPattern.size());
-            std::size_t pos = value.find_first_of('"') + 1;
-            version = value.substr(pos, value.find_last_of('"') - pos);
-            break;
-        }
-    }
-
-    if (version.empty())
+    if (!versionOpt.has_value())
     {
         lg2::error("Unable to parse VERSION_ID out of /etc/os-release");
         // let it hash the empty string
+    }
+    else
+    {
+        version = versionOpt.value();
     }
 
     using EVP_MD_CTX_Ptr =

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -120,88 +120,6 @@ sdbusplus::async::task<std::string> findSystemInventoryPath(
     co_return objects.begin()->first;
 }
 
-/**
- * @brief Run a shell command asynchronously
- *
- * Use the pipe()/fork() paradigm to fork off a child process to run
- * the command. The child will write the command RC to its FD obtained
- * from pipe() and exit. Meanwhile the parent will use async::fdio to
- * asynchronously wait for that rc to show up in its read FD it had
- * obtained from pipe().
- */
-// NOLINTNEXTLINE
-sdbusplus::async::task<int> runAsyncCmd(sdbusplus::async::context& ctx,
-                                        const std::string& cmd)
-{
-    int pipeFDs[2];
-
-    // Open the read and write pipes
-    if (pipe(pipeFDs) == -1)
-    {
-        auto e = errno;
-        lg2::error("runAsyncCmd: pipe() failed with errno: {ERRNO}", "ERRNO",
-                   e);
-        co_return -1;
-    }
-
-    pid_t pid = fork();
-    if (pid == -1)
-    {
-        auto e = errno;
-        close(pipeFDs[0]);
-        close(pipeFDs[1]);
-        lg2::error("runAsyncCmd: fork failed with errno {ERRNO}", "ERRNO", e);
-        co_return -1;
-    }
-    else if (pid == 0)
-    {
-        // Child
-
-        // Close the read pipe
-        close(pipeFDs[0]);
-
-        // NOLINTNEXTLINE(cert-env33-c)
-        int rc = std::system(cmd.c_str());
-
-        int exitCode = (rc == -1) ? -1 : (WIFEXITED(rc) ? WEXITSTATUS(rc) : -1);
-
-        // Write the exit code to the write pipe
-        ssize_t s = write(pipeFDs[1], &exitCode, sizeof(exitCode));
-
-        _exit((s == sizeof(rc)) ? 0 : 1);
-    }
-
-    // In the parent here.
-
-    // close the write pipe
-    close(pipeFDs[1]);
-
-    // Async wait for the child to write the command's rc to the read pipe
-    sdbusplus::async::fdio fdio(ctx, pipeFDs[0]);
-    co_await fdio.next();
-
-    int cmdRC = -1;
-    ssize_t bytesRead = read(pipeFDs[0], &cmdRC, sizeof(cmdRC));
-    close(pipeFDs[0]);
-
-    if (bytesRead != sizeof(cmdRC))
-    {
-        lg2::error("runAsyncCmd: Failed to read return code from command {CMD}",
-                   "CMD", cmd);
-        co_return -1;
-    }
-
-    // Wait for child to exit
-    int status;
-    if (waitpid(pid, &status, 0) == -1)
-    {
-        lg2::error("runAsyncCmd: waitpid failed for command {CMD}", "CMD", cmd);
-        co_return -1;
-    }
-
-    co_return cmdRC;
-}
-
 } // namespace util
 
 sdbusplus::async::task<> ServicesImpl::init()
@@ -854,6 +772,7 @@ sdbusplus::async::task<> ServicesImpl::flushJournal() const
     try
     {
         lg2::info("Starting journal flush");
+        // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
         auto rc = co_await util::runAsyncCmd(ctx, "/usr/bin/journalctl --sync");
         lg2::info("Completed journal flush with rc {RC}", "RC", rc);
     }

--- a/redundant-bmc/src/util.cpp
+++ b/redundant-bmc/src/util.cpp
@@ -5,6 +5,8 @@
 #include "persistent_data.hpp"
 #include "phosphor-logging/lg2.hpp"
 
+#include <fstream>
+
 namespace rbmc::util
 {
 
@@ -138,6 +140,41 @@ bool validateFailoverRedundancyInput(const FailoverOptions& options)
     }
 
     return true;
+}
+
+std::optional<std::string> getOSReleaseValue(const std::string& filePath,
+                                             const std::string& key)
+{
+    std::ifstream file{filePath};
+    if (!file.is_open())
+    {
+        lg2::error("Failed to open file: {FILE}", "FILE", filePath);
+        return std::nullopt;
+    }
+
+    // Append '=' to the key for matching
+    std::string keyPattern = key + "=";
+
+    std::string line;
+    while (std::getline(file, line))
+    {
+        // Check if line starts with the key pattern
+        if (line.substr(0, keyPattern.size()).find(keyPattern) !=
+            std::string::npos)
+        {
+            // Extract the value after the key pattern
+            auto value = line.substr(keyPattern.size());
+
+            // Handle quotes around the value
+            // If the value isn't surrounded by quotes, then pos will be
+            // npos + 1 = 0, and the 2nd arg to substr() will be npos
+            // which means get the rest of the string.
+            std::size_t pos = value.find_first_of('"') + 1;
+            return value.substr(pos, value.find_last_of('"') - pos);
+        }
+    }
+
+    return std::nullopt;
 }
 
 } // namespace rbmc::util

--- a/redundant-bmc/src/util.cpp
+++ b/redundant-bmc/src/util.cpp
@@ -5,6 +5,9 @@
 #include "persistent_data.hpp"
 #include "phosphor-logging/lg2.hpp"
 
+#include <sys/wait.h>
+#include <unistd.h>
+
 #include <fstream>
 
 namespace rbmc::util
@@ -176,5 +179,79 @@ std::optional<std::string> getOSReleaseValue(const std::string& filePath,
 
     return std::nullopt;
 }
+
+// NOLINTBEGIN(clang-analyzer-core.uninitialized.Branch)
+sdbusplus::async::task<int> runAsyncCmd(sdbusplus::async::context& ctx,
+                                        const std::string& cmd)
+{
+    int pipeFDs[2];
+
+    // Open the read and write pipes
+    if (pipe(pipeFDs) == -1)
+    {
+        auto e = errno;
+        lg2::error("runAsyncCmd: pipe() failed with errno: {ERRNO}", "ERRNO",
+                   e);
+        co_return -1;
+    }
+
+    pid_t pid = fork();
+    if (pid == -1)
+    {
+        auto e = errno;
+        close(pipeFDs[0]);
+        close(pipeFDs[1]);
+        lg2::error("runAsyncCmd: fork failed with errno {ERRNO}", "ERRNO", e);
+        co_return -1;
+    }
+    else if (pid == 0)
+    {
+        // Child
+
+        // Close the read pipe
+        close(pipeFDs[0]);
+
+        // NOLINTNEXTLINE(cert-env33-c)
+        int rc = std::system(cmd.c_str());
+
+        int exitCode = (rc == -1) ? -1 : (WIFEXITED(rc) ? WEXITSTATUS(rc) : -1);
+
+        // Write the exit code to the write pipe
+        ssize_t s = write(pipeFDs[1], &exitCode, sizeof(exitCode));
+
+        _exit((s == sizeof(rc)) ? 0 : 1);
+    }
+
+    // In the parent here.
+
+    // close the write pipe
+    close(pipeFDs[1]);
+
+    // Async wait for the child to write the command's rc to the read pipe
+    sdbusplus::async::fdio fdio(ctx, pipeFDs[0]);
+    co_await fdio.next();
+
+    int cmdRC = -1;
+    ssize_t bytesRead = read(pipeFDs[0], &cmdRC, sizeof(cmdRC));
+    close(pipeFDs[0]);
+
+    if (bytesRead != sizeof(cmdRC))
+    {
+        lg2::error("runAsyncCmd: Failed to read return code from command {CMD}",
+                   "CMD", cmd);
+        co_return -1;
+    }
+
+    // Wait for child to exit
+    int status;
+    if (waitpid(pid, &status, 0) == -1)
+    {
+        lg2::error("runAsyncCmd: waitpid failed for command {CMD}", "CMD", cmd);
+        co_return -1;
+    }
+
+    co_return cmdRC;
+}
+// NOLINTEND(clang-analyzer-core.uninitialized.Branch)
 
 } // namespace rbmc::util

--- a/redundant-bmc/src/util.hpp
+++ b/redundant-bmc/src/util.hpp
@@ -102,4 +102,14 @@ std::optional<T> getFailoverOption(
  */
 bool validateFailoverRedundancyInput(const FailoverOptions& options);
 
+/**
+ * @brief Get a value from an os-release file
+ *
+ * @param[in] filePath - The path to the os-release file
+ * @param[in] key - The key to look for
+ *
+ * @return std::optional<std::string> - The value, or nullopt if not found
+ */
+std::optional<std::string> getOSReleaseValue(const std::string& filePath,
+                                             const std::string& key);
 } // namespace rbmc::util

--- a/redundant-bmc/src/util.hpp
+++ b/redundant-bmc/src/util.hpp
@@ -3,6 +3,7 @@
 
 #include "types.hpp"
 
+#include <sdbusplus/async.hpp>
 #include <xyz/openbmc_project/Control/Failover/common.hpp>
 #include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
 
@@ -112,4 +113,15 @@ bool validateFailoverRedundancyInput(const FailoverOptions& options);
  */
 std::optional<std::string> getOSReleaseValue(const std::string& filePath,
                                              const std::string& key);
+/**
+ * @brief Run a command asynchronously
+ *
+ * @param[in] ctx - The async context
+ * @param[in] cmd - The command to run
+ *
+ * @return sdbusplus::async::task<int> - The exit code of the command
+ */
+sdbusplus::async::task<int> runAsyncCmd(sdbusplus::async::context& ctx,
+                                        const std::string& cmd);
+
 } // namespace rbmc::util

--- a/redundant-bmc/test/util_test.cpp
+++ b/redundant-bmc/test/util_test.cpp
@@ -272,3 +272,41 @@ TEST_F(UtilTest, GetOSReleaseValueEmptyValueNoQuotes)
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result.value(), "");
 }
+
+template <typename F>
+void runAsync(F func)
+{
+    sdbusplus::async::context ctx;
+    ctx.spawn(func(ctx) | sdbusplus::async::execution::then([&ctx]() {
+                  ctx.request_stop();
+              }));
+    ctx.run();
+}
+
+TEST(RunAsyncCmdTest, SuccessfulCommandExecution)
+{
+    // Test that a simple successful command returns a 0
+    int result = -1;
+
+    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
+    runAsync(
+        [&result](sdbusplus::async::context& ctx) -> sdbusplus::async::task<> {
+            result = co_await rbmc::util::runAsyncCmd(ctx, "echo 'test'");
+        });
+
+    EXPECT_EQ(result, 0);
+}
+
+TEST(RunAsyncCmdTest, CommandWithNonZeroExitCode)
+{
+    // Test that a command with non-zero exit code returns it
+    int result = -1;
+
+    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
+    runAsync(
+        [&result](sdbusplus::async::context& ctx) -> sdbusplus::async::task<> {
+            result = co_await rbmc::util::runAsyncCmd(ctx, "exit 1");
+        });
+
+    EXPECT_EQ(result, 1);
+}

--- a/redundant-bmc/test/util_test.cpp
+++ b/redundant-bmc/test/util_test.cpp
@@ -3,6 +3,8 @@
 #include "types.hpp"
 #include "util.hpp"
 
+#include <fstream>
+
 #include <gtest/gtest.h>
 
 using namespace rbmc::util;
@@ -10,7 +12,33 @@ using namespace rbmc::test;
 using Failover = sdbusplus::common::xyz::openbmc_project::control::Failover;
 
 class UtilTest : public PersistentDataTestFixture
-{};
+{
+  protected:
+    void SetUp() override
+    {
+        char dirTemplate[] = "/tmp/utils_testXXXXXX";
+        char* dir = mkdtemp(dirTemplate);
+        if (dir == nullptr)
+        {
+            throw std::runtime_error("Failed to create temp directory");
+        }
+        testDir = dir;
+    }
+
+    void TearDown() override
+    {
+        std::filesystem::remove_all(testDir);
+    }
+
+    void createOSReleaseFile(const std::string& content)
+    {
+        std::ofstream file(testDir / "os-release");
+        file << content;
+        file.close();
+    }
+
+    std::filesystem::path testDir;
+};
 
 TEST_F(UtilTest, ExternalRedundancyInputTest)
 {
@@ -174,4 +202,73 @@ TEST_F(UtilTest, ValidateFailoverRedundancyInput_InvalidValue)
     bool result = validateFailoverRedundancyInput(options);
 
     EXPECT_FALSE(result);
+}
+
+TEST_F(UtilTest, GetOSReleaseValueWithQuotes)
+{
+    constexpr auto content = R"(NAME="Test OS"
+VERSION_ID="1.2.3"
+ID=test
+)";
+    createOSReleaseFile(content);
+
+    auto result = getOSReleaseValue(testDir / "os-release", "VERSION_ID");
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), "1.2.3");
+}
+
+TEST_F(UtilTest, GetOSReleaseValueWithoutQuotes)
+{
+    constexpr auto content = R"(VERSION_ID=1.2.3
+)";
+    createOSReleaseFile(content);
+
+    auto result = getOSReleaseValue(testDir / "os-release", "VERSION_ID");
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), "1.2.3");
+}
+
+TEST_F(UtilTest, GetOSReleaseValueNotFound)
+{
+    constexpr auto content = R"(NAME="Test OS"
+ID=test
+)";
+    createOSReleaseFile(content);
+
+    auto result = getOSReleaseValue(testDir / "os-release", "VERSION_ID");
+
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(UtilTest, GetOSReleaseValueFileNotFound)
+{
+    auto result = getOSReleaseValue(testDir / "nonexistent.txt", "VERSION_ID");
+
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(UtilTest, GetOSReleaseValueEmptyValue)
+{
+    constexpr auto content = R"(VERSION_ID=""
+)";
+    createOSReleaseFile(content);
+
+    auto result = getOSReleaseValue(testDir / "os-release", "VERSION_ID");
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), "");
+}
+
+TEST_F(UtilTest, GetOSReleaseValueEmptyValueNoQuotes)
+{
+    constexpr auto content = R"(VERSION_ID=
+)";
+    createOSReleaseFile(content);
+
+    auto result = getOSReleaseValue(testDir / "os-release", "VERSION_ID");
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), "");
 }


### PR DESCRIPTION
Move runAsyncCmd and getOSReleaseValue from the util namespace in ServicesImpl to util.cpp so they can have testcases.

No functional changes.