### PR TITLE
RBMC: Increase active target timeout

### DIFF
--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -13,6 +13,7 @@ namespace rbmc
 using Failover = sdbusplus::common::xyz::openbmc_project::control::Failover;
 
 constexpr auto bmcActiveTarget = "obmc-bmc-active.target";
+const std::chrono::minutes bmcActiveTargetTimeout{30};
 const std::chrono::minutes siblingHealthTimeout{5};
 
 // NOLINTNEXTLINE
@@ -44,7 +45,7 @@ sdbusplus::async::task<> ActiveRoleHandler::start()
     try
     {
         // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
-        co_await services.startUnit(bmcActiveTarget, std::chrono::minutes{10});
+        co_await services.startUnit(bmcActiveTarget, bmcActiveTargetTimeout);
     }
     catch (const std::exception& e)
     {
@@ -293,7 +294,7 @@ sdbusplus::async::task<> ActiveRoleHandler::failoverStartActiveTarget()
     {
         // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
         co_await providers.getServices().startUnit(bmcActiveTarget,
-                                                   std::chrono::minutes{10});
+                                                   bmcActiveTargetTimeout);
     }
     catch (const std::exception& e)
     {


### PR DESCRIPTION
In a large simulation system, starting the active target took over 16 minutes.  To be extra safe, just increase the timeout to 30.  Also make a constant for it.

Change-Id: I05a2b67a17092bd40ca5331dda524266c4ff8071