### PR TITLE
obmcutil: update stop_off_targets to support multi-chassis

### DIFF
--- a/obmcutil
+++ b/obmcutil
@@ -357,13 +357,13 @@ function delete_logs()
 function stop_off_targets()
 {
     systemctl stop \
-        obmc-chassis-powered-off@0.target \
-        obmc-host-stop-pre@0.target \
-        obmc-host-stopped@0.target \
-        obmc-host-stopping@0.target \
-        obmc-power-off@0.target \
-        obmc-power-stop-pre@0.target \
-        obmc-power-stop@0.target
+        obmc-chassis-powered-off@*.target \
+        obmc-host-stop-pre@*.target \
+        obmc-host-stopped@*.target \
+        obmc-host-stopping@*.target \
+        obmc-power-off@*.target \
+        obmc-power-stop-pre@*.target \
+        obmc-power-stop@*.target
 }
 
 function show_verbose_chassis_states()


### PR DESCRIPTION
Replace hardcoded '0' with wildcard '*' in obmcutil stop_off_targets so all chassis instances are stopped properly. This allows the function to stop all instances of each power-off target across all chassis, supporting multi-chassis configurations.

Tested: Verified on Huygens Simics model that all targets are stopped properly.

Change-Id: I9f4cb368fa51452429ee676596d9d56081f340a8