### PR TITLE
RBMC: Reduce system state traces

### DIFF
--- a/redundant-bmc/src/redundancy_mgr.cpp
+++ b/redundant-bmc/src/redundancy_mgr.cpp
@@ -356,22 +356,23 @@ void RedundancyMgr::determineAndSetFailoversAllowed()
 
     auto reason = fona::getFailoversNotAllowedReason(input);
 
+    auto orig = redundancyInterface.failovers_not_allowed_reason();
     redundancyInterface.failovers_not_allowed_reason(reason);
 
     if (reason != FailoversNotAllowedReason::None)
     {
-        lg2::warning("Failovers not allowed because {REASON}", "REASON",
-                     fona::getFailoversNotAllowedDescription(reason));
+        if (orig != reason)
+        {
+            lg2::warning("Failovers not allowed because {REASON}", "REASON",
+                         fona::getFailoversNotAllowedDescription(reason));
+        }
 
         redundancyInterface.failovers_allowed(false);
     }
-    else
+    else if (!redundancyInterface.failovers_allowed())
     {
-        if (!redundancyInterface.failovers_allowed())
-        {
-            lg2::info("Changing failovers to allowed");
-            redundancyInterface.failovers_allowed(true);
-        }
+        lg2::info("Changing failovers to allowed");
+        redundancyInterface.failovers_allowed(true);
     }
 }
 

--- a/redundant-bmc/src/services_impl.cpp
+++ b/redundant-bmc/src/services_impl.cpp
@@ -481,9 +481,6 @@ void ServicesImpl::updateSystemState()
     SystemState newState =
         calculateSystemState(hostState.value(), bootProgress.value());
 
-    lg2::info("Calculated system state is {STATE}", "STATE",
-              getSystemStateName(newState));
-
     if (!systemState.has_value() || (newState != systemState.value()))
     {
         if (systemState.has_value())


### PR DESCRIPTION
The updateSystemState function is called every time the BootProgress sensor changes, which happens several times during a boot.  There is no need to trace the system state value determined in that function, because if it actually changes then it will be traced already by RedundancyMgr.

Along the same lines, there is no need to trace the reason for failovers not being allowed every time it is checked, but rather only if the reason it isn't allowed is changing from last time.

Change-Id: I14c8a715a5fb6703c0ff1f2ea46efbf9edaa15da