### PR TITLE
RBMC: Add Manager testcases

### DIFF
--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -76,6 +76,8 @@ sdbusplus::async::task<> ActiveRoleHandler::start()
     co_await redMgr.determineRedundancyAndSync();
 
     startAllWatches();
+
+    providers.getTracker().track(ProgressPoint::activeHandlerStartComplete);
 }
 
 void ActiveRoleHandler::siblingStateChange(BMCState state)

--- a/redundant-bmc/src/manager.hpp
+++ b/redundant-bmc/src/manager.hpp
@@ -78,6 +78,26 @@ class Manager :
                                          Requester requester,
                                          const FailoverOptions& options);
 
+    /**
+     * @brief Returns the Redundancy D-Bus interface object
+     *
+     * @return Reference to the redundancy interface
+     */
+    const RedundancyInterface& getRedundancyInterface() const
+    {
+        return redundancyInterface;
+    }
+
+    /**
+     * @brief Returns the Providers instance used
+     *
+     * @return Reference to providers
+     */
+    Providers& getProviders()
+    {
+        return *providers;
+    }
+
   private:
     /**
      * @brief Kicks off the Manager startup

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -98,7 +98,7 @@ sdbusplus::async::task<> PassiveRoleHandler::start()
             "ERROR", e);
     }
 
-    co_return;
+    providers.getTracker().track(ProgressPoint::passiveHandlerStartComplete);
 }
 
 void PassiveRoleHandler::setupSiblingRedEnabledWatch()

--- a/redundant-bmc/src/pcie_storage.hpp
+++ b/redundant-bmc/src/pcie_storage.hpp
@@ -71,13 +71,6 @@ class PCIeStorage
     PCIeStorage& operator=(PCIeStorage&&) = delete;
 
     /**
-     * @brief Write the complete redundancy state to PCIe storage
-     *
-     * @param[in] state - The redundancy state to write
-     */
-    virtual void writeState(const RedundancyState& state) = 0;
-
-    /**
      * @brief Read the complete redundancy state from PCIe storage
      *
      * @return The redundancy state
@@ -135,13 +128,15 @@ class PCIeStorageImpl : public PCIeStorage
     PCIeStorageImpl(const std::string& devPath, size_t offset);
     ~PCIeStorageImpl() override;
 
-    void writeState(const RedundancyState& state) override;
     RedundancyState readState() override;
 
     void updateRole(uint8_t role) override;
     void updateRedundancyEnabled(bool enabled) override;
     void updateFailoverInProgress(bool inProgress) override;
     void updateFailoversAllowed(bool allowed) override;
+
+  private:
+    void writeState(const RedundancyState& state);
 };
 
 } // namespace pcie_data

--- a/redundant-bmc/src/progress_tracker.hpp
+++ b/redundant-bmc/src/progress_tracker.hpp
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+namespace rbmc
+{
+
+enum class ProgressPoint
+{
+    activeHandlerStartComplete,
+    passiveHandlerStartComplete
+};
+
+/**
+ * @class ProgressTracker
+ */
+class ProgressTracker
+{
+  public:
+    ProgressTracker() = default;
+    virtual ~ProgressTracker() = default;
+
+    ProgressTracker(const ProgressTracker&) = delete;
+    ProgressTracker& operator=(const ProgressTracker&) = delete;
+    ProgressTracker(ProgressTracker&&) = delete;
+    ProgressTracker& operator=(ProgressTracker&&) = delete;
+
+    /**
+     * @brief Track a progress point
+     *
+     * @param[in] event - The point to track
+     */
+    virtual void track(ProgressPoint /* point */) {}
+
+    /**
+     * @brief Check if the progress point has been reached
+     *
+     * @param[in] point - The point to check
+     * @return true if it has been reached
+     */
+    virtual bool hasReached(ProgressPoint /* point */) const
+    {
+        return false;
+    }
+};
+
+} // namespace rbmc

--- a/redundant-bmc/src/providers.hpp
+++ b/redundant-bmc/src/providers.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "pcie_storage.hpp"
+#include "progress_tracker.hpp"
 #include "services.hpp"
 #include "sibling.hpp"
 #include "sibling_reset.hpp"
@@ -51,6 +52,11 @@ class Providers
      * @brief Returns the PCIeStorage provider if configured
      */
     virtual pcie_data::PCIeStorage* getPCIeStorage() = 0;
+
+    /**
+     * @brief Returns the ProgressTracker provider
+     */
+    virtual ProgressTracker& getTracker() = 0;
 
     /**
      * @brief Returns the WaitTracker

--- a/redundant-bmc/src/providers_impl.hpp
+++ b/redundant-bmc/src/providers_impl.hpp
@@ -86,6 +86,14 @@ class ProvidersImpl : public Providers
         return &*pcieStorage;
     }
 
+    /**
+     * @brief Returns the ProgressTracker provider
+     */
+    ProgressTracker& getTracker() override
+    {
+        return progTracker;
+    }
+
   private:
     /**
      * @brief Create PCIeStorage if config is present
@@ -136,6 +144,11 @@ class ProvidersImpl : public Providers
      * @brief The PCIeStorage implementation (optional)
      */
     std::optional<pcie_data::PCIeStorageImpl> pcieStorage;
+
+    /**
+     * @brief The ProgressTracker implementation
+     */
+    ProgressTracker progTracker;
 };
 
 }; // namespace rbmc

--- a/redundant-bmc/test/manager_test.cpp
+++ b/redundant-bmc/test/manager_test.cpp
@@ -1,23 +1,503 @@
 // SPDX-License-Identifier: Apache-2.0
+#include "manager.hpp"
+#include "mocks/async_helpers.hpp"
 #include "mocks/mock_providers.hpp"
+#include "persistent_data_test_fixture.hpp"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 using namespace rbmc;
+using namespace testing;
+using namespace test_helpers;
 
-class ManagerTest
+using Redundancy =
+    sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy;
+
+constexpr std::chrono::milliseconds hbInterval{5};
+
+class ManagerTest : public rbmc::test::PersistentDataTestFixture
 {
   protected:
-    void SetUp()
+    struct TestScenarioConfig
+    {
+        bool paired = true;
+        std::optional<size_t> bmcPosition = 0;
+        bool systemInventoryAvailable = true;
+        bool siblingServiceRunning = true;
+        bool siblingPresent = true;
+        bool siblingAlive = true;
+        Role siblingRole = Role::Passive;
+        bool siblingPaired = true;
+        bool siblingFailoverInProgress = false;
+    };
+
+    ~ManagerTest() noexcept override = default;
+
+    void SetUp() override
     {
         mockProviders = std::make_unique<MockProviders>();
+
+        ON_CALL(mockProviders->getMockServices(), getPersistentDataPath())
+            .WillByDefault(Return(dataDir));
     }
 
-    void TearDown()
+    void TearDown() override
     {
+        manager.reset();
         mockProviders.reset();
     }
 
+    /**
+     * @brief Set what the functions should return for a
+     *        specific test scenario.
+     */
+    void setupTestScenario(const TestScenarioConfig& config)
+    {
+        auto& services = mockProviders->getMockServices();
+        auto& sibling = mockProviders->getMockSibling();
+
+        ON_CALL(services, getPaired()).WillByDefault(Return(config.paired));
+
+        ON_CALL(services, getBMCPosition())
+            .WillByDefault(Return(config.bmcPosition));
+
+        ON_CALL(services, checkSystemInventoryStatus())
+            .WillByDefault([available = config.systemInventoryAvailable]() {
+                return makeCompletedTask(available);
+            });
+
+        if (config.siblingServiceRunning)
+        {
+            siblingServiceName =
+                "xyz.openbmc_project.State.BMC.Redundancy.Sibling";
+        }
+        else
+        {
+            siblingServiceName = "";
+        }
+
+        ON_CALL(sibling, getServiceName())
+            .WillByDefault(ReturnRef(siblingServiceName));
+
+        ON_CALL(sibling, isBMCPresent())
+            .WillByDefault(Return(config.siblingPresent));
+
+        ON_CALL(sibling, alive()).WillByDefault(Return(config.siblingAlive));
+
+        ON_CALL(sibling, getRole()).WillByDefault(Return(config.siblingRole));
+
+        ON_CALL(sibling, getPaired())
+            .WillByDefault(Return(config.siblingPaired));
+
+        ON_CALL(sibling, getFailoverInProgress())
+            .WillByDefault(Return(config.siblingFailoverInProgress));
+    }
+
+    struct RedundancyProps
+    {
+        Role role{};
+        bool redEnabled{};
+        bool failoverInProgress{};
+        bool failoversAllowed{};
+        bool failoverImminent{};
+        std::vector<Redundancy::ReasonForNoRedundancy> reasonsForNoRedundancy;
+        FailoversNotAllowedReason failoversNotAllowedReason;
+    };
+
+    static void verifyRedundancyProps(const RedundancyInterface& iface,
+                                      const RedundancyProps& expected)
+    {
+        EXPECT_EQ(iface.role(), expected.role);
+        EXPECT_EQ(iface.redundancy_enabled(), expected.redEnabled);
+        EXPECT_EQ(iface.failover_in_progress(), expected.failoverInProgress);
+        EXPECT_EQ(iface.failovers_allowed(), expected.failoversAllowed);
+        EXPECT_EQ(iface.failover_imminent(), expected.failoverImminent);
+        EXPECT_EQ(iface.reasons_for_no_redundancy(),
+                  expected.reasonsForNoRedundancy);
+        EXPECT_EQ(iface.failovers_not_allowed_reason(),
+                  expected.failoversNotAllowedReason);
+    }
+
+    void setupPCIeStorageExpects(const RedundancyProps& vals)
+    {
+        auto& storage = mockProviders->getMockPCIeStorage();
+
+        // Initialized to Unknown first
+        EXPECT_CALL(storage, updateRole(static_cast<uint8_t>(Role::Unknown)))
+            .Times(1);
+
+        EXPECT_CALL(storage, updateRole(static_cast<uint8_t>(vals.role)))
+            .Times(1);
+        EXPECT_CALL(storage, updateRedundancyEnabled(vals.redEnabled));
+        EXPECT_CALL(storage, updateFailoverInProgress(vals.failoverInProgress));
+        EXPECT_CALL(storage, updateFailoversAllowed(vals.failoversAllowed));
+    }
+
+    /**
+     * @brief Create the Manager and let it run until a progress point is hit.
+     */
+    void createManagerAndRun(ProgressPoint point)
+    {
+        // Spawns Manager::startup()
+        manager = std::make_unique<Manager>(ctx, std::move(mockProviders),
+                                            hbInterval);
+
+        ctx.spawn(waitForProgressPoint(point));
+
+        ctx.run();
+    }
+
+    /**
+     * @brief Let the context run until a progress point has been reached
+     *
+     * @param[in] point - The point to wait for
+     * @param[in] timeout - The timeout, default is 1s
+     * @param[in] stopWhenDone - If the context should be stopped afterwards.
+     */
+    sdbusplus::async::task<> waitForProgressPoint(ProgressPoint point,
+                                                  bool stopWhenDone = true)
+    {
+        using namespace std::chrono_literals;
+        auto deadline = std::chrono::steady_clock::now() + 1s;
+
+        while (std::chrono::steady_clock::now() < deadline)
+        {
+            if (manager->getProviders().getTracker().hasReached(point))
+            {
+                if (stopWhenDone)
+                {
+                    ctx.request_stop();
+                }
+                co_return;
+            }
+            co_await sdbusplus::async::sleep_for(ctx, 10ms);
+        }
+
+        ADD_FAILURE() << "Timed out waiting for progress point "
+                      << std::to_underlying(point);
+
+        // If timed out, stop regardless
+        ctx.request_stop();
+    }
+
+    /**
+     * @brief Verify 3 values in the persistent data.
+     */
+    static void verifyPersistentData(Role expectedRole,
+                                     const std::string& expectedRoleReason,
+                                     bool expectPassiveError = false)
+    {
+        // Verify role was saved
+        auto savedRole = data::read<Role>(data::key::role);
+        ASSERT_TRUE(savedRole.has_value())
+            << "Role should be saved to persistent data";
+        EXPECT_EQ(savedRole.value(), expectedRole);
+
+        // Verify passiveError flag was saved
+        auto savedPassiveError = data::read<bool>(data::key::passiveError);
+        ASSERT_TRUE(savedPassiveError.has_value())
+            << "PassiveError flag should be saved to persistent data";
+        EXPECT_EQ(savedPassiveError.value(), expectPassiveError);
+
+        // Verify role reason description was saved
+        auto savedRoleReason = data::read<std::string>(data::key::roleReason);
+        ASSERT_TRUE(savedRoleReason.has_value())
+            << "RoleReason should be saved to persistent data";
+        EXPECT_EQ(savedRoleReason.value(), expectedRoleReason);
+    }
+
     std::unique_ptr<MockProviders> mockProviders;
+    std::unique_ptr<Manager> manager;
+    std::string siblingServiceName;
+    std::chrono::seconds passiveTargetTimeout{300};
+    sdbusplus::async::context ctx;
 };
+
+/**
+ * @brief Test: BMC becomes passive when not paired
+ */
+TEST_F(ManagerTest, BecomesPassive_NotPaired)
+{
+    // Configure scenario: BMC is not paired
+    TestScenarioConfig config{.paired = false};
+    setupTestScenario(config);
+
+    auto& services = mockProviders->getMockServices();
+
+    EXPECT_CALL(services, logError(errors::error_msg::bmcIsPassiveDueToError,
+                                   errors::Level::Error, _))
+        .Times(1);
+
+    EXPECT_CALL(services,
+                startUnit("obmc-bmc-passive.target", passiveTargetTimeout))
+        .Times(1);
+
+    RedundancyProps expectedProps{
+        .role = Role::Passive,
+        .redEnabled = false,
+        .failoverInProgress = false,
+        .failoversAllowed = false,
+        .failoverImminent = false,
+        .reasonsForNoRedundancy =
+            {Redundancy::ReasonForNoRedundancy::SiblingCannotBeActive},
+        .failoversNotAllowedReason = FailoversNotAllowedReason::None};
+
+    setupPCIeStorageExpects(expectedProps);
+
+    createManagerAndRun(ProgressPoint::passiveHandlerStartComplete);
+
+    verifyRedundancyProps(manager->getRedundancyInterface(), expectedProps);
+    verifyPersistentData(expectedProps.role, "BMC is not paired", true);
+}
+
+/**
+ * @brief Test: BMC becomes passive when BMC position is unknown
+ */
+TEST_F(ManagerTest, BecomesPassive_NoBMCPosition)
+{
+    // Configure scenario: BMC position is unknown
+    TestScenarioConfig config{.bmcPosition = std::nullopt};
+    setupTestScenario(config);
+
+    auto& services = mockProviders->getMockServices();
+
+    EXPECT_CALL(services, logError(errors::error_msg::bmcIsPassiveDueToError,
+                                   errors::Level::Error, _))
+        .Times(1);
+
+    EXPECT_CALL(services,
+                startUnit("obmc-bmc-passive.target", passiveTargetTimeout))
+        .Times(1);
+
+    RedundancyProps expectedProps{
+        .role = Role::Passive,
+        .redEnabled = false,
+        .failoverInProgress = false,
+        .failoversAllowed = false,
+        .failoverImminent = false,
+        .reasonsForNoRedundancy =
+            {Redundancy::ReasonForNoRedundancy::SiblingCannotBeActive},
+        .failoversNotAllowedReason = FailoversNotAllowedReason::None};
+
+    setupPCIeStorageExpects(expectedProps);
+
+    createManagerAndRun(ProgressPoint::passiveHandlerStartComplete);
+
+    verifyRedundancyProps(manager->getRedundancyInterface(), expectedProps);
+    verifyPersistentData(expectedProps.role, "Cannot determine BMC position",
+                         true);
+}
+
+/**
+ * @brief Test: BMC becomes passive when system inventory is not available
+ */
+TEST_F(ManagerTest, BecomesPassive_SystemInventoryNotAvailable)
+{
+    // Configure scenario: System inventory is not available
+    TestScenarioConfig config{.systemInventoryAvailable = false};
+    setupTestScenario(config);
+
+    auto& services = mockProviders->getMockServices();
+
+    // Verify error log is created for passive due to error
+    EXPECT_CALL(services, logError(errors::error_msg::bmcIsPassiveDueToError,
+                                   errors::Level::Error, _))
+        .Times(1);
+
+    EXPECT_CALL(services,
+                startUnit("obmc-bmc-passive.target", passiveTargetTimeout))
+        .Times(1);
+
+    RedundancyProps expectedProps{
+        .role = Role::Passive,
+        .redEnabled = false,
+        .failoverInProgress = false,
+        .failoversAllowed = false,
+        .failoverImminent = false,
+        .reasonsForNoRedundancy =
+            {Redundancy::ReasonForNoRedundancy::SiblingCannotBeActive},
+        .failoversNotAllowedReason = FailoversNotAllowedReason::None};
+
+    setupPCIeStorageExpects(expectedProps);
+
+    createManagerAndRun(ProgressPoint::passiveHandlerStartComplete);
+
+    verifyRedundancyProps(manager->getRedundancyInterface(), expectedProps);
+    verifyPersistentData(expectedProps.role,
+                         "System inventory is not available", true);
+}
+
+/**
+ * @brief Test: BMC becomes passive when sibling service is not running
+ */
+TEST_F(ManagerTest, BecomesPassive_SiblingServiceNotRunning)
+{
+    // Configure scenario: Sibling service is not running
+    TestScenarioConfig config{.siblingServiceRunning = false};
+    setupTestScenario(config);
+
+    auto& services = mockProviders->getMockServices();
+
+    // Verify error log is created for passive due to error
+    EXPECT_CALL(services, logError(errors::error_msg::bmcIsPassiveDueToError,
+                                   errors::Level::Error, _))
+        .Times(1);
+
+    EXPECT_CALL(services,
+                startUnit("obmc-bmc-passive.target", passiveTargetTimeout))
+        .Times(1);
+
+    RedundancyProps expectedProps{
+        .role = Role::Passive,
+        .redEnabled = false,
+        .failoverInProgress = false,
+        .failoversAllowed = false,
+        .failoverImminent = false,
+        .reasonsForNoRedundancy =
+            {Redundancy::ReasonForNoRedundancy::SiblingCannotBeActive},
+        .failoversNotAllowedReason = FailoversNotAllowedReason::None};
+
+    setupPCIeStorageExpects(expectedProps);
+
+    createManagerAndRun(ProgressPoint::passiveHandlerStartComplete);
+
+    verifyRedundancyProps(manager->getRedundancyInterface(), expectedProps);
+    verifyPersistentData(expectedProps.role,
+                         "Sibling BMC service is not running", true);
+}
+
+/**
+ * @brief Test: BMC becomes passive when sibling is already active
+ */
+TEST_F(ManagerTest, BecomesPassive_SiblingAlreadyActive)
+{
+    // Configure scenario: Sibling is active, this BMC should be passive
+    TestScenarioConfig config{.bmcPosition = 1, .siblingRole = Role::Active};
+    setupTestScenario(config);
+
+    auto& services = mockProviders->getMockServices();
+
+    // No errors
+    EXPECT_CALL(services, logError(errors::error_msg::bmcIsPassiveDueToError,
+                                   errors::Level::Error, _))
+        .Times(0);
+
+    EXPECT_CALL(services,
+                startUnit("obmc-bmc-passive.target", passiveTargetTimeout))
+        .Times(1);
+
+    RedundancyProps expectedProps{
+        .role = Role::Passive,
+        .redEnabled = false,
+        .failoverInProgress = false,
+        .failoversAllowed = false,
+        .failoverImminent = false,
+        .reasonsForNoRedundancy = {},
+        .failoversNotAllowedReason = FailoversNotAllowedReason::None};
+
+    setupPCIeStorageExpects(expectedProps);
+
+    createManagerAndRun(ProgressPoint::passiveHandlerStartComplete);
+
+    verifyRedundancyProps(manager->getRedundancyInterface(), expectedProps);
+    verifyPersistentData(expectedProps.role, "Sibling is already active",
+                         false);
+}
+
+/**
+ * @brief Test: BMC becomes passive when sibling is already active, and
+ *        redundancy is enabled.
+ */
+TEST_F(ManagerTest, BecomesPassive_SiblingAlreadyActive_RedEnabled)
+{
+    // Configure scenario: Sibling is active, this BMC should be passive
+    TestScenarioConfig config{.bmcPosition = 1, .siblingRole = Role::Active};
+    setupTestScenario(config);
+
+    auto& sibling = mockProviders->getMockSibling();
+    auto& services = mockProviders->getMockServices();
+    auto& syncInterface = mockProviders->getMockSyncInterface();
+
+    // Sibling reports redundancy is enabled
+    ON_CALL(sibling, getRedundancyEnabled())
+        .WillByDefault(Return(std::make_optional(true)));
+
+    ON_CALL(sibling, getFailoversAllowed())
+        .WillByDefault(Return(std::make_optional(true)));
+
+    // No errors
+    EXPECT_CALL(services, logError(errors::error_msg::bmcIsPassiveDueToError,
+                                   errors::Level::Error, _))
+        .Times(0);
+
+    EXPECT_CALL(services,
+                startUnit("obmc-bmc-passive.target", passiveTargetTimeout))
+        .Times(1);
+
+    // A full sync should be run since redundancy is enabled
+    EXPECT_CALL(syncInterface, doFullSync()).Times(1);
+
+    createManagerAndRun(ProgressPoint::passiveHandlerStartComplete);
+
+    RedundancyProps expectedProps{
+        .role = Role::Passive,
+        .redEnabled = true,
+        .failoverInProgress = false,
+        .failoversAllowed = true,
+        .failoverImminent = false,
+        .reasonsForNoRedundancy = {},
+        .failoversNotAllowedReason = FailoversNotAllowedReason::None};
+
+    verifyRedundancyProps(manager->getRedundancyInterface(), expectedProps);
+    verifyPersistentData(expectedProps.role, "Sibling is already active",
+                         false);
+}
+
+/**
+ * @brief Test: Manager reads previous role from persistent storage on startup
+ */
+TEST_F(ManagerTest, ReadsPreviousRole_OnStartup)
+{
+    using namespace std::chrono_literals;
+
+    // Write previous role to persistent storage before creating Manager
+    data::write(data::key::role, Role::Passive);
+
+    // Configure scenario: Sibling role is Unknown so role determination
+    // falls through to resumePrevious logic
+    TestScenarioConfig config{.bmcPosition = 0, .siblingRole = Role::Unknown};
+    setupTestScenario(config);
+
+    auto& services = mockProviders->getMockServices();
+    auto& sibling = mockProviders->getMockSibling();
+
+    // No errors
+    EXPECT_CALL(services, logError(errors::error_msg::bmcIsPassiveDueToError,
+                                   errors::Level::Error, _))
+        .Times(0);
+
+    // Since previous role was Passive, manager should wait
+    // for sibling role during startup
+    EXPECT_CALL(sibling, waitForSiblingRole()).Times(1);
+
+    EXPECT_CALL(services,
+                startUnit("obmc-bmc-passive.target", passiveTargetTimeout))
+        .Times(1);
+
+    RedundancyProps expectedProps{
+        .role = Role::Passive,
+        .redEnabled = false,
+        .failoverInProgress = false,
+        .failoversAllowed = false,
+        .failoverImminent = false,
+        .reasonsForNoRedundancy = {},
+        .failoversNotAllowedReason = FailoversNotAllowedReason::None};
+
+    setupPCIeStorageExpects(expectedProps);
+
+    createManagerAndRun(ProgressPoint::passiveHandlerStartComplete);
+
+    verifyRedundancyProps(manager->getRedundancyInterface(), expectedProps);
+    verifyPersistentData(expectedProps.role, "Resuming previous role", false);
+}

--- a/redundant-bmc/test/mocks/async_helpers.hpp
+++ b/redundant-bmc/test/mocks/async_helpers.hpp
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <sdbusplus/async.hpp>
+
+namespace test_helpers
+{
+
+/**
+ * @brief Helper to create a completed coroutine task with no return value
+ *
+ * Use this for mocking methods that return sdbusplus::async::task<>
+ */
+inline sdbusplus::async::task<> makeCompletedTask()
+{
+    co_return;
+}
+
+/**
+ * @brief Generic helper to create a completed coroutine task for any type
+ *
+ * @tparam T - The return type
+ * @param value - The value to return
+ * @return Completed task with the specified value
+ */
+template <typename T>
+inline sdbusplus::async::task<T> makeCompletedTask(T value)
+{
+    co_return value;
+}
+
+} // namespace test_helpers

--- a/redundant-bmc/test/mocks/mock_pcie_storage.hpp
+++ b/redundant-bmc/test/mocks/mock_pcie_storage.hpp
@@ -13,7 +13,7 @@ namespace rbmc
  *
  * Mock implementation of PCIeStorage for testing.
  */
-class MockPCIeStorage : public pcie_data::PCIeStorage
+class MockPCIeStorage : public testing::NiceMock<pcie_data::PCIeStorage>
 {
   public:
     MOCK_METHOD(pcie_data::RedundancyState, readState, (), (override));

--- a/redundant-bmc/test/mocks/mock_pcie_storage.hpp
+++ b/redundant-bmc/test/mocks/mock_pcie_storage.hpp
@@ -16,8 +16,6 @@ namespace rbmc
 class MockPCIeStorage : public pcie_data::PCIeStorage
 {
   public:
-    MOCK_METHOD(void, writeState, (const pcie_data::RedundancyState&),
-                (override));
     MOCK_METHOD(pcie_data::RedundancyState, readState, (), (override));
     MOCK_METHOD(void, updateRole, (uint8_t), (override));
     MOCK_METHOD(void, updateRedundancyEnabled, (bool), (override));

--- a/redundant-bmc/test/mocks/mock_providers.hpp
+++ b/redundant-bmc/test/mocks/mock_providers.hpp
@@ -7,6 +7,7 @@
 #include "mock_sibling_reset.hpp"
 #include "mock_sync_interface.hpp"
 #include "providers.hpp"
+#include "test_progress_tracker.hpp"
 
 #include <gmock/gmock.h>
 
@@ -50,6 +51,11 @@ class MockProviders : public Providers
         return &mockPCIeStorage;
     }
 
+    ProgressTracker& getTracker() override
+    {
+        return testProgressTracker;
+    }
+
     // Helpers to get the Mock versions
     MockServices& getMockServices()
     {
@@ -76,12 +82,18 @@ class MockProviders : public Providers
         return mockPCIeStorage;
     }
 
+    TestProgressTracker& getTestTracker()
+    {
+        return testProgressTracker;
+    }
+
   private:
     MockServices mockServices;
     MockSibling mockSibling;
     MockSyncInterface mockSyncInterface;
     MockSiblingReset mockSiblingReset;
     MockPCIeStorage mockPCIeStorage;
+    TestProgressTracker testProgressTracker;
 };
 
 } // namespace rbmc

--- a/redundant-bmc/test/mocks/mock_providers.hpp
+++ b/redundant-bmc/test/mocks/mock_providers.hpp
@@ -23,7 +23,14 @@ namespace rbmc
 class MockProviders : public Providers
 {
   public:
-    MockProviders() = default;
+    MockProviders()
+    {
+        mockServices.setupDefaultBehavior();
+        mockSibling.setupDefaultBehavior();
+        mockSyncInterface.setupDefaultBehavior();
+        mockSiblingReset.setupDefaultBehavior();
+    }
+
     ~MockProviders() override = default;
 
     Services& getServices() override

--- a/redundant-bmc/test/mocks/mock_services.hpp
+++ b/redundant-bmc/test/mocks/mock_services.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "async_helpers.hpp"
 #include "services.hpp"
 
 #include <gmock/gmock.h>
@@ -68,6 +69,61 @@ class MockServices : public testing::NiceMock<Services>
     MOCK_METHOD(void, setRedundancyDetermined, (), (override));
 
     MOCK_METHOD(sdbusplus::async::task<>, waitForSelfPairing, (), (override));
+
+    /**
+     * @brief Setup default behaviors for common test scenarios to save
+     *        setup in the testcases.
+     */
+    void setupDefaultBehavior()
+    {
+        using ::testing::_;
+        using ::testing::Return;
+
+        ON_CALL(*this, init()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, logError(_, _, _)).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, getSystemState())
+            .WillByDefault(Return(SystemState::off));
+
+        ON_CALL(*this, getPeerConnected()).WillByDefault(Return(true));
+
+        ON_CALL(*this, waitForPeerConnection(_)).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, startUnit(_, _)).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, acquireFullHardwareAccess()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, getBMCState()).WillByDefault([]() {
+            using BMCState =
+                sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState;
+            return test_helpers::makeCompletedTask(BMCState::Ready);
+        });
+
+        ON_CALL(*this, doFailoverImminentDelay()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, flushJournal()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, getFWVersion()).WillByDefault(Return("12345678"));
+
+        ON_CALL(*this, waitForSelfPairing()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+    }
 };
 
 } // namespace rbmc

--- a/redundant-bmc/test/mocks/mock_sibling.hpp
+++ b/redundant-bmc/test/mocks/mock_sibling.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "async_helpers.hpp"
 #include "sibling.hpp"
 
 #include <gmock/gmock.h>
@@ -57,6 +58,62 @@ class MockSibling : public testing::NiceMock<Sibling>
         (sdbusplus::common::xyz::openbmc_project::control::Failover::Requester,
          const FailoverOptions&),
         (override));
+
+    /**
+     * @brief Setup default behaviors for common test scenarios to save
+     *        setup in the testcases.
+     */
+    void setupDefaultBehavior()
+    {
+        using ::testing::_;
+        using ::testing::Return;
+        using ::testing::ReturnRef;
+
+        ON_CALL(*this, init()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, getServiceName()).WillByDefault(ReturnRef(serviceName));
+
+        ON_CALL(*this, waitForSiblingUp()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, waitForSiblingRole()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, waitForBMCSteadyState()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, pauseForHeartbeatChange()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, pauseForDataPropagation()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+
+        ON_CALL(*this, getBMCState()).WillByDefault([this]() {
+            if (this->alive())
+            {
+                return std::make_optional(BMCState::Ready);
+            }
+            return std::optional<BMCState>{};
+        });
+
+        ON_CALL(*this, getFWVersion()).WillByDefault([this]() {
+            if (this->alive())
+            {
+                return std::make_optional<std::string>("12345678");
+            }
+            return std::optional<std::string>{};
+        });
+    }
+
+  private:
+    std::string serviceName{"xyz.openbmc_project.State.BMC.Redundancy.Sibling"};
 };
 
 } // namespace rbmc

--- a/redundant-bmc/test/mocks/mock_sibling_reset.hpp
+++ b/redundant-bmc/test/mocks/mock_sibling_reset.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "async_helpers.hpp"
 #include "sibling_reset.hpp"
 
 #include <gmock/gmock.h>
@@ -22,6 +23,17 @@ class MockSiblingReset : public testing::NiceMock<SiblingReset>
     MOCK_METHOD(void, assertReset, (), (override));
     MOCK_METHOD(void, releaseReset, (), (override));
     MOCK_METHOD(sdbusplus::async::task<>, toggleReset, (), (override));
+
+    /**
+     * @brief Setup default behaviors for common test scenarios to save
+     *        setup in the testcases.
+     */
+    void setupDefaultBehavior()
+    {
+        ON_CALL(*this, toggleReset()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+    }
 };
 
 } // namespace rbmc

--- a/redundant-bmc/test/mocks/mock_sync_interface.hpp
+++ b/redundant-bmc/test/mocks/mock_sync_interface.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "async_helpers.hpp"
 #include "sync_interface.hpp"
 
 #include <gmock/gmock.h>
@@ -22,6 +23,24 @@ class MockSyncInterface : public testing::NiceMock<SyncInterface>
     MOCK_METHOD(sdbusplus::async::task<bool>, doFullSync, (), (override));
     MOCK_METHOD(sdbusplus::async::task<>, disableBackgroundSync, (),
                 (override));
+
+    /**
+     * @brief Setup default behaviors for common test scenarios to save
+     *        setup in the testcases.
+     */
+    void setupDefaultBehavior()
+    {
+        ON_CALL(*this, doFullSync()).WillByDefault([this]() {
+            fullSyncComplete = true;
+            return test_helpers::makeCompletedTask(true);
+        });
+
+        ON_CALL(*this, disableBackgroundSync()).WillByDefault([]() {
+            return test_helpers::makeCompletedTask();
+        });
+    }
+
+    bool fullSyncComplete{false};
 };
 
 } // namespace rbmc

--- a/redundant-bmc/test/mocks/test_progress_tracker.hpp
+++ b/redundant-bmc/test/mocks/test_progress_tracker.hpp
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "progress_tracker.hpp"
+
+#include <set>
+
+namespace rbmc
+{
+
+/**
+ * @class TestProgressTracker
+ */
+class TestProgressTracker : public ProgressTracker
+{
+  public:
+    TestProgressTracker() = default;
+    ~TestProgressTracker() override = default;
+
+    TestProgressTracker(const TestProgressTracker&) = delete;
+    TestProgressTracker& operator=(const TestProgressTracker&) = delete;
+    TestProgressTracker(TestProgressTracker&&) = delete;
+    TestProgressTracker& operator=(TestProgressTracker&&) = delete;
+
+    /**
+     * @brief Track a progress point
+     *
+     * @param[in] event - The point to track
+     */
+    void track(ProgressPoint point) override
+    {
+        progress.insert(point);
+    }
+
+    /**
+     * @brief Check if the progress point has been reached
+     *
+     * @param[in] point - The point to check
+     * @return true if it has been reached
+     */
+    bool hasReached(ProgressPoint point) const override
+    {
+        return progress.contains(point);
+    }
+
+  private:
+    /**
+     * @brief The reached progress points
+     */
+    std::set<ProgressPoint> progress;
+};
+
+} // namespace rbmc


### PR DESCRIPTION
Add testcases for the Manager class where the BMC becomes passive on startup.

The mock classes all have a new setupDefaultBehaviors function to handle returning default values for their coroutine functions so the testcases themselves don't have to specify them unless they want a different one.

There is also a ProgressTracker base and child class that lives on Providers so that the code can set a progress point that the testcase can wait for, like finishing starting the active or passive role handlers.  This way, the testcase can just wait for those to be set and can be as fast as possible, as opposed to just delaying for some amount of time.  In the future, there would also be one for a failover completion.

Change-Id: I904b66138dc12c89f9afda9925192d162bd9eff3