### PR TITLE
RBMC: Be more lenient with forced failovers during code updates

### DIFF
--- a/redundant-bmc/README.md
+++ b/redundant-bmc/README.md
@@ -206,6 +206,57 @@ The indication will be cleared if:
    important than finishing the code update, so the code won't treat it
    differently anymore.
 
+### Recovering from bad code updates
+
+When the active BMC reboots into its new image, the following error paths can
+occur:
+
+1. It never comes back from the reboot.
+2. It hits one of the
+   [cases where it must be passive due to an error](#cases-that-require-a-bmc-must-be-passive)
+   and comes back as passive instead of active.
+3. Redundancy gets disabled for other reasons than just the mismatched code
+   levels.
+4. A critical service crashes and the BMC goes to the Quiesced state.
+5. Something outside of the redundant BMC realm is determined to not be working
+   correctly.
+
+In all of these cases, a failover to the passive BMC that is running the
+existing code may be desired.
+
+Assuming redundancy was enabled at the time the BMC was rebooted:
+
+In case 1, the passive BMC will remember redundancy was still enabled when it
+last heard from the active and still allow a failover.
+
+In the remaining cases, redundancy would be disabled at the very least because
+the code levels are no longer the same. To handle this case, the code will do
+the following:
+
+1. The 'code update in progress' indication mentioned above will be watched on
+   the passive BMC.
+2. If redundancy is enabled when it is asserted, the passive BMC will enter a
+   special code update failover mode.
+3. Now, regardless of the role or redundancy state of the active BMC, a forced
+   failover will still be allowed as long as the passive BMC is in this mode.
+   - The active BMC is not aware of this mode, so the forced failover has to be
+     issued on the passive BMC itself.
+
+This mode can be seen in the rbmctool output on the passive BMC to help service
+personnel identify it.
+
+```text
+Code Update FO Mode:  true
+```
+
+This mode is cleared:
+
+1. When the active BMC clears its code-update-in-progress indication.
+   - As mentioned above, this happens when the code levels match again, or a
+     boot is started.
+2. When the passive BMC is rebooted.
+3. When the passive BMC become active on a failover.
+
 ## Interacting with Data Sync on the Active BMC
 
 ### When Enabling Redundancy
@@ -320,6 +371,13 @@ the request if any of the following are true.
 1. The active BMC has no heartbeat and redundancy wasn't last known to be
    enabled. If it was last known to be enabled, a failover is allowed so that
    the remaining BMC can become active.
+   - Exception: if the passive BMC is in
+     [code update failover mode](#recovering-from-bad-code-updates) and `force`
+     was passed, this check is bypassed.
+1. Redundancy is not enabled and the sibling is alive.
+   - Exception: if the passive BMC is in
+     [code update failover mode](#recovering-from-bad-code-updates) and `force`
+     was passed, this check is bypassed.
 1. The passive BMC is not in the `Ready` state.
 
 ### Failover Sequence

--- a/redundant-bmc/src/active_role_handler.cpp
+++ b/redundant-bmc/src/active_role_handler.cpp
@@ -16,21 +16,46 @@ constexpr auto bmcActiveTarget = "obmc-bmc-active.target";
 const std::chrono::minutes bmcActiveTargetTimeout{30};
 const std::chrono::minutes siblingHealthTimeout{5};
 
-// NOLINTNEXTLINE
-sdbusplus::async::task<> ActiveRoleHandler::start()
+ActiveRoleHandler::ActiveRoleHandler(
+    sdbusplus::async::context& ctx, Providers& providers,
+    RedundancyInterface& iface, CodeUpdateActivation& codeUpdateActivation) :
+    RoleHandler(ctx, providers, iface),
+    redMgr(ctx, providers, iface, codeUpdateActivation),
+    siblingHealthTimer(
+        ctx, providers.getWaitTracker(),
+        std::bind_front(&ActiveRoleHandler::siblingHealthCritical, this)),
+    peerConnectionTimer(
+        ctx, providers.getWaitTracker(),
+        std::bind_front(&ActiveRoleHandler::peerConnectionCritical, this))
 {
-    auto& services = providers.getServices();
-    auto& sibling = providers.getSibling();
-
+    // This is only valid on the passive BMC
     try
     {
-        data::write(data::key::passiveError, false);
+        data::remove(data::key::passiveError);
     }
     catch (const std::exception& e)
     {
         lg2::error("Failed clearing the PassiveDueToError field: {ERROR}",
                    "ERROR", e);
     }
+
+    // This is only valid on the passive BMC
+    try
+    {
+        data::remove(data::key::codeUpdateFOMode);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed clearing the CodeUpdateFOMode field: {ERROR}",
+                   "ERROR", e);
+    }
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> ActiveRoleHandler::start()
+{
+    auto& services = providers.getServices();
+    auto& sibling = providers.getSibling();
 
     try
     {

--- a/redundant-bmc/src/active_role_handler.hpp
+++ b/redundant-bmc/src/active_role_handler.hpp
@@ -32,16 +32,7 @@ class ActiveRoleHandler : public RoleHandler
      */
     ActiveRoleHandler(sdbusplus::async::context& ctx, Providers& providers,
                       RedundancyInterface& iface,
-                      CodeUpdateActivation& codeUpdateActivation) :
-        RoleHandler(ctx, providers, iface),
-        redMgr(ctx, providers, iface, codeUpdateActivation),
-        siblingHealthTimer(
-            ctx, providers.getWaitTracker(),
-            std::bind_front(&ActiveRoleHandler::siblingHealthCritical, this)),
-        peerConnectionTimer(
-            ctx, providers.getWaitTracker(),
-            std::bind_front(&ActiveRoleHandler::peerConnectionCritical, this))
-    {}
+                      CodeUpdateActivation& codeUpdateActivation);
 
     /**
      * @brief Destructor

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -399,7 +399,8 @@ auto PassiveRoleHandler::getFailoverBlockedReason(
         // RedundancyEnabled will still have been mirrored to the passive.
         // This will be used to know if a failover is still OK without live
         // data from the active BMC.
-        .lastKnownRedundancyEnabled = redundancyInterface.redundancy_enabled()};
+        .lastKnownRedundancyEnabled = redundancyInterface.redundancy_enabled(),
+        .codeUpdateFailoverMode = codeUpdateFailoverMode};
 
     co_return fo_blocked::getPassiveFailoverBlockedReason(input);
 }

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -48,31 +48,6 @@ PassiveRoleHandler::PassiveRoleHandler(sdbusplus::async::context& ctx,
     }
 
     util::clearExternalRedundancyInputs();
-}
-
-// NOLINTNEXTLINE
-sdbusplus::async::task<> PassiveRoleHandler::start()
-{
-    try
-    {
-        // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
-        co_await providers.getServices().startUnit(bmcPassiveTarget,
-                                                   std::chrono::minutes{5});
-    }
-    catch (const std::exception& e)
-    {
-        lg2::error("Failed while starting BMC passive target: {ERROR}", "ERROR",
-                   e);
-    }
-
-    // Setup the mirroring of the active BMC RedundancyEnabled
-    setupSiblingRedEnabledWatch();
-
-    setupSiblingFailoversAllowedWatch();
-
-    setupSiblingHealthWatch();
-
-    setupPeerConnectedWatch();
 
     try
     {
@@ -97,6 +72,29 @@ sdbusplus::async::task<> PassiveRoleHandler::start()
             "Failed while removing CodeUpdateInProgress saved value: {ERROR}",
             "ERROR", e);
     }
+}
+
+sdbusplus::async::task<> PassiveRoleHandler::start()
+{
+    try
+    {
+        // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
+        co_await providers.getServices().startUnit(bmcPassiveTarget,
+                                                   std::chrono::minutes{5});
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed while starting BMC passive target: {ERROR}", "ERROR",
+                   e);
+    }
+
+    setupSiblingRedEnabledWatch();
+
+    setupSiblingFailoversAllowedWatch();
+
+    setupSiblingHealthWatch();
+
+    setupPeerConnectedWatch();
 
     providers.getTracker().track(ProgressPoint::passiveHandlerStartComplete);
 }

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -142,12 +142,9 @@ void PassiveRoleHandler::setupSiblingFailoversAllowedWatch()
 
 void PassiveRoleHandler::siblingRedEnabledHandler(bool enable)
 {
-    // If the sibling is Active, mirror the property on this BMC.
-    if (providers.getSibling().getRole().value_or(Role::Unknown) ==
-        Role::Active)
-    {
-        redundancyInterface.redundancy_enabled(enable);
-    }
+    // Mirror the property.  If the other BMC was also passive,
+    // the value would be false anyway.
+    redundancyInterface.redundancy_enabled(enable);
 
     // Kick off a full sync if possible
     ctx.spawn(tryFullSync());
@@ -155,14 +152,9 @@ void PassiveRoleHandler::siblingRedEnabledHandler(bool enable)
 
 void PassiveRoleHandler::siblingFailoversAllowedHandler(bool allowed)
 {
-    // If the sibling is Active, mirror the property on this BMC.
-    // TODO: The passive BMC ill have its own reasons for not allowing
-    // failovers that also need to be considered.
-    if (providers.getSibling().getRole().value_or(Role::Unknown) ==
-        Role::Active)
-    {
-        redundancyInterface.failovers_allowed(allowed);
-    }
+    // Mirror the property.  If the other BMC was also passive,
+    // the value would be false anyway.
+    redundancyInterface.failovers_allowed(allowed);
 }
 
 void PassiveRoleHandler::disableRedPropChanged(bool /*disable*/)
@@ -291,9 +283,22 @@ void PassiveRoleHandler::siblingHealthChange(bool alive)
 
     if (alive)
     {
-        // Probably redundancy would be disabled here,
-        // but try anyway just in case.
-        ctx.spawn(tryFullSync());
+        auto& sibling = providers.getSibling();
+
+        // Force a refresh of the redundancy properties here as they default
+        // to false when the active starts up and may not change again.
+        auto sibRedEnabled = sibling.getRedundancyEnabled();
+        if (sibRedEnabled.has_value())
+        {
+            // Would do a full sync if redundancy is enabled
+            siblingRedEnabledHandler(sibRedEnabled.value());
+        }
+
+        auto sibAllowed = sibling.getFailoversAllowed();
+        if (sibAllowed.has_value())
+        {
+            siblingFailoversAllowedHandler(sibAllowed.value());
+        }
     }
     else
     {

--- a/redundant-bmc/src/passive_role_handler.cpp
+++ b/redundant-bmc/src/passive_role_handler.cpp
@@ -72,6 +72,8 @@ PassiveRoleHandler::PassiveRoleHandler(sdbusplus::async::context& ctx,
             "Failed while removing CodeUpdateInProgress saved value: {ERROR}",
             "ERROR", e);
     }
+
+    setCUFOMode(false);
 }
 
 sdbusplus::async::task<> PassiveRoleHandler::start()
@@ -93,6 +95,8 @@ sdbusplus::async::task<> PassiveRoleHandler::start()
     setupSiblingFailoversAllowedWatch();
 
     setupSiblingHealthWatch();
+
+    setupSiblingInCodeUpdateWatch();
 
     setupPeerConnectedWatch();
 
@@ -153,6 +157,61 @@ void PassiveRoleHandler::siblingFailoversAllowedHandler(bool allowed)
     // Mirror the property.  If the other BMC was also passive,
     // the value would be false anyway.
     redundancyInterface.failovers_allowed(allowed);
+}
+
+void PassiveRoleHandler::setCUFOMode(bool value)
+{
+    codeUpdateFailoverMode = value;
+    try
+    {
+        data::write(data::key::codeUpdateFOMode, value);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed persisting CodeUpdateFOMode field: {ERROR}", "ERROR",
+                   e);
+    }
+}
+
+void PassiveRoleHandler::setupSiblingInCodeUpdateWatch()
+{
+    auto& sibling = providers.getSibling();
+
+    // Register for changes
+    sibling.addInCodeUpdateCallback(Role::Passive, [this](bool inCodeUpdate) {
+        siblingInCodeUpdateHandler(inCodeUpdate);
+    });
+
+    // Handle current value
+    auto sibInCodeUpdate = sibling.getInCodeUpdate();
+    if (sibInCodeUpdate.has_value())
+    {
+        siblingInCodeUpdateHandler(sibInCodeUpdate.value());
+    }
+}
+
+void PassiveRoleHandler::siblingInCodeUpdateHandler(bool inCodeUpdate)
+{
+    if (inCodeUpdate)
+    {
+        if (!redundancyInterface.redundancy_enabled())
+        {
+            lg2::warning(
+                "Sibling code update started but redundancy is disabled "
+                "so not entering code update failover mode");
+            return;
+        }
+
+        lg2::info("Sibling code update started so entering code update "
+                  "failover mode");
+        setCUFOMode(true);
+    }
+    else if (codeUpdateFailoverMode)
+    {
+        lg2::info(
+            "Sibling code update ended so clearing code update failover mode");
+        setCUFOMode(false);
+    }
 }
 
 void PassiveRoleHandler::disableRedPropChanged(bool /*disable*/)

--- a/redundant-bmc/src/passive_role_handler.hpp
+++ b/redundant-bmc/src/passive_role_handler.hpp
@@ -90,6 +90,27 @@ class PassiveRoleHandler : public RoleHandler
     void setupSiblingFailoversAllowedWatch();
 
     /**
+     * @brief Setup watching the sibling BMC's code update state.
+     */
+    void setupSiblingInCodeUpdateWatch();
+
+    /**
+     * @brief Handler for the sibling's code update state changing.
+     *
+     * @param[in] inCodeUpdate - true if a code update started
+     */
+    void siblingInCodeUpdateHandler(bool inCodeUpdate);
+
+    /**
+     * @brief Sets or clears the code update failover mode.
+     *
+     * Persists the state as well.
+     *
+     * @param[in] value - true to enter the mode, false to leave it
+     */
+    void setCUFOMode(bool value);
+
+    /**
      * @brief Handler for the FailoversAllowed property
      *        on the sibling's D-Bus interface changing.
      *
@@ -194,6 +215,13 @@ class PassiveRoleHandler : public RoleHandler
      * then just try on each one.
      */
     bool fullSyncDone{false};
+
+    /**
+     * @brief Tracks if the sibling started a code update while
+     *        redundancy was enabled, allowing more lenient failover
+     *        checking when the force option is used.
+     */
+    bool codeUpdateFailoverMode{false};
 };
 
 } // namespace rbmc

--- a/redundant-bmc/src/passive_role_handler.hpp
+++ b/redundant-bmc/src/passive_role_handler.hpp
@@ -79,8 +79,7 @@ class PassiveRoleHandler : public RoleHandler
      * @brief Handler for the RedundancyEnabled property
      *        on the sibling's D-Bus interface changing.
      *
-     * Will mirror the value on this BMC's Redundancy
-     * interface if the other BMC is Active.
+     * Will mirror the value on this BMC's Redundancy interface
      */
     void siblingRedEnabledHandler(bool enable);
 
@@ -94,8 +93,7 @@ class PassiveRoleHandler : public RoleHandler
      * @brief Handler for the FailoversAllowed property
      *        on the sibling's D-Bus interface changing.
      *
-     * Will mirror the value on this BMC's Redundancy
-     * interface if the other BMC is Active.
+     * Will mirror the value on this BMC's Redundancy interface
      */
     void siblingFailoversAllowedHandler(bool allowed);
 

--- a/redundant-bmc/src/persistent_data.hpp
+++ b/redundant-bmc/src/persistent_data.hpp
@@ -58,6 +58,7 @@ constexpr auto failoverInProgress = "FailoverInProgress";
 constexpr auto externalRedundancyInputs = "ExternalRedundancyInputs";
 constexpr auto hostOff = "HostOff";
 constexpr auto codeUpdateInProgress = "CodeUpdateInProgress";
+constexpr auto codeUpdateFOMode = "CodeUpdateFOMode";
 } // namespace key
 
 namespace util

--- a/redundant-bmc/src/redundancy.cpp
+++ b/redundant-bmc/src/redundancy.cpp
@@ -156,7 +156,16 @@ Reason getPassiveFailoverBlockedReason(const PassiveInput& input)
     {
         if (!input.redundancyEnabled)
         {
-            return Reason::redundancyNotEnabled;
+            if (input.codeUpdateFailoverMode && input.forceOption)
+            {
+                lg2::warning(
+                    "Redundancy not enabled but code update failover "
+                    "mode is active with the force option so allowing");
+            }
+            else
+            {
+                return Reason::redundancyNotEnabled;
+            }
         }
         else if (input.failoversNotAllowed)
         {
@@ -192,9 +201,21 @@ Reason getPassiveFailoverBlockedReason(const PassiveInput& input)
         // RedundancyEnabled to decide if a failover is OK.  Not perfect, but
         // otherwise we could be stuck with 1 dead BMC and 1 passive BMC with no
         // way to fail over.
+        // If codeUpdateFailoverMode is active, then redundancy was at one time
+        // enabled, so still allow the failover there too.
         if (!input.lastKnownRedundancyEnabled)
         {
-            return Reason::siblingDeadButRedundancyNotEnabled;
+            if (input.codeUpdateFailoverMode && input.forceOption)
+            {
+                lg2::warning(
+                    "Sibling dead and redundancy not enabled but code "
+                    "update failover mode is active with the force option "
+                    "so allowing");
+            }
+            else
+            {
+                return Reason::siblingDeadButRedundancyNotEnabled;
+            }
         }
 
         lg2::info(

--- a/redundant-bmc/src/redundancy.hpp
+++ b/redundant-bmc/src/redundancy.hpp
@@ -101,6 +101,7 @@ struct PassiveInput
     bool forceOption;
     bool failoverInProgress;
     bool lastKnownRedundancyEnabled;
+    bool codeUpdateFailoverMode;
 };
 
 /**

--- a/redundant-bmc/src/sibling.hpp
+++ b/redundant-bmc/src/sibling.hpp
@@ -4,6 +4,7 @@
 
 #include <sdbusplus/async.hpp>
 #include <xyz/openbmc_project/Control/Failover/common.hpp>
+#include <xyz/openbmc_project/Software/Activation/common.hpp>
 #include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
 #include <xyz/openbmc_project/State/BMC/common.hpp>
 
@@ -31,11 +32,14 @@ class Sibling
         sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState;
     using ReasonForNoRedundancy = sdbusplus::common::xyz::openbmc_project::
         state::bmc::Redundancy::ReasonForNoRedundancy;
+    using Activations = sdbusplus::common::xyz::openbmc_project::software::
+        Activation::Activations;
     using RedundancyEnabledCallback = std::function<void(bool)>;
     using BMCStateCallback = std::function<void(BMCState)>;
     using HealthCallback = std::function<void(bool)>;
     using FailoversAllowedCallback = std::function<void(bool)>;
     using FailoverImminentCallback = std::function<void(bool)>;
+    using InCodeUpdateCallback = std::function<void(bool)>;
 
     Sibling() = default;
     virtual ~Sibling() = default;
@@ -147,6 +151,13 @@ class Sibling
     virtual std::optional<bool> getHasReasonForNoRedundancy() const = 0;
 
     /**
+     * @brief Returns if the sibling has a code update in progress
+     *
+     * @return - If in progress, or nullopt if not available
+     */
+    virtual std::optional<bool> getInCodeUpdate() const = 0;
+
+    /**
      * @brief Returns if the sibling BMC is plugged in
      *
      * @return bool - if present
@@ -160,7 +171,8 @@ class Sibling
     virtual sdbusplus::async::task<> pauseForHeartbeatChange() const = 0;
 
     /**
-     * @brief Pause to allow time for data from the sibling BMC to propagate.
+     * @brief Pause to allow time for data from the sibling BMC to
+     * propagate.
      */
     virtual sdbusplus::async::task<> pauseForDataPropagation() const = 0;
 
@@ -202,6 +214,7 @@ class Sibling
         healthCBs.erase(role);
         foAllowedCBs.erase(role);
         foImminentCBs.erase(role);
+        inCodeUpdateCBs.erase(role);
     }
 
     /**
@@ -268,6 +281,18 @@ class Sibling
         foImminentCBs.emplace(role, std::move(callback));
     }
 
+    /**
+     * @brief Adds a callback function to invoke when the sibling's
+     *        code update state changes
+     *
+     * @param[in] role - The role to register with
+     * @param[in] callback - The callback function
+     */
+    void addInCodeUpdateCallback(Role role, InCodeUpdateCallback callback)
+    {
+        inCodeUpdateCBs.emplace(role, std::move(callback));
+    }
+
   protected:
     /**
      * @brief Callbacks for RedundancyEnabled
@@ -293,5 +318,10 @@ class Sibling
      * @brief Callbacks for FailoverImminent
      */
     std::map<Role, FailoverImminentCallback> foImminentCBs;
+
+    /**
+     * @brief Callbacks for InCodeUpdate
+     */
+    std::map<Role, InCodeUpdateCallback> inCodeUpdateCBs;
 };
 } // namespace rbmc

--- a/redundant-bmc/src/sibling_impl.cpp
+++ b/redundant-bmc/src/sibling_impl.cpp
@@ -25,6 +25,8 @@ using AvailIntf =
     sdbusplus::common::xyz::openbmc_project::state::decorator::Availability;
 using PairingIntf =
     sdbusplus::common::xyz::openbmc_project::provisioning::Provisioning;
+using ActivationIntf =
+    sdbusplus::common::xyz::openbmc_project::software::Activation;
 
 SiblingImpl::SiblingImpl(sdbusplus::async::context& ctx,
                          const RedundantBMCConfig& config, Services& services,
@@ -238,6 +240,28 @@ void SiblingImpl::loadPairingProps(const SiblingImpl::PropertyMap& propertyMap)
     }
 }
 
+void SiblingImpl::loadActivationProps(
+    const SiblingImpl::PropertyMap& propertyMap)
+{
+    activation.present = true;
+
+    auto it = propertyMap.find("Activation");
+    if (it != propertyMap.end())
+    {
+        auto old = activation.activating;
+        activation.activating =
+            std::get<Activations>(it->second) == Activations::Activating;
+        if (activation.activating != old)
+        {
+            for (const auto& callback :
+                 std::ranges::views::values(inCodeUpdateCBs))
+            {
+                callback(activation.activating);
+            }
+        }
+    }
+}
+
 sdbusplus::async::task<> SiblingImpl::watchInterfaceAdded(
     std::shared_ptr<sdbusplus::async::barrier> barrier)
 {
@@ -322,6 +346,10 @@ sdbusplus::async::task<> SiblingImpl::watchInterfaceRemoved(
         if (std::ranges::contains(interfaces, PairingIntf::interface))
         {
             pairing.present = false;
+        }
+        if (std::ranges::contains(interfaces, ActivationIntf::interface))
+        {
+            activation.present = false;
         }
 
         // If alive before and all interfaces are now gone invoke the callbacks
@@ -433,6 +461,10 @@ void SiblingImpl::loadFromPropertyMap(const std::string& interface,
     else if (interface == PairingIntf::interface)
     {
         loadPairingProps(propertyMap);
+    }
+    else if (interface == ActivationIntf::interface)
+    {
+        loadActivationProps(propertyMap);
     }
 }
 

--- a/redundant-bmc/src/sibling_impl.hpp
+++ b/redundant-bmc/src/sibling_impl.hpp
@@ -25,7 +25,7 @@ class SiblingImpl : public Sibling
   public:
     using PropertyVariant =
         std::variant<std::string, bool, Role, size_t, BMCState,
-                     std::vector<ReasonForNoRedundancy>>;
+                     std::vector<ReasonForNoRedundancy>, Activations>;
     using PropertyMap = std::unordered_map<std::string, PropertyVariant>;
     using InterfaceMap = std::map<std::string, PropertyMap>;
     using ManagedObjects =
@@ -59,7 +59,7 @@ class SiblingImpl : public Sibling
     bool alive() const override
     {
         return version.present && redundancy.present && bmcState.present &&
-               availability.present;
+               availability.present && activation.present;
     }
 
     /**
@@ -223,6 +223,21 @@ class SiblingImpl : public Sibling
     }
 
     /**
+     * @brief Returns if the sibling has a code update in progress
+     *
+     * @return - If in progress, or nullopt if not available
+     */
+    std::optional<bool> getInCodeUpdate() const override
+    {
+        if (alive())
+        {
+            return activation.activating;
+        }
+
+        return std::nullopt;
+    }
+
+    /**
      * @brief Returns if the sibling BMC is plugged in
      *
      * @return bool - if present
@@ -348,6 +363,13 @@ class SiblingImpl : public Sibling
     void loadPairingProps(const PropertyMap& propertyMap);
 
     /**
+     * @brief Sets Activation data members with whatever is in the property map
+     *
+     * @param[in] propertyMap - The property name -> value map
+     */
+    void loadActivationProps(const PropertyMap& propertyMap);
+
+    /**
      * @brief Sets data members with whatever is in the property map
      *
      * @param[in] interface - The interface name
@@ -366,6 +388,7 @@ class SiblingImpl : public Sibling
         version.present = false;
         availability.present = false;
         pairing.present = false;
+        activation.present = false;
     }
 
     /**
@@ -473,6 +496,17 @@ class SiblingImpl : public Sibling
      * @brief Pairing presence and value
      */
     Pairing pairing;
+
+    struct Activation
+    {
+        bool present = false;
+        bool activating = false;
+    };
+
+    /**
+     * @brief Activation presence and value
+     */
+    Activation activation;
 
     /**
      * @brief The D-Bus object path for the sibling.

--- a/redundant-bmc/test/manager_test.cpp
+++ b/redundant-bmc/test/manager_test.cpp
@@ -262,11 +262,14 @@ class ManagerTest : public rbmc::test::PersistentDataTestFixture
             << "Role should be saved to persistent data";
         EXPECT_EQ(savedRole.value(), expectedRole);
 
-        // Verify passiveError flag was saved
-        auto savedPassiveError = data::read<bool>(data::key::passiveError);
-        ASSERT_TRUE(savedPassiveError.has_value())
-            << "PassiveError flag should be saved to persistent data";
-        EXPECT_EQ(savedPassiveError.value(), expectPassiveError);
+        // PassiveError only exists on the passive BMC
+        if (expectedRole == Role::Passive)
+        {
+            auto savedPassiveError = data::read<bool>(data::key::passiveError);
+            ASSERT_TRUE(savedPassiveError.has_value())
+                << "PassiveError flag should be saved to persistent data";
+            EXPECT_EQ(savedPassiveError.value(), expectPassiveError);
+        }
 
         // Verify role reason description was saved
         auto savedRoleReason = data::read<std::string>(data::key::roleReason);

--- a/redundant-bmc/test/mocks/mock_sibling.hpp
+++ b/redundant-bmc/test/mocks/mock_sibling.hpp
@@ -44,6 +44,7 @@ class MockSibling : public testing::NiceMock<Sibling>
                 (const, override));
     MOCK_METHOD(std::optional<bool>, getHasReasonForNoRedundancy, (),
                 (const, override));
+    MOCK_METHOD(std::optional<bool>, getInCodeUpdate, (), (const, override));
     MOCK_METHOD(std::optional<BMCState>, getBMCState, (), (const, override));
 
     MOCK_METHOD(const std::string&, getServiceName, (), (const, override));

--- a/redundant-bmc/test/redundancy_test.cpp
+++ b/redundant-bmc/test/redundancy_test.cpp
@@ -249,7 +249,8 @@ TEST(RedundancyTest, PassiveFailoverBlockedTest)
         .failoversNotAllowed = false,
         .forceOption = false,
         .failoverInProgress = false,
-        .lastKnownRedundancyEnabled = true};
+        .lastKnownRedundancyEnabled = true,
+        .codeUpdateFailoverMode = false};
 
     EXPECT_EQ(rbmc::fo_blocked::getPassiveFailoverBlockedReason(golden),
               rbmc::fo_blocked::Reason::none);
@@ -329,6 +330,51 @@ TEST(RedundancyTest, PassiveFailoverBlockedTest)
         input.failoverInProgress = true;
         EXPECT_EQ(rbmc::fo_blocked::getPassiveFailoverBlockedReason(input),
                   rbmc::fo_blocked::Reason::failoverAlreadyInProgress);
+    }
+
+    // Code update failover mode: redundancy not enabled, force - allowed
+    {
+        auto input = golden;
+        input.redundancyEnabled = false;
+        input.forceOption = true;
+        input.codeUpdateFailoverMode = true;
+        EXPECT_EQ(rbmc::fo_blocked::getPassiveFailoverBlockedReason(input),
+                  rbmc::fo_blocked::Reason::none);
+    }
+
+    // Code update failover mode: redundancy not enabled, no force - still
+    // blocked
+    {
+        auto input = golden;
+        input.redundancyEnabled = false;
+        input.codeUpdateFailoverMode = true;
+        input.forceOption = false;
+        EXPECT_EQ(rbmc::fo_blocked::getPassiveFailoverBlockedReason(input),
+                  rbmc::fo_blocked::Reason::redundancyNotEnabled);
+    }
+
+    // Code update failover mode: sibling dead, last known red disabled, force -
+    // allowed
+    {
+        auto input = golden;
+        input.siblingAlive = false;
+        input.lastKnownRedundancyEnabled = false;
+        input.codeUpdateFailoverMode = true;
+        input.forceOption = true;
+        EXPECT_EQ(rbmc::fo_blocked::getPassiveFailoverBlockedReason(input),
+                  rbmc::fo_blocked::Reason::none);
+    }
+
+    // Code update failover mode: sibling dead, last known red disabled, no
+    // force - still blocked
+    {
+        auto input = golden;
+        input.siblingAlive = false;
+        input.lastKnownRedundancyEnabled = false;
+        input.codeUpdateFailoverMode = true;
+        input.forceOption = false;
+        EXPECT_EQ(rbmc::fo_blocked::getPassiveFailoverBlockedReason(input),
+                  rbmc::fo_blocked::Reason::siblingDeadButRedundancyNotEnabled);
     }
 }
 


### PR DESCRIPTION
The standard code update sequence is going to be to update the active
BMC first and reboot it, and follow by the passive if it went well on
the active.

If it doesn't go well, then a failover could be desired, even if
normally one wouldn't be possible.  See the README for the various
failure scenarios.  At the very least, redundancy would be disabled
because the code levels would no longer match.

A new 'code update failover mode' is now supported by the passive BMC.
It watches the code update status of the sibling, and if redundancy is
enabled when the code update starts, it turns on this mode.  It keeps
this mode on until either

1. There is a failover
2. The passive BMC reboots
3. The active BMC turns off its code update indication. This happens:
  - When code levels match again, or
  - When the system is booted.

While it doesn't persist this mode across passive BMC reboots, it still
writes the mode to data.json so that rbmctool will be able to print it
to help show when it is possible.

When this mode is set, then a forced failover will be allowed by the passive
BMC even when redundancy is disabled.
