### PR TITLE
RBMC: Add redundancy testcases and additional role related testcases

### DIFF
--- a/redundant-bmc/test/manager_test.cpp
+++ b/redundant-bmc/test/manager_test.cpp
@@ -27,7 +27,7 @@ class ManagerTest : public rbmc::test::PersistentDataTestFixture
         bool siblingServiceRunning = true;
         bool siblingPresent = true;
         bool siblingAlive = true;
-        Role siblingRole = Role::Passive;
+        Role siblingRole = Role::Unknown;
         bool siblingPaired = true;
         bool siblingFailoverInProgress = false;
     };
@@ -104,6 +104,29 @@ class ManagerTest : public rbmc::test::PersistentDataTestFixture
         std::vector<Redundancy::ReasonForNoRedundancy> reasonsForNoRedundancy;
         FailoversNotAllowedReason failoversNotAllowedReason;
     };
+
+    static const inline RedundancyProps activeRedundancyEnabledProps{
+        .role = Role::Active,
+        .redEnabled = true,
+        .failoverInProgress = false,
+        .failoversAllowed = true,
+        .failoverImminent = false,
+        .reasonsForNoRedundancy = {},
+        .failoversNotAllowedReason = FailoversNotAllowedReason::None};
+
+    static RedundancyProps activeRedundancyDisabledProps(
+        std::vector<Redundancy::ReasonForNoRedundancy> reasons)
+    {
+        return RedundancyProps{
+            .role = Role::Active,
+            .redEnabled = false,
+            .failoverInProgress = false,
+            .failoversAllowed = false,
+            .failoverImminent = false,
+            .reasonsForNoRedundancy = std::move(reasons),
+            .failoversNotAllowedReason =
+                FailoversNotAllowedReason::NoRedundancy};
+    }
 
     static void verifyRedundancyProps(const RedundancyInterface& iface,
                                       const RedundancyProps& expected)
@@ -217,6 +240,7 @@ class ManagerTest : public rbmc::test::PersistentDataTestFixture
     std::unique_ptr<Manager> manager;
     std::string siblingServiceName;
     std::chrono::seconds passiveTargetTimeout{300};
+    std::chrono::seconds activeTargetTimeout{1800};
     sdbusplus::async::context ctx;
 };
 
@@ -506,4 +530,143 @@ TEST_F(ManagerTest, ReadsPreviousRole_OnStartup)
 
     verifyRedundancyProps(manager->getRedundancyInterface(), expectedProps);
     verifyPersistentData(expectedProps.role, "Resuming previous role", false);
+}
+
+/**
+ * @brief Test: BMC becomes passive when position is 1
+ */
+TEST_F(ManagerTest, BecomesPassive_Position1)
+{
+    // Configure scenario: Sibling is alive, this BMC is position 1
+    TestScenarioConfig config{.bmcPosition = 1, .siblingRole = Role::Unknown};
+    setupTestScenario(config);
+
+    auto& services = mockProviders->getMockServices();
+
+    EXPECT_CALL(services,
+                startUnit("obmc-bmc-passive.target", passiveTargetTimeout))
+        .Times(1);
+
+    RedundancyProps expectedProps{
+        .role = Role::Passive,
+        .redEnabled = false,
+        .failoverInProgress = false,
+        .failoversAllowed = false,
+        .failoverImminent = false,
+        .reasonsForNoRedundancy = {},
+        .failoversNotAllowedReason = FailoversNotAllowedReason::None};
+
+    setupPCIeStorageExpects(expectedProps);
+
+    createManagerAndRun(ProgressPoint::passiveHandlerStartComplete);
+
+    verifyRedundancyProps(manager->getRedundancyInterface(), expectedProps);
+    verifyPersistentData(expectedProps.role, "BMC is not position 0", false);
+}
+
+/**
+ * @brief Test: BMC becomes active when position is 0
+ */
+TEST_F(ManagerTest, BecomesActive_Position0)
+{
+    // Configure scenario: Sibling is alive, this BMC is position 0
+    TestScenarioConfig config{.bmcPosition = 0, .siblingRole = Role::Unknown};
+    setupTestScenario(config);
+
+    auto& services = mockProviders->getMockServices();
+
+    EXPECT_CALL(services,
+                startUnit("obmc-bmc-active.target", activeTargetTimeout))
+        .Times(1);
+
+    RedundancyProps expectedProps{
+        .role = Role::Active,
+        .redEnabled = false,
+        .failoverInProgress = false,
+        .failoversAllowed = false,
+        .failoverImminent = false,
+        // This testcase only tests role selection, so not mocking the sibling
+        // changing to passive and other things to enable redundancy.
+        .reasonsForNoRedundancy =
+            {Redundancy::ReasonForNoRedundancy::SiblingNotPassive},
+        .failoversNotAllowedReason = FailoversNotAllowedReason::NoRedundancy};
+
+    setupPCIeStorageExpects(expectedProps);
+
+    createManagerAndRun(ProgressPoint::activeHandlerStartComplete);
+
+    verifyRedundancyProps(manager->getRedundancyInterface(), expectedProps);
+    verifyPersistentData(expectedProps.role, "BMC is position 0", false);
+}
+
+/**
+ * @brief Test: BMC becomes active when no sibling present
+ */
+TEST_F(ManagerTest, BecomesActive_NoSibling)
+{
+    // Configure scenario: Sibling is not present
+    TestScenarioConfig config{.bmcPosition = 1,
+                              .siblingPresent = false,
+                              .siblingAlive = false,
+                              .siblingRole = Role::Unknown};
+    setupTestScenario(config);
+
+    auto& services = mockProviders->getMockServices();
+    auto& sibling = mockProviders->getMockSibling();
+
+    // The wait functions shouldn't be called
+    EXPECT_CALL(sibling, waitForSiblingUp()).Times(0);
+    EXPECT_CALL(sibling, waitForSiblingRole()).Times(0);
+    EXPECT_CALL(sibling, waitForBMCSteadyState()).Times(0);
+    EXPECT_CALL(services, waitForPeerConnection(_)).Times(0);
+
+    EXPECT_CALL(services, acquireFullHardwareAccess()).Times(1);
+    EXPECT_CALL(services,
+                startUnit("obmc-bmc-active.target", activeTargetTimeout))
+        .Times(1);
+
+    const auto expectedProps = activeRedundancyDisabledProps(
+        {Redundancy::ReasonForNoRedundancy::SiblingMissing});
+
+    setupPCIeStorageExpects(expectedProps);
+
+    createManagerAndRun(ProgressPoint::activeHandlerStartComplete);
+
+    verifyRedundancyProps(manager->getRedundancyInterface(), expectedProps);
+    verifyPersistentData(Role::Active, "Sibling not alive", false);
+}
+
+/**
+ * @brief Test: BMC becomes active when sibling is dead
+ */
+TEST_F(ManagerTest, BecomesActive_SiblingDead)
+{
+    // Configure scenario: Sibling present but not alive
+    TestScenarioConfig config{
+        .bmcPosition = 1, .siblingPresent = true, .siblingAlive = false};
+    setupTestScenario(config);
+
+    auto& services = mockProviders->getMockServices();
+    auto& sibling = mockProviders->getMockSibling();
+
+    // Only 1 wait function should be called
+    EXPECT_CALL(sibling, waitForSiblingUp()).Times(1);
+    EXPECT_CALL(sibling, waitForSiblingRole()).Times(0);
+    EXPECT_CALL(sibling, waitForBMCSteadyState()).Times(0);
+    EXPECT_CALL(services, waitForPeerConnection(_)).Times(0);
+
+    EXPECT_CALL(services, acquireFullHardwareAccess()).Times(1);
+    EXPECT_CALL(services,
+                startUnit("obmc-bmc-active.target", activeTargetTimeout))
+        .Times(1);
+
+    const auto expectedProps = activeRedundancyDisabledProps(
+        {Redundancy::ReasonForNoRedundancy::SiblingNotAlive});
+
+    setupPCIeStorageExpects(expectedProps);
+
+    createManagerAndRun(ProgressPoint::activeHandlerStartComplete);
+
+    verifyRedundancyProps(manager->getRedundancyInterface(), expectedProps);
+    verifyPersistentData(Role::Active, "Sibling not alive", false);
 }

--- a/redundant-bmc/test/manager_test.cpp
+++ b/redundant-bmc/test/manager_test.cpp
@@ -3,11 +3,13 @@
 #include "mocks/async_helpers.hpp"
 #include "mocks/mock_providers.hpp"
 #include "persistent_data_test_fixture.hpp"
+#include "util.hpp"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 using namespace rbmc;
+using namespace rbmc::util;
 using namespace testing;
 using namespace test_helpers;
 
@@ -161,6 +163,43 @@ class ManagerTest : public rbmc::test::PersistentDataTestFixture
             .Times(vals.failoverInProgress ? 1 : 0);
         EXPECT_CALL(storage, updateFailoversAllowed(vals.failoversAllowed))
             .Times(vals.failoversAllowed ? 1 : 0);
+
+        // The constructor initializes PCIe storage with false; if the final
+        // expected value differs, expect the initial false call as well.
+        // if (vals.redEnabled)
+        // {
+        //     EXPECT_CALL(storage, updateRedundancyEnabled(false)).Times(1);
+        // }
+        // EXPECT_CALL(storage,
+        // updateRedundancyEnabled(vals.redEnabled)).Times(1);
+        //
+        // EXPECT_CALL(storage,
+        // updateFailoverInProgress(vals.failoverInProgress));
+        //
+        // if (vals.failoversAllowed)
+        // {
+        //     EXPECT_CALL(storage, updateFailoversAllowed(false)).Times(1);
+        // }
+        // EXPECT_CALL(storage, updateFailoversAllowed(vals.failoversAllowed))
+        //     .Times(1);
+    }
+
+    /**
+     * @brief Set the standard EXPECT_CALLs for when the BMC is active
+     *        and the sibling is alive.
+     */
+    void setupActiveBMCWithAliveSiblingExpects()
+    {
+        auto& services = mockProviders->getMockServices();
+        auto& sibling = mockProviders->getMockSibling();
+
+        EXPECT_CALL(services, acquireFullHardwareAccess()).Times(1);
+        EXPECT_CALL(services,
+                    startUnit("obmc-bmc-active.target", activeTargetTimeout))
+            .Times(1);
+        EXPECT_CALL(sibling, waitForSiblingRole()).Times(1);
+        EXPECT_CALL(sibling, waitForBMCSteadyState()).Times(1);
+        EXPECT_CALL(services, waitForPeerConnection(_)).Times(1);
     }
 
     /**
@@ -669,4 +708,224 @@ TEST_F(ManagerTest, BecomesActive_SiblingDead)
 
     verifyRedundancyProps(manager->getRedundancyInterface(), expectedProps);
     verifyPersistentData(Role::Active, "Sibling not alive", false);
+}
+
+/**
+ * @brief Test: BMC becomes active and enables redundancy
+ */
+TEST_F(ManagerTest, BecomeActive_EnableRedundancy)
+{
+    // Configure scenario: This BMC should become active
+    TestScenarioConfig config{.bmcPosition = 0, .siblingRole = Role::Passive};
+    setupTestScenario(config);
+
+    auto& services = mockProviders->getMockServices();
+    auto& syncInterface = mockProviders->getMockSyncInterface();
+
+    setupActiveBMCWithAliveSiblingExpects();
+
+    EXPECT_CALL(services, logError(_, _, _)).Times(0);
+    EXPECT_CALL(syncInterface, doFullSync()).Times(1);
+
+    setupPCIeStorageExpects(activeRedundancyEnabledProps);
+
+    createManagerAndRun(ProgressPoint::activeHandlerStartComplete);
+
+    verifyRedundancyProps(manager->getRedundancyInterface(),
+                          activeRedundancyEnabledProps);
+    verifyPersistentData(Role::Active, "Sibling is already passive", false);
+}
+
+/**
+ * @brief Test: BMC becomes active with redundancy enable but failovers
+ *        not allowed due to the system booting.
+ */
+TEST_F(ManagerTest, BecomeActive_FailoversNotAllowed_SystemBooting)
+{
+    // Configure scenario: This BMC should become active
+    TestScenarioConfig config{.bmcPosition = 0, .siblingRole = Role::Passive};
+    setupTestScenario(config);
+
+    auto& services = mockProviders->getMockServices();
+
+    setupActiveBMCWithAliveSiblingExpects();
+
+    // Configure system state to be 'booting'
+    ON_CALL(services, getSystemState())
+        .WillByDefault(Return(SystemState::booting));
+
+    RedundancyProps expectedProps{
+        .role = Role::Active,
+        .redEnabled = true,
+        .failoverInProgress = false,
+        .failoversAllowed = false,
+        .failoverImminent = false,
+        .reasonsForNoRedundancy = {},
+        .failoversNotAllowedReason =
+            FailoversNotAllowedReason::WrongSystemState};
+
+    setupPCIeStorageExpects(expectedProps);
+
+    createManagerAndRun(ProgressPoint::activeHandlerStartComplete);
+
+    verifyRedundancyProps(manager->getRedundancyInterface(), expectedProps);
+    verifyPersistentData(expectedProps.role, "Sibling is already passive",
+                         false);
+}
+
+/**
+ * @brief Test: BMC becomes active but disables redundancy
+ *        due to full sync failure
+ */
+TEST_F(ManagerTest, BecomeActive_FullSyncFails_RedundancyDisabled)
+{
+    // Configure scenario: This BMC should become active
+    TestScenarioConfig config{.bmcPosition = 0, .siblingRole = Role::Passive};
+    setupTestScenario(config);
+
+    auto& services = mockProviders->getMockServices();
+    auto& syncInterface = mockProviders->getMockSyncInterface();
+
+    setupActiveBMCWithAliveSiblingExpects();
+
+    // Configure full sync to fail
+    ON_CALL(syncInterface, doFullSync()).WillByDefault([]() {
+        return test_helpers::makeCompletedTask(false);
+    });
+
+    // Expect full sync to be called and fail
+    EXPECT_CALL(syncInterface, doFullSync()).Times(1);
+
+    // Expect disableBackgroundSync to be called when redundancy is disabled
+    EXPECT_CALL(syncInterface, disableBackgroundSync()).Times(1);
+
+    // Expect error log to be created when redundancy can't be enabled
+    EXPECT_CALL(services, logError(errors::error_msg::noRedundancy,
+                                   errors::Level::Error, _))
+        .Times(1);
+
+    const auto expectedProps = activeRedundancyDisabledProps(
+        {Redundancy::ReasonForNoRedundancy::DataSyncFailed});
+
+    createManagerAndRun(ProgressPoint::activeHandlerStartComplete);
+
+    verifyRedundancyProps(manager->getRedundancyInterface(), expectedProps);
+    verifyPersistentData(expectedProps.role, "Sibling is already passive",
+                         false);
+}
+
+/**
+ * @brief Test: BMC becomes active but redundancy not enabled due to no
+ *        peer connection
+ */
+TEST_F(ManagerTest, BecomeActive_PeerConnectionNeverConnects_RedundancyDisabled)
+{
+    // Configure scenario: This BMC should become active
+    TestScenarioConfig config{.bmcPosition = 0, .siblingRole = Role::Passive};
+    setupTestScenario(config);
+
+    auto& services = mockProviders->getMockServices();
+    auto& syncInterface = mockProviders->getMockSyncInterface();
+
+    setupActiveBMCWithAliveSiblingExpects();
+
+    // Configure getPeerConnected to always return false
+    ON_CALL(services, getPeerConnected()).WillByDefault(Return(false));
+
+    // Full sync should not be called.
+    EXPECT_CALL(syncInterface, doFullSync()).Times(0);
+    EXPECT_CALL(syncInterface, disableBackgroundSync()).Times(1);
+
+    EXPECT_CALL(services, logError(errors::error_msg::noRedundancy,
+                                   errors::Level::Error, _))
+        .Times(1);
+
+    const auto expectedProps = activeRedundancyDisabledProps(
+        {Redundancy::ReasonForNoRedundancy::NetworkError});
+
+    setupPCIeStorageExpects(expectedProps);
+
+    createManagerAndRun(ProgressPoint::activeHandlerStartComplete);
+
+    verifyRedundancyProps(manager->getRedundancyInterface(), expectedProps);
+    verifyPersistentData(Role::Active, "Sibling is already passive", false);
+}
+
+/**
+ * @brief Test: Redundancy is disabled because a passive BMC hardware
+ *             problem external redundancy input is set.
+ */
+TEST_F(ManagerTest, BecomeActive_PassiveHWProblem_RedundancyDisabled)
+{
+    // Set the external redundancy input value used in the checks.
+    util::writeExternalRedundancyInput(
+        RedundancyInput::PassiveBMCHardwareProblem, true);
+
+    // Configure scenario: This BMC should become active
+    TestScenarioConfig config{.bmcPosition = 0, .siblingRole = Role::Passive};
+    setupTestScenario(config);
+
+    auto& services = mockProviders->getMockServices();
+    auto& syncInterface = mockProviders->getMockSyncInterface();
+
+    setupActiveBMCWithAliveSiblingExpects();
+
+    // Full sync should not be called since redundancy is disabled
+    EXPECT_CALL(syncInterface, doFullSync()).Times(0);
+    EXPECT_CALL(syncInterface, disableBackgroundSync()).Times(1);
+
+    EXPECT_CALL(services, logError(errors::error_msg::noRedundancy,
+                                   errors::Level::Error, _))
+        .Times(1);
+
+    const auto expectedProps = activeRedundancyDisabledProps(
+        {Redundancy::ReasonForNoRedundancy::SystemHWConfigIssue});
+
+    setupPCIeStorageExpects(expectedProps);
+
+    createManagerAndRun(ProgressPoint::activeHandlerStartComplete);
+
+    verifyRedundancyProps(manager->getRedundancyInterface(), expectedProps);
+    verifyPersistentData(Role::Active, "Sibling is already passive", false);
+}
+
+/**
+ * @brief Test: Redundancy is disabled because redundancy was off when the
+ *             system previously entered runtime state.
+ */
+TEST_F(ManagerTest, BecomeActive_RedundancyOffAtRuntimeStart_RedundancyDisabled)
+{
+    // Set redundancy off at runtime.  The tuple is {valid, off}.
+    data::write(data::key::redundancyOffAtRuntime,
+                std::tuple<bool, bool>{true, true});
+
+    TestScenarioConfig config{.bmcPosition = 0, .siblingRole = Role::Passive};
+    setupTestScenario(config);
+
+    auto& services = mockProviders->getMockServices();
+    auto& syncInterface = mockProviders->getMockSyncInterface();
+
+    // System is at runtime.
+    ON_CALL(services, getSystemState())
+        .WillByDefault(Return(SystemState::runtime));
+
+    setupActiveBMCWithAliveSiblingExpects();
+
+    // Redundancy is disabled before sync is attempted
+    EXPECT_CALL(syncInterface, doFullSync()).Times(0);
+    EXPECT_CALL(syncInterface, disableBackgroundSync()).Times(1);
+
+    EXPECT_CALL(services, logError(errors::error_msg::noRedundancy,
+                                   errors::Level::Error, _))
+        .Times(1);
+
+    const auto expectedProps = activeRedundancyDisabledProps(
+        {Redundancy::ReasonForNoRedundancy::RedundancyOffAtRuntimeStart});
+
+    setupPCIeStorageExpects(expectedProps);
+
+    createManagerAndRun(ProgressPoint::activeHandlerStartComplete);
+
+    verifyRedundancyProps(manager->getRedundancyInterface(), expectedProps);
+    verifyPersistentData(Role::Active, "Sibling is already passive", false);
 }

--- a/redundant-bmc/test/mocks/mock_sync_interface.hpp
+++ b/redundant-bmc/test/mocks/mock_sync_interface.hpp
@@ -31,7 +31,7 @@ class MockSyncInterface : public testing::NiceMock<SyncInterface>
     void setupDefaultBehavior()
     {
         ON_CALL(*this, doFullSync()).WillByDefault([this]() {
-            fullSyncComplete = true;
+            SyncInterface::fullSyncComplete = true;
             return test_helpers::makeCompletedTask(true);
         });
 
@@ -39,8 +39,6 @@ class MockSyncInterface : public testing::NiceMock<SyncInterface>
             return test_helpers::makeCompletedTask();
         });
     }
-
-    bool fullSyncComplete{false};
 };
 
 } // namespace rbmc


### PR DESCRIPTION
Add testcases that cover more role determination testcases and also ones that cover determining redundancy.