### PR TITLE
RBMC: Use sdbusplus-generated property accessors

### DIFF
--- a/redundant-bmc/src/code_update_activation.cpp
+++ b/redundant-bmc/src/code_update_activation.cpp
@@ -22,30 +22,30 @@ CodeUpdateActivation::CodeUpdateActivation(sdbusplus::async::context& ctx) :
 {
     try
     {
-        activation_ =
+        properties.activation =
             data::read<bool>(data::key::codeUpdateInProgress).value_or(false)
                 ? Activations::Activating
                 : Activations::Active;
     }
     catch (const std::exception& e)
     {
-        activation_ = Activations::Active;
+        properties.activation = Activations::Active;
         lg2::error("Failed reading code-update-in-progress state: {ERROR}",
                    "ERROR", e);
     }
 
-    if (activation_ == Activations::Activating)
+    if (properties.activation == Activations::Activating)
     {
         lg2::info("Code update in progress on startup");
     }
 
-    requested_activation_ = RequestedActivations::None;
+    properties.requested_activation = RequestedActivations::None;
     emit_added();
 }
 
 bool CodeUpdateActivation::codeUpdateInProgress() const
 {
-    return activation_ == Activations::Activating;
+    return properties.activation == Activations::Activating;
 }
 
 void CodeUpdateActivation::setCodeUpdateInProgress()
@@ -61,20 +61,20 @@ void CodeUpdateActivation::clearCodeUpdateInProgress()
 bool CodeUpdateActivation::set_property([[maybe_unused]] activation_t type,
                                         Activations activation)
 {
-    if (activation == activation_)
+    if (activation == properties.activation)
     {
         return false;
     }
 
     lg2::info("Activation property changing to {VALUE}", "VALUE", activation);
 
-    activation_ = activation;
+    properties.activation = activation;
 
     // This needs to be saved through a reboot, so persist it.
     try
     {
         data::write(data::key::codeUpdateInProgress,
-                    activation_ == Activations::Activating);
+                    properties.activation == Activations::Activating);
     }
     catch (const std::exception& e)
     {

--- a/redundant-bmc/src/redundancy_interface.cpp
+++ b/redundant-bmc/src/redundancy_interface.cpp
@@ -21,7 +21,7 @@ RedundancyInterface::RedundancyInterface(sdbusplus::async::context& ctx,
 {
     try
     {
-        disable_redundancy_override_ =
+        properties.disable_redundancy_override =
             data::read<bool>(data::key::disableRed).value_or(false);
     }
     catch (const std::exception& e)
@@ -32,9 +32,9 @@ RedundancyInterface::RedundancyInterface(sdbusplus::async::context& ctx,
 
     try
     {
-        failover_in_progress_ =
+        properties.failover_in_progress =
             data::read<bool>(data::key::failoverInProgress).value_or(false);
-        if (failover_in_progress_)
+        if (properties.failover_in_progress)
         {
             lg2::info("Failover was previously in progress");
         }
@@ -61,10 +61,11 @@ RedundancyInterface::RedundancyInterface(sdbusplus::async::context& ctx,
         try
         {
             pcieStorage->writeState(
-                {pcie_data::redundancyDataVersion, static_cast<uint8_t>(role_),
-                 static_cast<uint8_t>(redundancy_enabled_),
-                 static_cast<uint8_t>(failover_in_progress_),
-                 static_cast<uint8_t>(failovers_allowed_)});
+                {pcie_data::redundancyDataVersion,
+                 static_cast<uint8_t>(properties.role),
+                 static_cast<uint8_t>(properties.redundancy_enabled),
+                 static_cast<uint8_t>(properties.failover_in_progress),
+                 static_cast<uint8_t>(properties.failovers_allowed)});
         }
         catch (const std::exception& e)
         {
@@ -83,18 +84,18 @@ RedundancyInterface::RedundancyInterface(sdbusplus::async::context& ctx,
 
 bool RedundancyInterface::set_property([[maybe_unused]] role_t type, Role role)
 {
-    if (role == role_)
+    if (role == properties.role)
     {
         return false;
     }
 
-    role_ = role;
+    properties.role = role;
 
     if (pcieStorage != nullptr)
     {
         try
         {
-            pcieStorage->updateRole(static_cast<uint8_t>(role_));
+            pcieStorage->updateRole(static_cast<uint8_t>(properties.role));
         }
         catch (const std::exception& e)
         {
@@ -128,7 +129,7 @@ bool RedundancyInterface::set_property(
         }
     }
 
-    redundancy_enabled_ = enabled;
+    properties.redundancy_enabled = enabled;
     return true;
 }
 
@@ -156,7 +157,7 @@ bool RedundancyInterface::set_property(
             "DISABLE", disable, "ERROR", e);
     }
 
-    disable_redundancy_override_ = disable;
+    properties.disable_redundancy_override = disable;
     return true;
 }
 
@@ -193,7 +194,7 @@ bool RedundancyInterface::set_property(
         }
     }
 
-    failover_in_progress_ = inProgress;
+    properties.failover_in_progress = inProgress;
     return true;
 }
 
@@ -201,7 +202,7 @@ bool RedundancyInterface::set_property(
     [[maybe_unused]] reasons_for_no_redundancy_t type,
     const std::vector<ReasonForNoRedundancy>& reasons)
 {
-    if (reasons == reasons_for_no_redundancy_)
+    if (reasons == properties.reasons_for_no_redundancy)
     {
         return false;
     }
@@ -225,7 +226,7 @@ bool RedundancyInterface::set_property(
                    e);
     }
 
-    reasons_for_no_redundancy_ = reasons;
+    properties.reasons_for_no_redundancy = reasons;
     return true;
 }
 
@@ -259,7 +260,7 @@ bool RedundancyInterface::set_property(
         }
     }
 
-    failovers_allowed_ = allowed;
+    properties.failovers_allowed = allowed;
     return true;
 }
 


### PR DESCRIPTION
Replace stale trailing-underscore Redundancy property references with the generated sdbusplus accessors/setters.

These changes are required to support latest sdbusplus changes added in [1].

This keeps the existing *_t property tag types unchanged and fixes the build failure caused by references such as role_, failover_in_progress_,and disable_redundancy_override_ no longer being present.

[1]: https://github.com/openbmc/sdbusplus/commit/b1b8fac883af0a1db0bc74ac68877cbb02c3ad41