### PR TITLE
RBMC: Add bmc uptime to rbmctool output

### DIFF
--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -264,10 +264,7 @@ sdbusplus::async::task<> getLocalBMCInfo(sdbusplus::async::context& ctx,
                                     .service(pairingService)
                                     .path(Pairing::instance_path)
                                     .properties();
-            if (!pairingProps.provisioned)
-            {
-                output["Paired"] = pairingProps.provisioned;
-            }
+            output["Paired"] = pairingProps.provisioned;
 
             if (pairingProps.peer_connected != PeerConnectionStatus::Connected)
             {
@@ -372,10 +369,7 @@ sdbusplus::async::task<> getSiblingBMCInfo(sdbusplus::async::context& ctx,
         output["Failovers Allowed"] = rProps.failovers_allowed;
         output["BMC State"] = getPDIEnumString(state);
         output["FW Version Hash"] = fwVersion;
-        if (!pairingProps.provisioned)
-        {
-            output["Paired"] = pairingProps.provisioned;
-        }
+        output["Paired"] = pairingProps.provisioned;
     }
     catch (const std::exception& e)
     {

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <format>
+#include <fstream>
 #include <print>
 
 using Redundancy =
@@ -201,6 +202,24 @@ void addActiveWaits(nlohmann::ordered_json& output)
     }
 }
 
+void addBMCUptime(nlohmann::ordered_json& output)
+{
+    std::ifstream f("/proc/uptime");
+    if (!f)
+    {
+        return;
+    }
+
+    // Read only the integer seconds; kernel writes e.g. "5416.64 0.22"
+    uint64_t total{};
+    if (!(f >> total))
+    {
+        return;
+    }
+
+    output["BMC Uptime"] = rbmc::util::uptimeToString(total);
+}
+
 // NOLINTNEXTLINE
 sdbusplus::async::task<> getLocalBMCInfo(sdbusplus::async::context& ctx,
                                          bool extended,
@@ -273,6 +292,8 @@ sdbusplus::async::task<> getLocalBMCInfo(sdbusplus::async::context& ctx,
                 data::read<std::string>(data::key::roleReason)
                     .value_or("No reason found");
         }
+
+        addBMCUptime(output);
 
         if ((role == "Active") && !props.redundancy_enabled)
         {

--- a/redundant-bmc/src/rbmc_tool.cpp
+++ b/redundant-bmc/src/rbmc_tool.cpp
@@ -619,6 +619,9 @@ void displayPCIeState()
 
 int main(int argc, char** argv)
 {
+    // Set lg2 output to just the message
+    setenv("LG2_FORMAT", "%m", 0);
+
     CLI::App app{"RBMC Tool"};
     bool info{};
     bool extended{};
@@ -631,7 +634,6 @@ int main(int argc, char** argv)
     bool jsonOutput{};
     bool readPCIe{};
     sdbusplus::async::context ctx;
-
     auto* displayGroup = app.add_option_group("Display RBMC information");
     auto* flag =
         displayGroup->add_flag("-d", info, "Display basic RBMC information");

--- a/redundant-bmc/src/util.cpp
+++ b/redundant-bmc/src/util.cpp
@@ -8,7 +8,12 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <cstdint>
+#include <format>
 #include <fstream>
+#include <ranges>
+#include <string>
+#include <vector>
 
 namespace rbmc::util
 {
@@ -95,6 +100,41 @@ void writeExternalRedundancyInput(RedundancyInput input, bool set)
                    "ERROR", e);
         throw;
     }
+}
+
+std::string uptimeToString(uint64_t total)
+{
+    constexpr uint64_t secondsPerMinute = 60;
+    constexpr uint64_t secondsPerHour = 60 * secondsPerMinute;
+    constexpr uint64_t secondsPerDay = 24 * secondsPerHour;
+
+    // Full days elapsed
+    auto days = total / secondsPerDay;
+    // Hours portion of the remainder within a day
+    auto hours = (total % secondsPerDay) / secondsPerHour;
+    // Minutes portion of the remainder within an hour
+    auto minutes = (total % secondsPerHour) / secondsPerMinute;
+
+    std::vector<std::string> parts;
+    if (days > 0)
+    {
+        parts.emplace_back(std::format("{}d", days));
+    }
+    if (hours > 0)
+    {
+        parts.emplace_back(std::format("{}h", hours));
+    }
+    if (minutes > 0)
+    {
+        parts.emplace_back(std::format("{}m", minutes));
+    }
+    if (parts.empty())
+    {
+        parts.emplace_back("0m");
+    }
+
+    auto joined = parts | std::views::join_with(' ');
+    return {joined.begin(), joined.end()};
 }
 
 bool clearExternalRedundancyInputs()

--- a/redundant-bmc/src/util.hpp
+++ b/redundant-bmc/src/util.hpp
@@ -7,8 +7,10 @@
 #include <xyz/openbmc_project/Control/Failover/common.hpp>
 #include <xyz/openbmc_project/State/BMC/Redundancy/common.hpp>
 
+#include <cstdint>
 #include <optional>
 #include <set>
+#include <string>
 
 namespace rbmc::util
 {
@@ -123,5 +125,15 @@ std::optional<std::string> getOSReleaseValue(const std::string& filePath,
  */
 sdbusplus::async::task<int> runAsyncCmd(sdbusplus::async::context& ctx,
                                         const std::string& cmd);
+/**
+ * @brief Convert a raw uptime in seconds to a human-readable string
+ *        of the form "Xd Xh Xm", omitting leading zero components.
+ *        If total is less than one minute, returns "0m".
+ *
+ * @param[in] uptimeSeconds - Seconds since boot
+ *
+ * @return std::string - Human-readable uptime string
+ */
+std::string uptimeToString(uint64_t uptimeSeconds);
 
 } // namespace rbmc::util

--- a/redundant-bmc/test/util_test.cpp
+++ b/redundant-bmc/test/util_test.cpp
@@ -310,3 +310,15 @@ TEST(RunAsyncCmdTest, CommandWithNonZeroExitCode)
 
     EXPECT_EQ(result, 1);
 }
+
+TEST(UptimeToStringTest, FormatsCorrectly)
+{
+    EXPECT_EQ(uptimeToString(0), "0m");            // less than a minute
+    EXPECT_EQ(uptimeToString(45), "0m");           // still less than a minute
+    EXPECT_EQ(uptimeToString(60), "1m");           // exact minute
+    EXPECT_EQ(uptimeToString(125), "2m");          // minutes only
+    EXPECT_EQ(uptimeToString(3600), "1h");         // exact hour
+    EXPECT_EQ(uptimeToString(3723), "1h 2m");      // hours and minutes
+    EXPECT_EQ(uptimeToString(86400), "1d");        // exact day
+    EXPECT_EQ(uptimeToString(183845), "2d 3h 4m"); // all components
+}


### PR DESCRIPTION
Add the uptime from /proc/uptime for the local BMC in the rbmctool output. Ignore the seconds portion. This can help give context to the other values, like if it was up for days vs a minute.

Tested:

```
Failovers Allowed:    true
Failover In Progress: false
FWVersion Hash:       EF2E9F3F
Role Reason:          Failover
BMC Uptime:           7d 12h 33m  <------
```

Matches 'uptime':
```
$ uptime
21:38:29  up 7 days 12:33,  0 users,  load average: 1.32, 0.94, 0.99
```

The second commit changes the rbmctool output so the Paired value is always shown, to make it easier to know the current status.

The third commit removes the `<6>` journal level value from the rbmctool output when lg2 writes to the console.