### PR TITLE
test: replace deprecated gMock Invoke usage

### DIFF
--- a/test/test_chassis_smp_enhanced.cpp
+++ b/test/test_chassis_smp_enhanced.cpp
@@ -61,11 +61,11 @@ class ChassisSMPEnhancedTest : public Test
         if (mockInventoryPresent)
         {
             EXPECT_CALL(sdbusMock, sd_bus_call(_, _, _, _, _))
-                .WillRepeatedly(Invoke([&chassisStates](
-                                           sd_bus* /*bus*/, sd_bus_message* m,
-                                           uint64_t /*timeout*/,
-                                           sd_bus_error* /*error*/,
-                                           sd_bus_message** /*reply*/) {
+                .WillRepeatedly([&chassisStates](sd_bus* /*bus*/,
+                                                 sd_bus_message* m,
+                                                 uint64_t /*timeout*/,
+                                                 sd_bus_error* /*error*/,
+                                                 sd_bus_message** /*reply*/) {
                     // Parse the message to determine what's being requested
                     const char* member = sd_bus_message_get_member(m);
                     const char* path = sd_bus_message_get_path(m);
@@ -107,7 +107,7 @@ class ChassisSMPEnhancedTest : public Test
                         }
                     }
                     return 0;
-                }));
+                });
         }
 
         return std::make_unique<ChassisSMP>(

--- a/test/test_chassis_wait_smp.cpp
+++ b/test/test_chassis_wait_smp.cpp
@@ -42,9 +42,9 @@ class SMPChassisWaiterTest : public Test
     {
         EXPECT_CALL(sdbusMock, sd_bus_call(_, _, _, _, _))
             .WillRepeatedly(
-                Invoke([present](sd_bus* /*bus*/, sd_bus_message* m,
-                                 uint64_t /*timeout*/, sd_bus_error* /*error*/,
-                                 sd_bus_message** /*reply*/) {
+                [present](sd_bus* /*bus*/, sd_bus_message* m,
+                          uint64_t /*timeout*/, sd_bus_error* /*error*/,
+                          sd_bus_message** /*reply*/) {
                     const char* member = sd_bus_message_get_member(m);
                     const char* path = sd_bus_message_get_path(m);
 
@@ -56,7 +56,7 @@ class SMPChassisWaiterTest : public Test
                         return present ? 0 : -1;
                     }
                     return 0;
-                }));
+                });
     }
 
     // Helper to mock chassis power state
@@ -64,9 +64,9 @@ class SMPChassisWaiterTest : public Test
     {
         EXPECT_CALL(sdbusMock, sd_bus_call(_, _, _, _, _))
             .WillRepeatedly(
-                Invoke([state](sd_bus* /*bus*/, sd_bus_message* m,
-                               uint64_t /*timeout*/, sd_bus_error* /*error*/,
-                               sd_bus_message** /*reply*/) {
+                [state](sd_bus* /*bus*/, sd_bus_message* m,
+                        uint64_t /*timeout*/, sd_bus_error* /*error*/,
+                        sd_bus_message** /*reply*/) {
                     const char* member = sd_bus_message_get_member(m);
                     const char* path = sd_bus_message_get_path(m);
 
@@ -78,7 +78,7 @@ class SMPChassisWaiterTest : public Test
                         return 0;
                     }
                     return 0;
-                }));
+                });
     }
 };
 
@@ -292,9 +292,9 @@ TEST_F(SMPChassisWaiterTest, HandlesPowerStateQueryFailures)
 
     // Mock power state query to fail
     EXPECT_CALL(sdbusMock, sd_bus_call(_, _, _, _, _))
-        .WillRepeatedly(Invoke([](sd_bus* /*bus*/, sd_bus_message* m,
-                                  uint64_t /*timeout*/, sd_bus_error* /*error*/,
-                                  sd_bus_message** /*reply*/) {
+        .WillRepeatedly([](sd_bus* /*bus*/, sd_bus_message* m,
+                           uint64_t /*timeout*/, sd_bus_error* /*error*/,
+                           sd_bus_message** /*reply*/) {
             const char* member = sd_bus_message_get_member(m);
             const char* path = sd_bus_message_get_path(m);
 
@@ -305,7 +305,7 @@ TEST_F(SMPChassisWaiterTest, HandlesPowerStateQueryFailures)
                 return -1; // Fail power state query
             }
             return 0;      // Succeed inventory query
-        }));
+        });
 
     // Should handle power state query failure gracefully
     EXPECT_NO_THROW({ SMPChassisWaiter waiter(mockedBus, event, 1); });


### PR DESCRIPTION
Build started failing with -Werror=deprecated-declarations after gMock deprecated Invoke(function) for callable actions

Update the affected EXPECT_CALL(...).WillRepeatedly(...) sites to pass lambdas directly instead of wrapping them with Invoke(...). This keeps the mocked behavior unchanged and only removes deprecated syntax

Tested:
   meson setup build
   ninja -C build
   ninja -C build test

Change-Id: I2409c0e3f529d17685ab724ad22341dc5fe61111