### PR TITLE
multi-chassis-smp: clear chassis@0-on file on aggregate power on

### DIFF
--- a/chassis_state_manager_smp.cpp
+++ b/chassis_state_manager_smp.cpp
@@ -10,6 +10,7 @@
 #include <xyz/openbmc_project/Common/error.hpp>
 #include <xyz/openbmc_project/Inventory/Item/common.hpp>
 
+#include <filesystem>
 #include <format>
 #include <fstream>
 #include <iostream>
@@ -46,12 +47,18 @@ ChassisSMP::ChassisSMP(sdbusplus::bus_t& bus,
     ChassisInherit(bus, objPath.str.c_str(),
                    ChassisInherit::action::defer_emit),
     bus(bus), numChassis(numChassis),
-    systemdSignalJobNew(std::make_unique<sdbusplus::bus::match_t>(
+    systemdSignalJobNew(
         bus,
         sdbusRule::type::signal() + sdbusRule::member("JobNew") +
             sdbusRule::path("/org/freedesktop/systemd1") +
             sdbusRule::interface("org.freedesktop.systemd1.Manager"),
-        [this](sdbusplus::message_t& m) { sysStateChangeJobNew(m); }))
+        [this](sdbusplus::message_t& m) { sysStateChangeJobNew(m); }),
+    systemdSignalJobRemoved(
+        bus,
+        sdbusRule::type::signal() + sdbusRule::member("JobRemoved") +
+            sdbusRule::path("/org/freedesktop/systemd1") +
+            sdbusRule::interface("org.freedesktop.systemd1.Manager"),
+        [](sdbusplus::message_t& m) { sysStateChangeJobRemoved(m); })
 {
     if (numChassis == 0)
     {
@@ -593,4 +600,35 @@ void ChassisSMP::sysStateChangeJobNew(sdbusplus::message_t& msg)
     }
 }
 
+void ChassisSMP::sysStateChangeJobRemoved(sdbusplus::message_t& msg)
+{
+    uint32_t newStateID{};
+    sdbusplus::object_path newStateObjPath;
+    std::string newStateUnit{};
+    std::string newStateResult{};
+
+    msg.read(newStateID, newStateObjPath, newStateUnit, newStateResult);
+
+    // When obmc-chassis-poweron@0.target completes successfully, remove the
+    // temporary file that was created to indicate chassis power was on when the
+    // BMC rebooted. This mirrors the same logic in the standard chassis
+    // manager's sysStateChange(). We must do this here (on JobRemoved) rather
+    // than during the initial aggregation so that we do not race with
+    // phosphor-reset-chassis-running@0.service, which creates the file and runs
+    // concurrently with our startup aggregation.
+    if ((newStateUnit == CHASSIS_POWERON_TARGET) && (newStateResult == "done"))
+    {
+        info("Chassis0: Received signal that chassis 0 poweron target is "
+             "complete, clearing chassis@0-on file if present");
+
+        auto chassisFile = std::format(CHASSIS_ON_FILE, 0);
+        std::error_code ec;
+        std::filesystem::remove(chassisFile, ec);
+        if (ec)
+        {
+            error("Failed to remove chassis@0-on file {PATH}: {EC}", "PATH",
+                  chassisFile, "EC", ec.message());
+        }
+    }
+}
 } // namespace phosphor::state::manager

--- a/chassis_state_manager_smp.hpp
+++ b/chassis_state_manager_smp.hpp
@@ -65,6 +65,17 @@ class ChassisSMP : public ChassisInherit
      */
     void sysStateChangeJobNew(sdbusplus::message_t& msg);
 
+    /** @brief Handle systemd JobRemoved signals for chassis 0 targets
+     *
+     * Clears the chassis@0-on file once obmc-chassis-poweron@0.target
+     * completes. This must happen on JobRemoved (not during startup
+     * aggregation) to avoid racing with phosphor-reset-chassis-running@0
+     * which writes the file concurrently at startup.
+     *
+     * @param[in] msg - D-Bus message containing job information
+     */
+    static void sysStateChangeJobRemoved(sdbusplus::message_t& msg);
+
     /** @brief Start the systemd unit requested
      *
      * This function calls `StartUnit` on the systemd unit given.
@@ -129,7 +140,11 @@ class ChassisSMP : public ChassisInherit
     std::vector<std::unique_ptr<sdbusplus::match>> inventoryPresentMatches;
 
     /** @brief Systemd JobNew signal match for chassis 0 target monitoring. **/
-    std::unique_ptr<sdbusplus::bus::match_t> systemdSignalJobNew;
+    sdbusplus::match systemdSignalJobNew;
+
+    /** @brief Systemd JobRemoved signal match for chassis 0 target monitoring.
+     **/
+    sdbusplus::match systemdSignalJobRemoved;
 
     /** @brief Cached power states from each chassis instance. **/
     std::map<size_t, PowerState> chassisPowerStates;


### PR DESCRIPTION
The standard chassis_state_manager clears the CHASSIS_ON_FILE (e.g. /run/openbmc/chassis@N-on) once it detects that the corresponding obmc-chassis-poweron@N.target has completed via the JobRemoved signal. This file is a temporary indicator used by chassis-related systemd services to detect that chassis power was already on when the BMC rebooted, so those services can skip running. This file must be cleared once the corresponding systemd target has completed otherwise future power on requests will not actually power on the system.

The SMP aggregator (chassis instance 0) never cleared its own chassis@0-on file. Add a JobRemoved signal match and handler (sysStateChangeJobRemoved) that removes /run/openbmc/chassis@0-on when obmc-chassis-poweron@0.target completes with result "done".

The cleanup must happen in the JobRemoved handler rather than during the initial aggregatePowerState() call at startup. The two events race: phosphor-reset-chassis-running@0.service writes the file at the same time the aggregator is doing its initial D-Bus property scan. If we clear the file during aggregation the service finishes shortly afterwards and re-creates it, leaving it behind permanently. By waiting for the poweron target's JobRemoved signal we guarantee the file was already written before we remove it.

Tested:
- Verified /run/openbmc/chassis@0-on is removed after obmc-chassis-poweron@0.target completes following a BMC reboot with chassis power already on

Change-Id: I704c6a583871c470355445624692bcef622bf0ee