### PR TITLE
state-manager: require active target for done jobs

### DIFF
--- a/bmc_state_manager.cpp
+++ b/bmc_state_manager.cpp
@@ -202,7 +202,8 @@ int BMC::bmcStateChange(sdbusplus::message_t& msg)
     // Read the msg and populate each variable
     msg.read(newStateID, newStateObjPath, newStateUnit, newStateResult);
 
-    if ((newStateUnit == obmcQuiesceTarget) && (newStateResult == signalDone))
+    if ((newStateUnit == obmcQuiesceTarget) && (newStateResult == signalDone) &&
+        (getUnitState(newStateUnit) == activeState))
     {
         error("BMC has entered BMC_QUIESCED state");
         bmcIsQuiesced();
@@ -210,7 +211,8 @@ int BMC::bmcStateChange(sdbusplus::message_t& msg)
     }
 
     // Caught the signal that indicates the BMC is now BMC_READY
-    if ((newStateUnit == obmcStandbyTarget) && (newStateResult == signalDone))
+    if ((newStateUnit == obmcStandbyTarget) && (newStateResult == signalDone) &&
+        (getUnitState(newStateUnit) == activeState))
     {
         info("BMC_READY");
         this->currentBMCState(BMCState::Ready);

--- a/chassis_state_manager.cpp
+++ b/chassis_state_manager.cpp
@@ -557,17 +557,15 @@ int Chassis::sysStateChange(sdbusplus::message_t& msg)
         return 0;
     }
 
-    if ((newStateUnit == fmt::format(CHASSIS_STATE_POWEROFF_TGT_FMT, id)) &&
-        (newStateResult == "done") &&
-        (!stateActive(systemdTargetTable[Transition::On])))
+    if ((newStateUnit == std::format(CHASSIS_STATE_POWEROFF_TGT_FMT, id)) &&
+        (newStateResult == "done") && (stateActive(newStateUnit)))
     {
         info("Received signal that power OFF is complete");
         this->currentPowerState(server::Chassis::PowerState::Off);
         this->setStateChangeTime();
     }
     else if ((newStateUnit == systemdTargetTable[Transition::On]) &&
-             (newStateResult == "done") &&
-             (stateActive(systemdTargetTable[Transition::On])))
+             (newStateResult == "done") && (stateActive(newStateUnit)))
     {
         info("Received signal that power ON is complete");
         this->currentPowerState(server::Chassis::PowerState::On);

--- a/host_state_manager.cpp
+++ b/host_state_manager.cpp
@@ -278,8 +278,7 @@ void Host::sysStateChangeJobRemoved(sdbusplus::message_t& msg)
     msg.read(newStateID, newStateObjPath, newStateUnit, newStateResult);
 
     if ((newStateUnit == getTarget(server::Host::HostState::Off)) &&
-        (newStateResult == "done") &&
-        (!stateActive(getTarget(server::Host::HostState::Running))))
+        (newStateResult == "done") && (stateActive(newStateUnit)))
     {
         info("Received signal that host is off");
         this->currentHostState(server::Host::HostState::Off);
@@ -287,8 +286,7 @@ void Host::sysStateChangeJobRemoved(sdbusplus::message_t& msg)
         this->operatingSystemState(osstatus::Status::OSStatus::Inactive);
     }
     else if ((newStateUnit == getTarget(server::Host::HostState::Running)) &&
-             (newStateResult == "done") &&
-             (stateActive(getTarget(server::Host::HostState::Running))))
+             (newStateResult == "done") && (stateActive(newStateUnit)))
     {
         info("Received signal that host is running");
         this->currentHostState(server::Host::HostState::Running);
@@ -308,8 +306,7 @@ void Host::sysStateChangeJobRemoved(sdbusplus::message_t& msg)
         }
     }
     else if ((newStateUnit == getTarget(server::Host::HostState::Quiesced)) &&
-             (newStateResult == "done") &&
-             (stateActive(getTarget(server::Host::HostState::Quiesced))))
+             (newStateResult == "done") && (stateActive(newStateUnit)))
     {
         if (Host::isAutoReboot())
         {


### PR DESCRIPTION
debug-trigger reboots the BMC by calling systemd directly, bypassing phosphor-state-manager. This can cause PSM to see a "done" signal from a target that is stopping rather than starting, and incorrectly advance its state (e.g. to BMC_READY) while the BMC is mid-reboot. Because bmcweb was still running at that point, a false BMC_READY was sent to the HMC.

Tested: confirmed in Rainier Simics that the false BMC_READY is no longer sent to the HMC during a debug-trigger BMC reboot.