### PR TITLE
utils: return log entry path from createError and link to BMC dump

### DIFF
--- a/host_state_manager.cpp
+++ b/host_state_manager.cpp
@@ -226,12 +226,14 @@ bool Host::isAutoReboot()
                 // Generate log since we will now be sitting in Quiesce
                 const std::string errorMsg =
                     "xyz.openbmc_project.State.Error.HostQuiesce";
-                utils::createError(this->bus, errorMsg,
-                                   sdbusplus::xyz::openbmc_project::Logging::
-                                       server::Entry::Level::Critical);
+                auto logEntryPath = utils::createError(
+                    this->bus, errorMsg,
+                    sdbusplus::xyz::openbmc_project::Logging::server::Entry::
+                        Level::Critical);
 
-                // Generate BMC dump to assist with debug
-                utils::createBmcDump(this->bus);
+                // Generate BMC dump linked to the error log above so dreport
+                // collects the elog details (EventId = log entry object path)
+                utils::createBmcDump(this->bus, logEntryPath);
 
                 return false;
             }

--- a/utils.cpp
+++ b/utils.cpp
@@ -172,7 +172,7 @@ int getGpioValue(const std::string& gpioName)
     return gpioval;
 }
 
-void createError(
+sdbusplus::message::object_path createError(
     sdbusplus::bus_t& bus, const std::string& errorMsg,
     sdbusplus::server::xyz::openbmc_project::logging::Entry::Level errLevel,
     std::map<std::string, std::string> additionalData)
@@ -191,6 +191,10 @@ void createError(
 
         method.append(errorMsg, errLevel, additionalData);
         auto resp = bus.call(method);
+
+        sdbusplus::message::object_path entryPath;
+        resp.read(entryPath);
+        return entryPath;
     }
     catch (const sdbusplus::exception_t& e)
     {
@@ -210,16 +214,35 @@ void createError(
 
 void createBmcDump(sdbusplus::bus_t& bus)
 {
+    createBmcDump(bus, {});
+}
+
+void createBmcDump(sdbusplus::bus_t& bus, const std::string& objectPath)
+{
     using DumpCreate = sdbusplus::client::xyz::openbmc_project::dump::Create<>;
+    using DumpIntr = sdbusplus::common::xyz::openbmc_project::dump::Create;
+    using CreateParameters = DumpIntr::CreateParameters;
+
     auto dumpPath = sdbusplus::object_path(DumpCreate::namespace_path::value) /
                     DumpCreate::namespace_path::bmc;
 
     auto method =
         bus.new_method_call(DumpCreate::default_service, dumpPath.str.c_str(),
                             DumpCreate::interface, "CreateDump");
-    method.append(
-        std::vector<
-            std::pair<std::string, std::variant<std::string, uint64_t>>>());
+
+    // Pass the log entry object path as FilePath — the dump manager extracts
+    // this into dreport -p, and dreport -t elog runs the elog plugin which
+    // does basename($optional_path) for the id and busctl queries the full
+    // path.
+    std::vector<std::pair<std::string, std::variant<std::string, uint64_t>>>
+        params;
+    if (!objectPath.empty())
+    {
+        params.emplace_back(DumpIntr::convertCreateParametersToString(
+                                CreateParameters::FilePath),
+                            objectPath);
+    }
+    method.append(params);
     try
     {
         bus.call_noreply(method);

--- a/utils.hpp
+++ b/utils.hpp
@@ -69,12 +69,14 @@ int getGpioValue(const std::string& gpioName);
 
 /** @brief Create an error log
  *
- * @param[in] bus           - The Dbus bus object
- * @param[in] errorMsg      - The error message
- * @param[in] errLevel      - The error level
- * parampin] additionalData - Optional extra data to add to the log
+ * @param[in] bus            - The Dbus bus object
+ * @param[in] errorMsg       - The error message
+ * @param[in] errLevel       - The error level
+ * @param[in] additionalData - Optional extra data to add to the log
+ *
+ * @return The D-Bus object path of the created log entry
  */
-void createError(
+sdbusplus::message::object_path createError(
     sdbusplus::bus_t& bus, const std::string& errorMsg,
     sdbusplus::server::xyz::openbmc_project::logging::Entry::Level errLevel,
     std::map<std::string, std::string> additionalData = {});
@@ -84,6 +86,16 @@ void createError(
  * @param[in] bus          - The Dbus bus object
  */
 void createBmcDump(sdbusplus::bus_t& bus);
+
+/** @brief Call phosphor-dump-manager to create BMC dump linked to an event log
+ *
+ * @param[in] bus          - The Dbus bus object
+ * @param[in] objectPath - D-Bus object path of the associated error log entry
+ *                           (e.g. /xyz/openbmc_project/logging/entry/5).
+ *                           Passed as EventId to CreateDump so dreport can
+ *                           collect the elog details inside the dump.
+ */
+void createBmcDump(sdbusplus::bus_t& bus, const std::string& objectPath);
 
 /** @brief Attempt to locate the obmc-chassis-lost-power@ file
  *    to indicate that an AC loss occurred.


### PR DESCRIPTION
Multiple repositories create user dumps in response to system errors. On a running system it is difficult to identify which component created a particular dump and what error drove it. By capturing the associated error log details inside the dump archive, a user dump can be directly correlated with the error that triggered it.

The Logging.Create.Create() D-Bus method already returns the object path of the newly created log entry (e.g.
/xyz/openbmc_project/logging/entry/5) but createError() was discarding it. Change createError() to read and return that object path so callers can use it.

Add a new createBmcDump(bus, eventId) overload that accepts the log entry object path and passes it as CreateParameters::FilePath to Dump.Create.CreateDump(). The dump manager extracts FilePath and passes it verbatim to dreport as -p, which sets the $optional_path variable inherited by all dreport plugins. The dreport elog plugin then uses this path to collect the full error log entry details inside the dump archive. This is the same mechanism already used by elog_watch in phosphor-debug-collector.

The existing createBmcDump(bus) overload is preserved and delegates to the new overload with an empty string so all existing call sites remain unaffected. Callers that do not need the return value of createError() can discard it — C++ allows this without any changes at those sites.

Use the new API in host_state_manager when the host enters Quiesce state after exhausting boot retries as a demonstration.

Change-Id: Ia7e9b2ec044d170e244355fa7b216d81ea69ed10